### PR TITLE
Adding v2 interfaces and basic implementations for detection pipeline

### DIFF
--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/alert/v2/AlertEvaluator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/alert/v2/AlertEvaluator.java
@@ -1,0 +1,136 @@
+package org.apache.pinot.thirdeye.alert.v2;
+
+import static org.apache.pinot.thirdeye.resources.ResourceUtils.badRequest;
+import static org.apache.pinot.thirdeye.resources.ResourceUtils.serverError;
+import static org.apache.pinot.thirdeye.resources.ResourceUtils.statusListApi;
+import static org.apache.pinot.thirdeye.spi.ThirdEyeStatus.ERR_DATA_UNAVAILABLE;
+import static org.apache.pinot.thirdeye.spi.ThirdEyeStatus.ERR_TIMEOUT;
+import static org.apache.pinot.thirdeye.spi.ThirdEyeStatus.ERR_UNKNOWN;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.pinot.thirdeye.api.v2.AlertEvaluationPlanApi;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+import org.apache.pinot.thirdeye.detection.DataProviderException;
+import org.apache.pinot.thirdeye.detection.DetectionPipelineException;
+import org.apache.pinot.thirdeye.detection.v2.DetectionPipelineResult;
+import org.apache.pinot.thirdeye.detection.v2.PlanNode;
+import org.apache.pinot.thirdeye.detection.v2.plan.DetectionPipelinePlanNodeFactory;
+import org.apache.pinot.thirdeye.spi.ThirdEyeException;
+import org.apache.pinot.thirdeye.spi.api.DetectionEvaluationApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class AlertEvaluator {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(AlertEvaluator.class);
+
+  public static final String ROOT_OPERATOR_KEY = "root";
+  // 5 detection previews are running at the same time at most
+  private static final int PARALLELISM = 5;
+  // max time allowed for a preview task
+  private static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
+
+  private final ExecutorService executorService;
+
+  @Inject
+  public AlertEvaluator() {
+    this.executorService = Executors.newFixedThreadPool(PARALLELISM);
+  }
+
+  private void stop() {
+    this.executorService.shutdownNow();
+  }
+
+  public Map<String, Map<String, DetectionEvaluationApi>> evaluate(
+      final AlertEvaluationPlanApi request)
+      throws ExecutionException {
+    try {
+      Map<String, DetectionPipelineResult> result = runPipeline(request);
+      return toApi(result);
+    } catch (ThirdEyeException e) {
+      throw badRequest(statusListApi(e.getStatus(), e.getMessage()));
+    } catch (InterruptedException e) {
+      LOG.error("Error occurred during evaluate", e);
+      throw serverError(ERR_UNKNOWN, e.getMessage());
+    } catch (TimeoutException e) {
+      LOG.error("Error occurred during evaluate", e);
+      throw serverError(ERR_TIMEOUT);
+    } catch (ExecutionException e) {
+      LOG.error("Error occurred during evaluate", e);
+      handleExecutionException(e);
+      throw e;
+    } catch (Exception e) {
+      LOG.error("Error occurred during evaluate", e);
+      throw serverError(ERR_UNKNOWN);
+    }
+  }
+
+  private void handleExecutionException(final ExecutionException e) {
+    final Throwable cause = e.getCause();
+    if (cause instanceof DetectionPipelineException) {
+      final Throwable innerCause = cause.getCause();
+      if (innerCause instanceof DataProviderException) {
+        throw serverError(ERR_DATA_UNAVAILABLE, innerCause.getMessage());
+      }
+      throw serverError(ERR_UNKNOWN, cause.getMessage());
+    }
+  }
+
+  private Map<String, DetectionPipelineResult> runPipeline(final AlertEvaluationPlanApi request)
+      throws Exception {
+    Map<String, PlanNode> pipelinePlanNodes = new HashMap<>();
+    for (DetectionPlanApi operator : request.getNodes()) {
+      final String operatorName = operator.getPlanNodeName();
+      pipelinePlanNodes.put(operatorName, DetectionPipelinePlanNodeFactory
+          .get(operatorName,
+              pipelinePlanNodes,
+              operator,
+              request.getStart().getTime(),
+              request.getEnd().getTime()));
+    }
+    return executorService.submit(() -> {
+      PlanNode rootNode = pipelinePlanNodes.get(ROOT_OPERATOR_KEY);
+      Map<String, DetectionPipelineResult> context = new HashMap<>();
+      PlanExecutor.executePlanNode(pipelinePlanNodes, context, rootNode);
+      return getOutput(context, rootNode);
+    }).get(TIMEOUT, TimeUnit.MILLISECONDS);
+  }
+
+  private Map<String, DetectionPipelineResult> getOutput(
+      final Map<String, DetectionPipelineResult> context,
+      final PlanNode rootNode) {
+    Map<String, DetectionPipelineResult> results = new HashMap<>();
+    for (String contextKey : context.keySet()) {
+      if (PlanExecutor.getNodeFromContextKey(contextKey).equals(rootNode.getName())) {
+        results.put(PlanExecutor.getOutputKeyFromContextKey(contextKey), context.get(contextKey));
+      }
+    }
+    return results;
+  }
+
+  private Map<String, Map<String, DetectionEvaluationApi>> toApi(
+      final Map<String, DetectionPipelineResult> outputMap) {
+
+    final Map<String, Map<String, DetectionEvaluationApi>> resultMap = new HashMap<>();
+    for (String key : outputMap.keySet()) {
+      final DetectionPipelineResult result = outputMap.get(key);
+      resultMap.put(key, detectionPipelineResultToApi(result));
+    }
+    return resultMap;
+  }
+
+  private Map<String, DetectionEvaluationApi> detectionPipelineResultToApi(
+      final DetectionPipelineResult result) {
+    // TODO: implement this
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/alert/v2/PlanExecutor.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/alert/v2/PlanExecutor.java
@@ -1,0 +1,47 @@
+package org.apache.pinot.thirdeye.alert.v2;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi.InputApi;
+import org.apache.pinot.thirdeye.detection.v2.DetectionPipelineResult;
+import org.apache.pinot.thirdeye.detection.v2.Operator;
+import org.apache.pinot.thirdeye.detection.v2.PlanNode;
+
+public class PlanExecutor {
+
+  private static final String CONTEXT_KEY_SPLIT = "\t\t\t\t";
+
+  public static void executePlanNode(Map<String, PlanNode> pipelinePlanNodes,
+      Map<String, DetectionPipelineResult> context, final PlanNode node)
+      throws Exception {
+    for (InputApi input : node.getPlanNodeInputs()) {
+      final String contextKey = getContextKey(input.getSourcePlanNode(), input.getSourceProperty());
+      if (!context.containsKey(contextKey)) {
+        PlanNode inputPlanNode = pipelinePlanNodes.get(input.getSourcePlanNode());
+        executePlanNode(pipelinePlanNodes, context, inputPlanNode);
+      }
+      if (!context.containsKey(contextKey)) {
+        throw new RuntimeException("Missing context key - " + contextKey);
+      }
+      node.setInput(input.getTargetProperty(), context.get(contextKey));
+    }
+    Operator operator = node.run();
+    operator.execute();
+    Map<String, DetectionPipelineResult> outputs = operator.getOutputs();
+    for (Entry<String, DetectionPipelineResult> output : outputs.entrySet()) {
+      context.put(getContextKey(node.getName(), output.getKey()), output.getValue());
+    }
+  }
+
+  public static String getContextKey(final String name, final String key) {
+    return String.format("%s" + CONTEXT_KEY_SPLIT + "%s", name, key);
+  }
+
+  public static String getOutputKeyFromContextKey(final String contextKey) {
+    return contextKey.split(CONTEXT_KEY_SPLIT)[1];
+  }
+
+  public static String getNodeFromContextKey(final String contextKey) {
+    return contextKey.split(CONTEXT_KEY_SPLIT)[0];
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResultV1.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/DetectionPipelineResultV1.java
@@ -23,11 +23,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.thirdeye.detection.v2.DetectionPipelineResult;
 import org.apache.pinot.thirdeye.spi.datalayer.dto.EvaluationDTO;
 import org.apache.pinot.thirdeye.spi.datalayer.dto.MergedAnomalyResultDTO;
 import org.apache.pinot.thirdeye.spi.detection.PredictionResult;
 
-public class DetectionPipelineResultV1 {
+public class DetectionPipelineResultV1 implements DetectionPipelineResult {
 
   public static String DIAGNOSTICS_DATA = "data";
   public static String DIAGNOSTICS_CHANGE_POINTS = "changepoints";

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNode.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.v2.plan;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi.InputApi;
+import org.apache.pinot.thirdeye.detection.v2.DetectionPipelineResult;
+import org.apache.pinot.thirdeye.detection.v2.PlanNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * DetectionPipeline forms the root of the detection class hierarchy. It represents a wireframe
+ * for implementing (intermittently stateful) executable pipelines on top of it.
+ */
+public abstract class DetectionPipelinePlanNode implements PlanNode {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DetectionPipelinePlanNode.class);
+
+  protected final String name;
+  protected final Map<String, PlanNode> pipelinePlanNodes;
+  protected final DetectionPlanApi detectionPlanApi;
+  protected final long startTime;
+  protected final long endTime;
+  protected final Map<String, DetectionPipelineResult> inputsMap;
+
+  protected DetectionPipelinePlanNode() {
+    this.name = null;
+    this.pipelinePlanNodes = null;
+    this.detectionPlanApi = null;
+    this.startTime = -1;
+    this.endTime = -1;
+    this.inputsMap = null;
+  }
+
+  protected DetectionPipelinePlanNode(String name, Map<String, PlanNode> pipelinePlanNodes,
+      DetectionPlanApi detectionPlanApi, long startTime,
+      long endTime) {
+    this.name = name;
+    this.pipelinePlanNodes = pipelinePlanNodes;
+    this.detectionPlanApi = detectionPlanApi;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.inputsMap = new HashMap<>();
+  }
+
+  /**
+   * @param properties Used to set properties during plan execution.
+   */
+  abstract void setNestedProperties(Map<String, Object> properties);
+
+  public DetectionPlanApi getDetectionPlanApi() {
+    return detectionPlanApi;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getEndTime() {
+    return endTime;
+  }
+
+  @Override
+  public List<InputApi> getPlanNodeInputs() {
+    return detectionPlanApi.getInputs();
+  }
+
+  public void setInput(String key, DetectionPipelineResult input) {
+    this.inputsMap.put(key, input);
+  }
+
+  @Override
+  public Map<String, Object> getParams() {
+    return detectionPlanApi.getParams();
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNodeFactory.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNodeFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.v2.plan;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+import org.apache.pinot.thirdeye.detection.v2.PlanNode;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DetectionPipelinePlanNodeFactory {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(DetectionPipelinePlanNodeFactory.class);
+  private static final Map<String, Class<? extends PlanNode>> PLAN_NODE_TYPE_TO_CLASS_MAP = new HashMap<>();
+  public static final String V2_DETECTION_PLAN_PACKAGE_NAME = "org.apache.pinot.thirdeye.detection.v2.plan";
+
+  static {
+    long startTimeMs = System.currentTimeMillis();
+    Reflections reflections = new Reflections(V2_DETECTION_PLAN_PACKAGE_NAME);
+    Set<Class<? extends PlanNode>> classes = reflections.getSubTypesOf(PlanNode.class);
+    for (Class<? extends PlanNode> planNodeClass : classes) {
+      if (Modifier.isAbstract(planNodeClass.getModifiers())) {
+        continue;
+      }
+      String typeKey;
+      try {
+        PlanNode planNodeInstance = planNodeClass.newInstance();
+        typeKey = planNodeInstance.getType();
+      } catch (Exception e) {
+        throw new RuntimeException("Unable to init PlanNode Class - " + planNodeClass, e);
+      }
+      if (!PLAN_NODE_TYPE_TO_CLASS_MAP.containsKey(typeKey)) {
+        PLAN_NODE_TYPE_TO_CLASS_MAP.put(typeKey, planNodeClass);
+      } else {
+        LOG.error("Found duplicated type key: {}", typeKey);
+        throw new RuntimeException("Found duplicated type key - " + typeKey);
+      }
+    }
+    LOG.info("Initialized planNodeTypeToClassNameMap with {} functions: {} in {}ms",
+        PLAN_NODE_TYPE_TO_CLASS_MAP.size(),
+        PLAN_NODE_TYPE_TO_CLASS_MAP.keySet(),
+        System.currentTimeMillis() - startTimeMs);
+  }
+
+  public static PlanNode get(String name,
+      Map<String, PlanNode> pipelinePlanNodes,
+      DetectionPlanApi detectionPlanApi, long startTime, long endTime) {
+    String typeKey = detectionPlanApi.getType();
+    Class<? extends PlanNode> planNodeClass = PLAN_NODE_TYPE_TO_CLASS_MAP.get(typeKey);
+    if (planNodeClass == null) {
+      throw new UnsupportedOperationException("Not supported type - " + typeKey);
+    }
+    try {
+      final Constructor<?> constructor = planNodeClass
+          .getConstructor(String.class,
+              Map.class,
+              DetectionPlanApi.class,
+              long.class,
+              long.class);
+      return (DetectionPipelinePlanNode) constructor
+          .newInstance(name, pipelinePlanNodes, detectionPlanApi, startTime, endTime);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to initialize the plan node: type - " + typeKey,
+          e);
+    }
+  }
+
+  public static Map<String, Class<? extends PlanNode>> getAllPlanNodes() {
+    return PLAN_NODE_TYPE_TO_CLASS_MAP;
+  }
+}

--- a/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNodeFactoryTest.java
+++ b/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNodeFactoryTest.java
@@ -1,0 +1,27 @@
+package org.apache.pinot.thirdeye.detection.v2.plan;
+
+import static org.apache.pinot.thirdeye.detection.v2.plan.DetectionPipelinePlanNodeFactory.V2_DETECTION_PLAN_PACKAGE_NAME;
+
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import org.apache.pinot.thirdeye.detection.v2.PlanNode;
+import org.reflections.Reflections;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DetectionPipelinePlanNodeFactoryTest {
+
+  @Test
+  public void testNoDuplicatedTypeKeyRegistration() {
+    int numPlanNodes = DetectionPipelinePlanNodeFactory.getAllPlanNodes().size();
+    Reflections reflections = new Reflections(V2_DETECTION_PLAN_PACKAGE_NAME);
+    Set<Class<? extends PlanNode>> planNodeClasses = reflections.getSubTypesOf(PlanNode.class);
+    int expectPlanNodeClassesNum = planNodeClasses.size();
+    for (Class<? extends PlanNode> planNodeClass : planNodeClasses) {
+      if (Modifier.isAbstract(planNodeClass.getModifiers())) {
+        expectPlanNodeClassesNum--;
+      }
+    }
+    Assert.assertEquals(numPlanNodes, expectPlanNodeClassesNum);
+  }
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/api/v2/AlertEvaluationPlanApi.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/api/v2/AlertEvaluationPlanApi.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.pinot.thirdeye.api.v2;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.utils.GroovyTemplateUtils;
+import org.apache.pinot.thirdeye.spi.api.AlertApi;
+
+/**
+ * AlertEvaluationPlanApi defines the evaluation plan with AlertApi and a list of DetectionPlanApi
+ * also start/end time.
+ */
+@JsonInclude(Include.NON_NULL)
+public class AlertEvaluationPlanApi {
+
+  private AlertApi alert;
+  private List<DetectionPlanApi> nodes;
+  private Date start;
+  private Date end;
+
+  public List<DetectionPlanApi> getNodes() {
+    return nodes;
+  }
+
+  public AlertEvaluationPlanApi setNodes(final List<DetectionPlanApi> nodes) {
+    this.nodes = nodes;
+    return this;
+  }
+
+  public Date getStart() {
+    return start;
+  }
+
+  public AlertEvaluationPlanApi setStart(final Date start) {
+    this.start = start;
+    return this;
+  }
+
+  public Date getEnd() {
+    return end;
+  }
+
+  public AlertEvaluationPlanApi setEnd(final Date end) {
+    this.end = end;
+    return this;
+  }
+
+  public AlertApi getAlert() {
+    return alert;
+  }
+
+  public AlertEvaluationPlanApi setAlert(final AlertApi alert) {
+    this.alert = alert;
+    return this;
+  }
+
+  public static AlertEvaluationPlanApi applyContextToTemplate(String template,
+      Map<String, Object> context) throws IOException, ClassNotFoundException {
+    return new ObjectMapper().readValue(
+        GroovyTemplateUtils.renderTemplate(template, context), AlertEvaluationPlanApi.class);
+  }
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/api/v2/DetectionPlanApi.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/api/v2/DetectionPlanApi.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.pinot.thirdeye.api.v2;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DetectionPlanApi is self-described detection plan node.
+ */
+@JsonInclude(Include.NON_NULL)
+public class DetectionPlanApi {
+
+  /**
+   * Unique planNodeName been referred across the entire AlertEvaluation plan
+   */
+  private String planNodeName;
+  /**
+   * PlanNode type, which is registered by the implementation of
+   * 'org.apache.pinot.thirdeye.detection.v2.spi.PlanNode'.
+   */
+  private String type;
+  /**
+   * Customized params to init the PlanNode.
+   */
+  private Map<String, Object> params;
+  /**
+   * Defines the inputs of this PlanNode are set
+   */
+  private List<InputApi> inputs;
+  /**
+   * Defines the output mapping layout
+   */
+  private List<OutputApi> outputs;
+
+  public String getPlanNodeName() {
+    return planNodeName;
+  }
+
+  public DetectionPlanApi setPlanNodeName(final String planNodeName) {
+    this.planNodeName = planNodeName;
+    return this;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public DetectionPlanApi setType(final String type) {
+    this.type = type;
+    return this;
+  }
+
+  public Map<String, Object> getParams() {
+    return params;
+  }
+
+  public DetectionPlanApi setParams(final Map<String, Object> params) {
+    this.params = params;
+    return this;
+  }
+
+  public List<InputApi> getInputs() {
+    return inputs;
+  }
+
+  public DetectionPlanApi setInputs(
+      final List<InputApi> inputs) {
+    this.inputs = inputs;
+    return this;
+  }
+
+  public List<OutputApi> getOutputs() {
+    return outputs;
+  }
+
+  public DetectionPlanApi setOutputs(
+      final List<OutputApi> outputs) {
+    this.outputs = outputs;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      return this.toString();
+    }
+  }
+
+  /**
+   * InputApi defines how to describe the input for a plan plan.
+   * 'targetProperty' is the key used to refer to the Input object
+   * 'sourcePlanNode' is the plan plan name which contains the output
+   * 'sourceProperty' is the key of the output from 'sourcePlanNode'
+   */
+  @JsonInclude(Include.NON_NULL)
+  public static class InputApi {
+
+    private String targetProperty;
+    private String sourcePlanNode;
+    private String sourceProperty;
+
+    public String getTargetProperty() {
+      return targetProperty;
+    }
+
+    public InputApi setTargetProperty(final String targetProperty) {
+      this.targetProperty = targetProperty;
+      return this;
+    }
+
+    public String getSourcePlanNode() {
+      return sourcePlanNode;
+    }
+
+    public InputApi setSourcePlanNode(final String sourcePlanNode) {
+      this.sourcePlanNode = sourcePlanNode;
+      return this;
+    }
+
+    public String getSourceProperty() {
+      return sourceProperty;
+    }
+
+    public InputApi setSourceProperty(final String sourceProperty) {
+      this.sourceProperty = sourceProperty;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      try {
+        return new ObjectMapper().writeValueAsString(this);
+      } catch (JsonProcessingException e) {
+        return this.toString();
+      }
+    }
+  }
+
+  /**
+   * OutputApi defines how to describe the output for a plan node.
+   * Users can set this to rename the output from `outputKey` to `outputName`.
+   * E.g. By default DataFetcher always set output to key `output`. Users can rename it
+   * from `output` to `baselineOutput` by set OutputApi like:
+   * { "outputKey": "output", "outputName": "baselineOutput" }
+   */
+  @JsonInclude(Include.NON_NULL)
+  public static class OutputApi {
+
+    private String outputKey;
+    private String outputName;
+
+    public String getOutputKey() {
+      return outputKey;
+    }
+
+    public OutputApi setOutputKey(final String outputKey) {
+      this.outputKey = outputKey;
+      return this;
+    }
+
+    public String getOutputName() {
+      return outputName;
+    }
+
+    public OutputApi setOutputName(final String outputName) {
+      this.outputName = outputName;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      try {
+        return new ObjectMapper().writeValueAsString(this);
+      } catch (JsonProcessingException e) {
+        return this.toString();
+      }
+    }
+  }
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/DetectionPipelineResult.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/DetectionPipelineResult.java
@@ -1,0 +1,4 @@
+package org.apache.pinot.thirdeye.detection.v2;
+
+public interface DetectionPipelineResult {
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/Operator.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/Operator.java
@@ -1,0 +1,33 @@
+package org.apache.pinot.thirdeye.detection.v2;
+
+import java.util.Map;
+
+
+public interface Operator<T extends DetectionPipelineResult> {
+
+  void execute()
+      throws Exception;
+
+  String getOperatorName();
+
+  void setProperty(String key, Object value);
+
+
+  /**
+   * Set keyed input
+   * @param key
+   * @param input
+   */
+  void setInput(String key, DetectionPipelineResult input);
+
+  /**
+   * Get keyed output
+   * @param key
+   */
+  DetectionPipelineResult getOutput(String key);
+
+  /**
+   * Get all keyed outputs
+   */
+  Map<String, DetectionPipelineResult> getOutputs();
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNode.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNode.java
@@ -1,0 +1,51 @@
+package org.apache.pinot.thirdeye.detection.v2;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi.InputApi;
+
+/**
+ * The <code>PlanNode</code> is a single execution plan node inside the Plan tree.
+ */
+public interface PlanNode {
+  /**
+   *
+   * @return unique PlanNode name
+   */
+  String getName();
+
+  /**
+   *
+   * @return PlanNode type
+   */
+  String getType();
+
+  /**
+   * Set one Input from the other Operator
+   *
+   * @param key
+   * @param obj
+   */
+  void setInput(String key, DetectionPipelineResult obj);
+
+  /**
+   *
+   * @return All Inputs set
+   */
+  List<InputApi> getPlanNodeInputs();
+
+  /**
+   *
+   * @return all params
+   */
+  Map<String, Object> getParams();
+
+  /**
+   * Get the execution operator associated with the PlanNode.
+   *
+   * @return execution operator.
+   */
+  Operator<? extends DetectionPipelineResult> run()
+      throws Exception;
+
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNodeInput.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNodeInput.java
@@ -1,0 +1,37 @@
+package org.apache.pinot.thirdeye.detection.v2;
+
+/**
+ * Defines an input for any PlanNode, with plan node name and all the keys of outputs.
+ */
+public class PlanNodeInput {
+  private String inputKey;
+  private String nodeName;
+  private String outputKey;
+
+  public String getInputKey() {
+    return inputKey;
+  }
+
+  public PlanNodeInput setInputKey(final String inputKey) {
+    this.inputKey = inputKey;
+    return this;
+  }
+
+  public String getNodeName() {
+    return nodeName;
+  }
+
+  public PlanNodeInput setNodeName(final String nodeName) {
+    this.nodeName = nodeName;
+    return this;
+  }
+
+  public String getOutputKey() {
+    return outputKey;
+  }
+
+  public PlanNodeInput setOutputKey(final String outputKey) {
+    this.outputKey = outputKey;
+    return this;
+  }
+}

--- a/thirdeye-spi/src/test/java/org/apache/pinot/thirdeye/api/v2/AlertEvaluationPlanApiTest.java
+++ b/thirdeye-spi/src/test/java/org/apache/pinot/thirdeye/api/v2/AlertEvaluationPlanApiTest.java
@@ -1,0 +1,48 @@
+package org.apache.pinot.thirdeye.api.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Date;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AlertEvaluationPlanApiTest {
+
+  @Test
+  public void testAlertEvaluationPlan() throws IOException, ClassNotFoundException {
+    final ClassLoader classLoader = AlertEvaluationPlanApiTest.class.getClassLoader();
+    URL resource = classLoader.getResource("alertEvaluation.json");
+    String alertEvaluationPlanApiTemplate = IOUtils.toString(resource);
+    resource = classLoader.getResource("alertEvaluation-context.json");
+    Map<String, Object> alertEvaluationPlanApiContext = new ObjectMapper().readValue(resource.openStream(),
+        Map.class);
+
+    final AlertEvaluationPlanApi alertEvaluationPlanApi = AlertEvaluationPlanApi.applyContextToTemplate(
+        alertEvaluationPlanApiTemplate,
+        alertEvaluationPlanApiContext);
+
+    Assert.assertEquals(alertEvaluationPlanApi.getAlert().getName(), "percentage-change-template");
+    Assert.assertEquals(alertEvaluationPlanApi.getAlert().getDescription(),
+        "Percentage drop template");
+    Assert.assertEquals(alertEvaluationPlanApi.getAlert().getCron(), "0 0/1 * 1/1 * ? *");
+    Assert.assertEquals(alertEvaluationPlanApi.getStart(), new Date(1621300000));
+    Assert.assertEquals(alertEvaluationPlanApi.getEnd(), new Date(1621200000));
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().size(), 5);
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(0).getPlanNodeName(), "root");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(1).getPlanNodeName(),
+        "percentageChangeDetector");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(2).getPlanNodeName(),
+        "baselineDataFetcher");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(3).getPlanNodeName(),
+        "currentDataFetcher");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(4).getPlanNodeName(), "sqlJoin");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(0).getType(), "ChildKeepingMerge");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(1).getType(), "AnomalyDetector");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(2).getType(), "DataFetcher");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(3).getType(), "DataFetcher");
+    Assert.assertEquals(alertEvaluationPlanApi.getNodes().get(4).getType(), "SqlQueryExecutor");
+  }
+}

--- a/thirdeye-spi/src/test/java/org/apache/pinot/thirdeye/api/v2/DetectionPlanApiTest.java
+++ b/thirdeye-spi/src/test/java/org/apache/pinot/thirdeye/api/v2/DetectionPlanApiTest.java
@@ -1,0 +1,42 @@
+package org.apache.pinot.thirdeye.api.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URL;
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DetectionPlanApiTest {
+
+  @Test
+  public void testInputNode() throws IOException {
+    URL resource = DetectionPlanApiTest.class.getClassLoader().getResource("inputNode.json");
+    final DetectionPlanApi inputNode = new ObjectMapper().readValue(IOUtils.toString(resource),
+        DetectionPlanApi.class);
+    Assert.assertEquals(inputNode.getPlanNodeName(), "baselineDataFetcher");
+    Assert.assertEquals(inputNode.getType(), "DataFetcher");
+    Assert.assertEquals(inputNode.getParams().size(), 5);
+    Assert.assertEquals(inputNode.getOutputs().size(), 1);
+    Assert.assertEquals(inputNode.getOutputs().get(0).getOutputKey(), "output");
+    Assert.assertEquals(inputNode.getOutputs().get(0).getOutputName(), "current");
+  }
+
+  @Test
+  public void testDetectionNode() throws IOException {
+    URL resource = DetectionPlanApiTest.class.getClassLoader().getResource("detectionNode.json");
+    final DetectionPlanApi inputNode = new ObjectMapper().readValue(IOUtils.toString(resource),
+        DetectionPlanApi.class);
+    Assert.assertEquals(inputNode.getPlanNodeName(), "percentageChangeDetector");
+    Assert.assertEquals(inputNode.getType(), "AnomalyDetector");
+    Assert.assertEquals(inputNode.getParams().size(), 6);
+    Assert.assertEquals(inputNode.getInputs().size(), 2);
+    Assert.assertEquals(inputNode.getInputs().get(0).getTargetProperty(), "baseline");
+    Assert.assertEquals(inputNode.getInputs().get(0).getSourcePlanNode(), "baselineDataFetcher");
+    Assert.assertEquals(inputNode.getInputs().get(0).getSourceProperty(), "baselineOutput");
+    Assert.assertEquals(inputNode.getInputs().get(1).getTargetProperty(), "current");
+    Assert.assertEquals(inputNode.getInputs().get(1).getSourcePlanNode(), "currentDataFetcher");
+    Assert.assertEquals(inputNode.getInputs().get(1).getSourceProperty(), "currentOutput");
+    Assert.assertNull(inputNode.getOutputs());
+  }
+}

--- a/thirdeye-spi/src/test/resources/alertEvaluation-context.json
+++ b/thirdeye-spi/src/test/resources/alertEvaluation-context.json
@@ -1,0 +1,14 @@
+{
+  "cronExpr": "0 0/1 * 1/1 * ? *",
+  "start": "1621300000",
+  "end": "1621200000",
+  "baseline_start": "20200202",
+  "baseline_end": "20200214",
+  "current_start": "20200302",
+  "current_end": "20200314",
+  "percent_change": 0.2,
+  "table": "pageviews",
+  "timestamp": "ts",
+  "metricName": "met",
+  "dataSourceName": "QuickStartCluster"
+}

--- a/thirdeye-spi/src/test/resources/alertEvaluation.json
+++ b/thirdeye-spi/src/test/resources/alertEvaluation.json
@@ -1,0 +1,104 @@
+{
+  "alert": {
+    "name": "percentage-change-template",
+    "description": "Percentage drop template",
+    "cron": "${cronExpr}"
+  },
+  "nodes": [
+    {
+      "planNodeName": "root",
+      "type": "ChildKeepingMerge",
+      "inputs": [
+        {
+          "targetProperty": "input",
+          "sourcePlanNode": "anomalyDetector",
+          "sourceProperty": "output"
+        }
+      ]
+    },
+    {
+      "planNodeName": "percentageChangeDetector",
+      "type": "AnomalyDetector",
+      "params": {
+        "detectorName": "PERCENTAGE_RULE",
+        "percentageChange": "${percent_change}",
+        "pattern": "down",
+        "dimensions": [],
+        "metric": "${metricName}",
+        "timestamp": "${timestamp}"
+      },
+      "inputs": [
+        {
+          "targetProperty": "baseline",
+          "sourcePlanNode": "baselineDataFetcher",
+          "sourceProperty": "baselineOutput"
+        },
+        {
+          "targetProperty": "current",
+          "sourcePlanNode": "currentDataFetcher",
+          "sourceProperty": "currentOutput"
+        }
+      ]
+    },
+    {
+      "planNodeName": "baselineDataFetcher",
+      "type": "DataFetcher",
+      "params": {
+        "dataSource": "${dataSourceName}",
+        "startTime": "${baseline_start}",
+        "endTime": "${baseline_end}",
+        "pinot.zookeeper": "localhost:2123/QuickStartCluster",
+        "dataSource": "pinot",
+        "table": "${table}",
+        "query": "SELECT \"date\" as ${timestamp}, count(*) as ${metricName} FROM ${table} WHERE \"date\" >= ${baseline_start} AND \"date\" < ${baseline_end} GROUP BY \"date\" LIMIT 100"
+      },
+      "inputs": [],
+      "outputs": [
+        {
+          "outputKey": "output",
+          "outputName": "baselineOutput"
+        }
+      ]
+    },
+    {
+      "planNodeName": "currentDataFetcher",
+      "type": "DataFetcher",
+      "params": {
+        "dataSource": "${dataSourceName}",
+        "startTime": "${start}",
+        "endTime": "${end}",
+        "dataSource": "pinot",
+        "table": "${table}",
+        "query": "SELECT \"date\" as ${timestamp}, count(*) as ${metricName} FROM ${table} WHERE \"date\" >= ${current_start} AND \"date\" < ${current_end} GROUP BY \"date\" LIMIT 100"
+      },
+      "inputs": [],
+      "outputs": [
+        {
+          "outputKey": "output",
+          "outputName": "currentOutput"
+        }
+      ]
+    },
+    {
+      "planNodeName": "sqlJoin",
+      "type": "SqlQueryExecutor",
+      "inputs": [
+        {
+          "targetProperty": "t1",
+          "sourcePlanNode": "baselineDataFetcher",
+          "sourceProperty": "baselineOutput"
+        },
+        {
+          "targetProperty": "t2",
+          "sourcePlanNode": "currentDataFetcher",
+          "sourceProperty": "currentOutput"
+        }
+      ],
+      "params": {
+        "sql": "SELECT t1.met/t2.met as met, t1.ts as ts FROM t1 JOIN t2 on t1.ts = t2.ts"
+      }
+    }
+  ],
+  "start": "${start}",
+  "end": "${end}"
+}

--- a/thirdeye-spi/src/test/resources/detectionNode.json
+++ b/thirdeye-spi/src/test/resources/detectionNode.json
@@ -1,0 +1,23 @@
+{
+  "planNodeName": "percentageChangeDetector",
+  "type": "AnomalyDetector",
+  "params": {
+    "detectorName": "PERCENTAGE_RULE",
+    "percentageChange": "${percent_change}",
+    "pattern": "down",
+    "dimensions": [],
+    "metric": "${metricName}",
+    "timestamp": "${timestamp}"
+  },
+  "inputs": [
+    {
+      "targetProperty": "baseline",
+      "sourcePlanNode": "baselineDataFetcher",
+      "sourceProperty": "baselineOutput"
+    },{
+      "targetProperty": "current",
+      "sourcePlanNode": "currentDataFetcher",
+      "sourceProperty": "currentOutput"
+    }
+  ]
+}

--- a/thirdeye-spi/src/test/resources/inputNode.json
+++ b/thirdeye-spi/src/test/resources/inputNode.json
@@ -1,0 +1,18 @@
+{
+  "planNodeName": "baselineDataFetcher",
+  "type": "DataFetcher",
+  "params": {
+    "dataSource": "${dataSourceName}",
+    "startTime": "${start}",
+    "endTime": "${end}",
+    "table": "${table}",
+    "query": "SELECT \"date\" as ${timestamp}, count(*) as ${metricName} FROM ${table} WHERE \"date\" >= ${start} AND \"date\" < ${end} GROUP BY \"date\" LIMIT 100"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "outputKey": "output",
+      "outputName": "current"
+    }
+  ]
+}


### PR DESCRIPTION
- Adding DetectionPipelineResult interface and rename existing DetectionPipelineResult implementation to DetectionPipelineResultV1, so we can re-use this object in V2 implementation for a while
- Adding v2 interfaces for PlanNode and Operator
- Adding the AlertEvaluator and PlanExecutor implementation
