### PR TITLE
Adding DataFetcher plan node and operator

### DIFF
--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/alert/v2/AlertEvaluator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/alert/v2/AlertEvaluator.java
@@ -40,9 +40,12 @@ public class AlertEvaluator {
   private static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
 
   private final ExecutorService executorService;
+  private final DetectionPipelinePlanNodeFactory detectionPipelinePlanNodeFactory;
 
   @Inject
-  public AlertEvaluator() {
+  public AlertEvaluator(
+      final DetectionPipelinePlanNodeFactory detectionPipelinePlanNodeFactory) {
+    this.detectionPipelinePlanNodeFactory = detectionPipelinePlanNodeFactory;
     this.executorService = Executors.newFixedThreadPool(PARALLELISM);
   }
 
@@ -90,7 +93,7 @@ public class AlertEvaluator {
     Map<String, PlanNode> pipelinePlanNodes = new HashMap<>();
     for (DetectionPlanApi operator : request.getNodes()) {
       final String operatorName = operator.getPlanNodeName();
-      pipelinePlanNodes.put(operatorName, DetectionPipelinePlanNodeFactory
+      pipelinePlanNodes.put(operatorName, detectionPipelinePlanNodeFactory
           .get(operatorName,
               pipelinePlanNodes,
               operator,

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/datafetcher/DataFetcher.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/datafetcher/DataFetcher.java
@@ -1,0 +1,9 @@
+package org.apache.pinot.thirdeye.detection.v2.components.datafetcher;
+
+import org.apache.pinot.thirdeye.detection.v2.BaseComponent;
+import org.apache.pinot.thirdeye.detection.v2.results.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.spec.AbstractSpec;
+
+public interface DataFetcher<T extends AbstractSpec> extends BaseComponent<T> {
+  DataTable getDataTable() throws Exception;
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/datafetcher/PinotDataFetcher.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/datafetcher/PinotDataFetcher.java
@@ -1,0 +1,62 @@
+package org.apache.pinot.thirdeye.detection.v2.components.datafetcher;
+
+import java.util.concurrent.ExecutionException;
+import org.apache.pinot.thirdeye.datasource.pinot.PinotQuery;
+import org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
+import org.apache.pinot.thirdeye.datasource.pinot.resultset.ThirdEyeResultSetGroup;
+import org.apache.pinot.thirdeye.detection.v2.results.DataTable;
+import org.apache.pinot.thirdeye.detection.v2.spec.DataFetcherSpec;
+
+public class PinotDataFetcher implements DataFetcher<DataFetcherSpec> {
+
+  /**
+   * Query to execute.
+   */
+  private String query;
+  /**
+   * Table to query.
+   */
+  private String tableName;
+
+  private PinotThirdEyeDataSource pinotDataSource;
+
+  public String getQuery() {
+    return query;
+  }
+
+  public PinotDataFetcher setQuery(final String query) {
+    this.query = query;
+    return this;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public PinotDataFetcher setTableName(final String tableName) {
+    this.tableName = tableName;
+    return this;
+  }
+
+  @Override
+  public void init(final DataFetcherSpec dataFetcherSpec) {
+    this.query = dataFetcherSpec.getQuery();
+    this.tableName = dataFetcherSpec.getTableName();
+    if (dataFetcherSpec.getDataSourceCache() != null) {
+      this.pinotDataSource = (PinotThirdEyeDataSource) dataFetcherSpec.getDataSourceCache()
+          .getDataSource(dataFetcherSpec.getDataSource());
+    }
+  }
+
+  @Override
+  public DataTable getDataTable() throws Exception {
+    try {
+      ThirdEyeResultSetGroup thirdEyeResultSetGroup = pinotDataSource.executeSQL(new PinotQuery(
+          query,
+          tableName));
+      return new DataTable(thirdEyeResultSetGroup);
+    } catch (ExecutionException e) {
+      throw e;
+    }
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DataFetcherOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DataFetcherOperator.java
@@ -1,0 +1,64 @@
+package org.apache.pinot.thirdeye.detection.v2.operator;
+
+import static org.apache.pinot.thirdeye.detection.v2.plan.DetectionPipelinePlanNodeFactory.DATA_SOURCE_CACHE_REF_KEY;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi.OutputApi;
+import org.apache.pinot.thirdeye.datasource.cache.DataSourceCache;
+import org.apache.pinot.thirdeye.detection.v2.BaseComponent;
+import org.apache.pinot.thirdeye.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.detection.v2.components.datafetcher.DataFetcher;
+import org.apache.pinot.thirdeye.detection.v2.results.DataTable;
+import org.apache.pinot.thirdeye.detection.v2.spec.DataFetcherSpec;
+import org.apache.pinot.thirdeye.spi.detection.spec.AbstractSpec;
+
+public class DataFetcherOperator extends DetectionPipelineOperator<DataTable> {
+
+  private DataSourceCache dataSourceCache;
+  private Map<String, String> outputKeyMap = new HashMap<>();
+
+  public DataFetcherOperator() {
+    super();
+  }
+
+  @Override
+  protected AbstractSpec getComponentSpec(Map<String, Object> componentSpecs, String componentKey) {
+    final AbstractSpec componentSpec = super.getComponentSpec(componentSpecs, componentKey);
+    if (componentSpec instanceof DataFetcherSpec) {
+      ((DataFetcherSpec) componentSpec).setDataSourceCache(dataSourceCache);
+    }
+    return componentSpec;
+  }
+
+  @Override
+  public void init(final OperatorContext context) {
+    this.dataSourceCache = (DataSourceCache) context.getProperties()
+        .get(DATA_SOURCE_CACHE_REF_KEY);
+    super.init(context);
+    for (OutputApi outputApi : context.getDetectionPlanApi().getOutputs()) {
+      outputKeyMap.put(outputApi.getOutputKey(), outputApi.getOutputName());
+    }
+  }
+
+  @Override
+  public void execute() throws Exception {
+    for (Object key : this.getComponents().keySet()) {
+      final BaseComponent component = this.getComponents().get(key);
+      if (component instanceof DataFetcher) {
+        final DataFetcher fetcher = (DataFetcher) component;
+        final DataTable dataTable = fetcher.getDataTable();
+        if (outputKeyMap.containsKey(key)) {
+          resultMap.put(outputKeyMap.get(key), dataTable);
+        } else {
+          resultMap.put(key.toString(), dataTable);
+        }
+      }
+    }
+  }
+
+  @Override
+  public String getOperatorName() {
+    return "DataFetcherOperator";
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.v2.operator;
+
+import static org.apache.pinot.thirdeye.detection.DetectionUtils.getSpecClassName;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+import org.apache.pinot.thirdeye.detection.DetectionUtils;
+import org.apache.pinot.thirdeye.detection.v2.BaseComponent;
+import org.apache.pinot.thirdeye.detection.v2.DetectionPipelineResult;
+import org.apache.pinot.thirdeye.detection.v2.Operator;
+import org.apache.pinot.thirdeye.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.spi.detection.ConfigUtils;
+import org.apache.pinot.thirdeye.spi.detection.spec.AbstractSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * DetectionPipeline forms the root of the detection class hierarchy. It represents a wireframe
+ * for implementing (intermittently stateful) executable pipelines on top of it.
+ */
+public abstract class DetectionPipelineOperator<T extends DetectionPipelineResult> implements
+    Operator {
+
+  private static final String PROP_CLASS_NAME = "className";
+  private static final Logger LOG = LoggerFactory.getLogger(DetectionPipelineOperator.class);
+
+  protected DetectionPlanApi config;
+  protected long startTime;
+  protected long endTime;
+  protected Map<String, DetectionPipelineResult> resultMap = new HashMap<>();
+  protected Map<String, BaseComponent> instancesMap = new HashMap<>();
+  protected Map<String, DetectionPipelineResult> inputMap;
+
+  protected DetectionPipelineOperator() {
+  }
+
+  @Override
+  public void init(final OperatorContext context) {
+    this.config = context.getDetectionPlanApi();
+    this.startTime = context.getStartTime();
+    this.endTime = context.getEndTime();
+    this.instancesMap = new HashMap<>();
+    this.resultMap = new HashMap<>();
+    this.initComponents();
+  }
+
+  /**
+   * Returns a detection result for the time range between {@code startTime} and {@code endTime}.
+   *
+   * @return detection result
+   */
+  public abstract void execute()
+      throws Exception;
+
+  /**
+   * Initialize all components in the pipeline
+   */
+  protected void initComponents() {
+    Map<String, Object> componentSpecs = getComponentSpecs(config.getParams());
+    if (componentSpecs != null) {
+      for (String componentKey : componentSpecs.keySet()) {
+        Map<String, Object> componentSpec = ConfigUtils.getMap(componentSpecs.get(componentKey));
+        if (!instancesMap.containsKey(componentKey)) {
+          instancesMap.put(componentKey, createComponent(componentSpec));
+        }
+      }
+
+      for (String componentKey : componentSpecs.keySet()) {
+        // Initialize the components
+        instancesMap.get(componentKey).init(getComponentSpec(componentSpecs, componentKey));
+      }
+    }
+  }
+
+  protected AbstractSpec getComponentSpec(Map<String, Object> componentSpecs, String componentKey) {
+    Map<String, Object> componentSpec = ConfigUtils.getMap(componentSpecs.get(componentKey));
+    for (Map.Entry<String, Object> entry : componentSpec.entrySet()) {
+      if (entry.getValue() != null && DetectionUtils.isReferenceName(entry.getValue()
+          .toString())) {
+        componentSpec
+            .put(entry.getKey(),
+                instancesMap.get(DetectionUtils.getComponentKey(entry.getValue().toString())));
+      }
+    }
+
+    String className = MapUtils.getString(componentSpec, PROP_CLASS_NAME);
+    try {
+      Class clazz = Class.forName(className);
+      Class<AbstractSpec> specClazz = (Class<AbstractSpec>) Class.forName(getSpecClassName(clazz));
+      return AbstractSpec.fromProperties(componentSpec, specClazz);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to get component spec for " + className, e);
+    }
+  }
+
+  protected Map<String, Object> getComponentSpecs(Map<String, Object> params) {
+    Map<String, Object> componentSpecs = new HashMap<>();
+    if (params != null) {
+      for (String key : params.keySet()) {
+        final String[] splits = key.split("\\.");
+        if (splits.length > 2 && "component".equalsIgnoreCase(splits[0])) {
+          String componentKey = splits[1];
+          if (!componentSpecs.containsKey(componentKey)) {
+            componentSpecs.put(componentKey, new HashMap<>());
+          }
+          final Map<String, Object> componentSpec = (Map<String, Object>) componentSpecs.get(
+              componentKey);
+          componentSpec.put(StringUtils.join(Arrays.copyOfRange(splits, 2, splits.length), "."),
+              params.get(key));
+        }
+      }
+    }
+    return componentSpecs;
+  }
+
+  private BaseComponent createComponent(Map<String, Object> componentSpec) {
+    String className = MapUtils.getString(componentSpec, PROP_CLASS_NAME);
+    try {
+      Class<BaseComponent> clazz = (Class<BaseComponent>) Class.forName(className);
+      return clazz.newInstance();
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to create component for " + className,
+          e.getCause());
+    }
+  }
+
+  public DetectionPlanApi getConfig() {
+    return config;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getEndTime() {
+    return endTime;
+  }
+
+  @Override
+  public void setProperty(String key, Object value) {
+    config.getParams().put(key, value);
+  }
+
+  public Map<String, BaseComponent> getComponents() {
+    return instancesMap;
+  }
+
+  @Override
+  public DetectionPipelineResult getOutput(String key) {
+    return resultMap.get(key);
+  }
+
+  @Override
+  public Map<String, DetectionPipelineResult> getOutputs() {
+    return resultMap;
+  }
+
+  @Override
+  public void setInput(String key, DetectionPipelineResult input) {
+    this.inputMap.put(key, input);
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DataFetcherPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DataFetcherPlanNode.java
@@ -1,0 +1,72 @@
+package org.apache.pinot.thirdeye.detection.v2.plan;
+
+import static org.apache.pinot.thirdeye.detection.v2.plan.DetectionPipelinePlanNodeFactory.DATA_SOURCE_CACHE_REF_KEY;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+import org.apache.pinot.thirdeye.datasource.cache.DataSourceCache;
+import org.apache.pinot.thirdeye.detection.v2.Operator;
+import org.apache.pinot.thirdeye.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.detection.v2.PlanNodeContext;
+import org.apache.pinot.thirdeye.detection.v2.operator.DataFetcherOperator;
+import org.apache.pinot.thirdeye.detection.v2.results.DataTable;
+
+public class DataFetcherPlanNode extends DetectionPipelinePlanNode {
+
+  private DataSourceCache dataSourceCache = null;
+
+  public DataFetcherPlanNode() {
+    super();
+  }
+
+  @Override
+  public void init(final PlanNodeContext planNodeContext) {
+    super.init(planNodeContext);
+    this.dataSourceCache = (DataSourceCache) planNodeContext.getProperties()
+        .get(DATA_SOURCE_CACHE_REF_KEY);
+  }
+
+  @Override
+  void setNestedProperties(final Map<String, Object> properties) {
+  }
+
+  @Override
+  public String getType() {
+    return "DataFetcher";
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Map<String, Object> getParams() {
+    return detectionPlanApi.getParams();
+  }
+
+  @Override
+  public Operator<DataTable> run() throws Exception {
+    long startTime;
+    try {
+      startTime = Long.parseLong(getParams().get("startTime").toString());
+    } catch (Exception e) {
+      startTime = this.startTime;
+    }
+    long endTime;
+    try {
+      endTime = Long.parseLong(getParams().get("endTime").toString());
+    } catch (Exception e) {
+      endTime = this.endTime;
+    }
+    final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
+    dataFetcherOperator.init(new OperatorContext()
+        .setStartTime(startTime)
+        .setEndTime(endTime)
+        .setDetectionPlanApi(detectionPlanApi)
+        .setProperties(ImmutableMap.of(DATA_SOURCE_CACHE_REF_KEY, dataSourceCache))
+    );
+    return dataFetcherOperator;
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNode.java
@@ -26,6 +26,7 @@ import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
 import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi.InputApi;
 import org.apache.pinot.thirdeye.detection.v2.DetectionPipelineResult;
 import org.apache.pinot.thirdeye.detection.v2.PlanNode;
+import org.apache.pinot.thirdeye.detection.v2.PlanNodeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,31 +38,23 @@ public abstract class DetectionPipelinePlanNode implements PlanNode {
 
   private static final Logger LOG = LoggerFactory.getLogger(DetectionPipelinePlanNode.class);
 
-  protected final String name;
-  protected final Map<String, PlanNode> pipelinePlanNodes;
-  protected final DetectionPlanApi detectionPlanApi;
-  protected final long startTime;
-  protected final long endTime;
-  protected final Map<String, DetectionPipelineResult> inputsMap;
+  protected String name = null;
+  protected Map<String, PlanNode> pipelinePlanNodes = null;
+  protected DetectionPlanApi detectionPlanApi = null;
+  protected long startTime = -1;
+  protected long endTime = -1;
+  protected Map<String, DetectionPipelineResult> inputsMap = new HashMap<>();
 
   protected DetectionPipelinePlanNode() {
-    this.name = null;
-    this.pipelinePlanNodes = null;
-    this.detectionPlanApi = null;
-    this.startTime = -1;
-    this.endTime = -1;
-    this.inputsMap = null;
   }
 
-  protected DetectionPipelinePlanNode(String name, Map<String, PlanNode> pipelinePlanNodes,
-      DetectionPlanApi detectionPlanApi, long startTime,
-      long endTime) {
-    this.name = name;
-    this.pipelinePlanNodes = pipelinePlanNodes;
-    this.detectionPlanApi = detectionPlanApi;
-    this.startTime = startTime;
-    this.endTime = endTime;
-    this.inputsMap = new HashMap<>();
+  @Override
+  public void init(final PlanNodeContext planNodeContext) {
+    this.name = planNodeContext.getName();
+    this.pipelinePlanNodes = planNodeContext.getPipelinePlanNodes();
+    this.detectionPlanApi = planNodeContext.getDetectionPlanApi();
+    this.startTime = planNodeContext.getStartTime();
+    this.endTime = planNodeContext.getEndTime();
   }
 
   /**

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DataTable.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DataTable.java
@@ -1,0 +1,17 @@
+package org.apache.pinot.thirdeye.detection.v2.results;
+
+import org.apache.pinot.thirdeye.datasource.pinot.resultset.ThirdEyeResultSetGroup;
+import org.apache.pinot.thirdeye.detection.v2.DetectionPipelineResult;
+
+public class DataTable implements DetectionPipelineResult {
+
+  private final ThirdEyeResultSetGroup thirdEyeResultSetGroup;
+
+  public DataTable(final ThirdEyeResultSetGroup thirdEyeResultSetGroup) {
+    this.thirdEyeResultSetGroup = thirdEyeResultSetGroup;
+  }
+
+  public ThirdEyeResultSetGroup getThirdEyeResultSetGroup() {
+    return thirdEyeResultSetGroup;
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/spec/DataFetcherSpec.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/spec/DataFetcherSpec.java
@@ -1,0 +1,58 @@
+package org.apache.pinot.thirdeye.detection.v2.spec;
+
+import org.apache.pinot.thirdeye.datasource.cache.DataSourceCache;
+import org.apache.pinot.thirdeye.spi.detection.spec.AbstractSpec;
+
+public class DataFetcherSpec extends AbstractSpec {
+
+  /**
+   * The name refer to ThirdEyeDataSource
+   */
+  private String dataSource;
+  /**
+   * The query to execute
+   */
+  private String query;
+  /**
+   * The table to query
+   */
+  private String tableName;
+  /**
+   * Expected to be set during DataFetcherOperator init
+   */
+  private DataSourceCache dataSourceCache;
+
+  public String getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(final String dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(final String query) {
+    this.query = query;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public void setTableName(final String tableName) {
+    this.tableName = tableName;
+  }
+
+  public DataSourceCache getDataSourceCache() {
+    return dataSourceCache;
+  }
+
+  public DataFetcherSpec setDataSourceCache(
+      final DataSourceCache dataSourceCache) {
+    this.dataSourceCache = dataSourceCache;
+    return this;
+  }
+}

--- a/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/DataFetcherOperatorTest.java
+++ b/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/DataFetcherOperatorTest.java
@@ -1,0 +1,72 @@
+package org.apache.pinot.thirdeye.detection.v2.operator;
+
+import static org.apache.pinot.thirdeye.detection.v2.plan.DetectionPipelinePlanNodeFactory.DATA_SOURCE_CACHE_REF_KEY;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+import org.apache.pinot.thirdeye.datasource.cache.DataSourceCache;
+import org.apache.pinot.thirdeye.detection.v2.BaseComponent;
+import org.apache.pinot.thirdeye.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.detection.v2.components.datafetcher.PinotDataFetcher;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DataFetcherOperatorTest {
+
+  @Test
+  public void testNewInstance() {
+    final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + 1000L;
+    final DetectionPlanApi detectionPlanApi = new DetectionPlanApi().setOutputs(ImmutableList.of());
+    final DataSourceCache mockDataSourceCache = mock(DataSourceCache.class);
+    final Map<String, Object> properties = ImmutableMap.of(DATA_SOURCE_CACHE_REF_KEY,
+        mockDataSourceCache);
+    final OperatorContext context = new OperatorContext().setStartTime(startTime)
+        .setEndTime(endTime)
+        .setDetectionPlanApi(detectionPlanApi)
+        .setProperties(properties);
+    dataFetcherOperator.init(context);
+    Assert.assertEquals(dataFetcherOperator.getStartTime(), startTime);
+    Assert.assertEquals(dataFetcherOperator.getEndTime(), endTime);
+  }
+
+  @Test
+  public void testInitComponents() {
+    Map<String, Object> params = new HashMap<>();
+
+    params.put("component.pinot.dataSource", "pinot-cluster-1");
+    params.put("component.pinot.query", "SELECT * FROM myTable");
+    params.put("component.pinot.tableName", "myTable");
+    params.put("component.pinot.className",
+        "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.PinotDataFetcher");
+
+    final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + 1000L;
+    final DetectionPlanApi detectionPlanApi = new DetectionPlanApi()
+        .setOutputs(ImmutableList.of())
+        .setInputs(ImmutableList.of())
+        .setParams(params);
+    final DataSourceCache mockDataSourceCache = mock(DataSourceCache.class);
+
+    final Map<String, Object> properties = ImmutableMap.of(DATA_SOURCE_CACHE_REF_KEY,
+        mockDataSourceCache);
+    final OperatorContext context = new OperatorContext().setStartTime(startTime)
+        .setEndTime(endTime)
+        .setDetectionPlanApi(detectionPlanApi)
+        .setProperties(properties);
+    dataFetcherOperator.init(context);
+    Assert.assertEquals(dataFetcherOperator.getStartTime(), startTime);
+    Assert.assertEquals(dataFetcherOperator.getEndTime(), endTime);
+    Assert.assertEquals(dataFetcherOperator.getComponents().size(), 1);
+    final BaseComponent pinotDataFetcher = dataFetcherOperator.getComponents().get("pinot");
+    Assert.assertTrue(pinotDataFetcher instanceof PinotDataFetcher);
+    Assert.assertEquals(((PinotDataFetcher) pinotDataFetcher).getQuery(), "SELECT * FROM myTable");
+    Assert.assertEquals(((PinotDataFetcher) pinotDataFetcher).getTableName(), "myTable");
+  }
+}

--- a/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNodeFactoryTest.java
+++ b/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/plan/DetectionPipelinePlanNodeFactoryTest.java
@@ -1,9 +1,11 @@
 package org.apache.pinot.thirdeye.detection.v2.plan;
 
 import static org.apache.pinot.thirdeye.detection.v2.plan.DetectionPipelinePlanNodeFactory.V2_DETECTION_PLAN_PACKAGE_NAME;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Modifier;
 import java.util.Set;
+import org.apache.pinot.thirdeye.datasource.cache.DataSourceCache;
 import org.apache.pinot.thirdeye.detection.v2.PlanNode;
 import org.reflections.Reflections;
 import org.testng.Assert;
@@ -13,7 +15,9 @@ public class DetectionPipelinePlanNodeFactoryTest {
 
   @Test
   public void testNoDuplicatedTypeKeyRegistration() {
-    int numPlanNodes = DetectionPipelinePlanNodeFactory.getAllPlanNodes().size();
+    DetectionPipelinePlanNodeFactory detectionPipelinePlanNodeFactory = new DetectionPipelinePlanNodeFactory(
+        mock(DataSourceCache.class));
+    int numPlanNodes = detectionPipelinePlanNodeFactory.getAllPlanNodes().size();
     Reflections reflections = new Reflections(V2_DETECTION_PLAN_PACKAGE_NAME);
     Set<Class<? extends PlanNode>> planNodeClasses = reflections.getSubTypesOf(PlanNode.class);
     int expectPlanNodeClassesNum = planNodeClasses.size();

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/BaseComponent.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/BaseComponent.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.v2;
+
+import org.apache.pinot.thirdeye.spi.detection.spec.AbstractSpec;
+
+public interface BaseComponent<T extends AbstractSpec> {
+
+  void init(T spec);
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/Operator.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/Operator.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 public interface Operator<T extends DetectionPipelineResult> {
 
+  void init(OperatorContext context);
+
   void execute()
       throws Exception;
 

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/OperatorContext.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/OperatorContext.java
@@ -1,0 +1,48 @@
+package org.apache.pinot.thirdeye.detection.v2;
+
+import java.util.Map;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+
+public class OperatorContext {
+
+  private long startTime;
+  private long endTime;
+  private DetectionPlanApi detectionPlanApi;
+  private Map<String, Object> properties;
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public OperatorContext setStartTime(final long startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public long getEndTime() {
+    return endTime;
+  }
+
+  public OperatorContext setEndTime(final long endTime) {
+    this.endTime = endTime;
+    return this;
+  }
+
+  public DetectionPlanApi getDetectionPlanApi() {
+    return detectionPlanApi;
+  }
+
+  public OperatorContext setDetectionPlanApi(final DetectionPlanApi detectionPlanApi) {
+    this.detectionPlanApi = detectionPlanApi;
+    return this;
+  }
+
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+
+  public OperatorContext setProperties(final Map<String, Object> properties) {
+    this.properties = properties;
+    return this;
+  }
+}

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNode.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNode.java
@@ -8,6 +8,14 @@ import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi.InputApi;
  * The <code>PlanNode</code> is a single execution plan node inside the Plan tree.
  */
 public interface PlanNode {
+
+  /**
+   * Initialize PlanNode with Context.
+   *
+   * @param planNodeContext
+   */
+  void init(PlanNodeContext planNodeContext);
+
   /**
    *
    * @return unique PlanNode name

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNodeContext.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/detection/v2/PlanNodeContext.java
@@ -1,0 +1,68 @@
+package org.apache.pinot.thirdeye.detection.v2;
+
+import java.util.Map;
+import org.apache.pinot.thirdeye.api.v2.DetectionPlanApi;
+
+public class PlanNodeContext {
+
+  private String name;
+  private Map<String, PlanNode> pipelinePlanNodes;
+  private DetectionPlanApi detectionPlanApi;
+  private long startTime;
+  private long endTime;
+  private Map<String, Object> properties;
+
+  public String getName() {
+    return name;
+  }
+
+  public PlanNodeContext setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public Map<String, PlanNode> getPipelinePlanNodes() {
+    return pipelinePlanNodes;
+  }
+
+  public PlanNodeContext setPipelinePlanNodes(final Map<String, PlanNode> pipelinePlanNodes) {
+    this.pipelinePlanNodes = pipelinePlanNodes;
+    return this;
+  }
+
+  public DetectionPlanApi getDetectionPlanApi() {
+    return detectionPlanApi;
+  }
+
+  public PlanNodeContext setDetectionPlanApi(final DetectionPlanApi detectionPlanApi) {
+    this.detectionPlanApi = detectionPlanApi;
+    return this;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public PlanNodeContext setStartTime(final long startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public long getEndTime() {
+    return endTime;
+  }
+
+  public PlanNodeContext setEndTime(final long endTime) {
+    this.endTime = endTime;
+    return this;
+  }
+
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+
+  public PlanNodeContext setProperties(final Map<String, Object> properties) {
+    this.properties = properties;
+    return this;
+  }
+}

--- a/thirdeye-spi/src/test/resources/alertEvaluation.json
+++ b/thirdeye-spi/src/test/resources/alertEvaluation.json
@@ -44,13 +44,12 @@
       "planNodeName": "baselineDataFetcher",
       "type": "DataFetcher",
       "params": {
-        "dataSource": "${dataSourceName}",
+        "component.pinot.className": "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.PinotDataFetcher",
+        "component.pinot.dataSource": "${dataSourceName}",
+        "component.pinot.query": "SELECT \"date\" as ${timestamp}, count(*) as ${metricName} FROM ${table} WHERE \"date\" >= ${baseline_start} AND \"date\" < ${baseline_end} GROUP BY \"date\" LIMIT 100",
+        "component.pinot.tableName": "${table}",
         "startTime": "${baseline_start}",
-        "endTime": "${baseline_end}",
-        "pinot.zookeeper": "localhost:2123/QuickStartCluster",
-        "dataSource": "pinot",
-        "table": "${table}",
-        "query": "SELECT \"date\" as ${timestamp}, count(*) as ${metricName} FROM ${table} WHERE \"date\" >= ${baseline_start} AND \"date\" < ${baseline_end} GROUP BY \"date\" LIMIT 100"
+        "endTime": "${baseline_end}"
       },
       "inputs": [],
       "outputs": [
@@ -64,12 +63,12 @@
       "planNodeName": "currentDataFetcher",
       "type": "DataFetcher",
       "params": {
-        "dataSource": "${dataSourceName}",
+        "component.pinot.className": "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.PinotDataFetcher",
+        "component.pinot.dataSource": "${dataSourceName}",
+        "component.pinot.query": "SELECT \"date\" as ${timestamp}, count(*) as ${metricName} FROM ${table} WHERE \"date\" >= ${current_start} AND \"date\" < ${current_end} GROUP BY \"date\" LIMIT 100",
+        "component.pinot.tableName": "${table}",
         "startTime": "${start}",
-        "endTime": "${end}",
-        "dataSource": "pinot",
-        "table": "${table}",
-        "query": "SELECT \"date\" as ${timestamp}, count(*) as ${metricName} FROM ${table} WHERE \"date\" >= ${current_start} AND \"date\" < ${current_end} GROUP BY \"date\" LIMIT 100"
+        "endTime": "${end}"
       },
       "inputs": [],
       "outputs": [


### PR DESCRIPTION
We only have one implementation for DataFetcherPlanNode and DataFetcherOperator.
The DataFetcherOperator will use components for different types of data sources, e.g. Pinot.
- Add BaseComponent interface
- Make `DetectionPipelinePlanNodeFactory` a singleton and inject DataSourceCache
- Init DataFetcher with DataSourceCache 