### PR TITLE
[v2] [detector] Adding detector plan and operator

### DIFF
--- a/config/data-sources/pinot-quickstart-data-sources-config.yml
+++ b/config/data-sources/pinot-quickstart-data-sources-config.yml
@@ -1,0 +1,12 @@
+# Please put the mock data source as the first in this configuration.
+dataSourceConfigs:
+  - className: org.apache.pinot.thirdeye.datasource.pinot.PinotThirdEyeDataSource
+    properties:
+      zookeeperUrl: localhost:2123
+      clusterName: 'QuickStartCluster'
+      controllerConnectionScheme: 'http'
+      controllerHost: localhost
+      controllerPort: 9000
+      cacheLoaderClassName: org.apache.pinot.thirdeye.datasource.pinot.PinotControllerResponseCacheLoader
+    metadataSourceConfigs:
+      - className: org.apache.pinot.thirdeye.auto.onboard.AutoOnboardPinotMetadataSource

--- a/thirdeye-core/pom.xml
+++ b/thirdeye-core/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-core</artifactId>
       <exclusions>
@@ -138,12 +142,6 @@
     <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/detector/PercentageChangeRuleDetector.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/detector/PercentageChangeRuleDetector.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.v2.components.detector;
+
+import static org.apache.pinot.thirdeye.spi.dataframe.DoubleSeries.POSITIVE_INFINITY;
+import static org.apache.pinot.thirdeye.spi.dataframe.Series.DoubleFunction;
+import static org.apache.pinot.thirdeye.spi.dataframe.Series.map;
+
+import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.thirdeye.dashboard.resources.v2.BaselineParsingUtils;
+import org.apache.pinot.thirdeye.detection.DetectionUtils;
+import org.apache.pinot.thirdeye.detection.Pattern;
+import org.apache.pinot.thirdeye.detection.spi.model.TimeSeries;
+import org.apache.pinot.thirdeye.detection.v2.results.DataTableUtils;
+import org.apache.pinot.thirdeye.detection.v2.results.DetectionResult;
+import org.apache.pinot.thirdeye.detection.v2.results.DimensionInfo;
+import org.apache.pinot.thirdeye.detection.v2.results.GroupedDetectionResults;
+import org.apache.pinot.thirdeye.detection.v2.spec.PercentageChangeRuleDetectorSpec;
+import org.apache.pinot.thirdeye.spi.common.time.TimeGranularity;
+import org.apache.pinot.thirdeye.spi.dataframe.BooleanSeries;
+import org.apache.pinot.thirdeye.spi.dataframe.DataFrame;
+import org.apache.pinot.thirdeye.spi.dataframe.DoubleSeries;
+import org.apache.pinot.thirdeye.spi.dataframe.util.MetricSlice;
+import org.apache.pinot.thirdeye.spi.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.spi.detection.annotation.Components;
+import org.apache.pinot.thirdeye.spi.detection.annotation.DetectionTag;
+import org.apache.pinot.thirdeye.spi.detection.annotation.Param;
+import org.apache.pinot.thirdeye.spi.detection.annotation.PresentationOption;
+import org.apache.pinot.thirdeye.spi.detection.spi.exception.DetectorException;
+import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.v2.DetectionPipelineResult;
+import org.apache.pinot.thirdeye.spi.detection.v2.components.detector.AnomalyDetector;
+import org.joda.time.Interval;
+
+@Components(title = "Percentage change rule detection", type = "PERCENTAGE_RULE", tags = {
+    DetectionTag.RULE_DETECTION}, description =
+    "Computes a multi-week aggregate baseline and compares the current value "
+        + "based on relative change.", presentation = {
+    @PresentationOption(name = "percentage change", template = "comparing ${offset} is ${pattern} more than ${percentageChange}")}, params = {
+    @Param(name = "offset", defaultValue = "wo1w"),
+    @Param(name = "percentageChange", placeholder = "value"),
+    @Param(name = "pattern", allowableValues = {"up", "down"})})
+public class PercentageChangeRuleDetector implements
+    AnomalyDetector<PercentageChangeRuleDetectorSpec> {
+
+  private static final String COL_CURR = "current";
+  private static final String COL_CHANGE = "change";
+  private static final String COL_ANOMALY = "anomaly";
+  private static final String COL_PATTERN = "pattern";
+  private static final String COL_CHANGE_VIOLATION = "change_violation";
+  private double percentageChange;
+  private Pattern pattern;
+  private String monitoringGranularity;
+  private TimeGranularity timeGranularity;
+  private DayOfWeek weekStart;
+  private String timestamp = "timestamp";
+  private String metric = "value";
+  private List<String> dimensions = Collections.emptyList();
+
+  @Override
+  public void init(PercentageChangeRuleDetectorSpec spec) {
+    this.percentageChange = spec.getPercentageChange();
+    String timezone = spec.getTimezone();
+    String offset = spec.getOffset();
+    this.timestamp = spec.getTimestamp();
+    this.metric = spec.getMetric();
+    this.dimensions = spec.getDimensions();
+
+    BaselineParsingUtils.parseOffset(offset, timezone);
+    this.pattern = Pattern.valueOf(spec.getPattern().toUpperCase());
+
+    this.monitoringGranularity = spec.getMonitoringGranularity();
+    if (this.monitoringGranularity.endsWith(TimeGranularity.MONTHS) || this.monitoringGranularity
+        .endsWith(TimeGranularity.WEEKS)) {
+      this.timeGranularity = MetricSlice.NATIVE_GRANULARITY;
+    } else {
+      this.timeGranularity = TimeGranularity.fromString(spec.getMonitoringGranularity());
+    }
+    if (this.monitoringGranularity.endsWith(TimeGranularity.WEEKS)) {
+      this.weekStart = DayOfWeek.valueOf(spec.getWeekStart());
+    }
+  }
+
+  @Override
+  public DetectionPipelineResult runDetection(Interval window, DataTable baseline,
+      DataTable current)
+      throws DetectorException {
+    final Map<DimensionInfo, DataTable> baselineDataTableMap = DataTableUtils.splitDataTable(
+        baseline);
+    final Map<DimensionInfo, DataTable> currentDataTableMap = DataTableUtils.splitDataTable(
+        current);
+    List<DetectionResult> detectionResults = new ArrayList<>();
+    for (DimensionInfo dimensionInfo : baselineDataTableMap.keySet()) {
+      final DetectionResult detectionResult = runDetectionOnSingleDataTable(window,
+          baselineDataTableMap.get(dimensionInfo),
+          currentDataTableMap.get(dimensionInfo));
+      detectionResults.add(detectionResult);
+    }
+    return new GroupedDetectionResults(detectionResults);
+  }
+
+  private DetectionResult runDetectionOnSingleDataTable(final Interval window,
+      final DataTable baseline, final DataTable current) {
+    final DataFrame currentDf = current.getDataFrame();
+    final DataFrame baselineDf = baseline.getDataFrame();
+    DataFrame df = new DataFrame();
+    df.addSeries(DataFrame.COL_TIME, currentDf.get(this.timestamp));
+    df.addSeries(DataFrame.COL_CURRENT, currentDf.get(this.metric));
+    df.addSeries(DataFrame.COL_VALUE, baselineDf.get(this.metric));
+    // calculate percentage change
+    df.addSeries(COL_CHANGE, map((DoubleFunction) values -> {
+      if (Double.compare(values[1], 0.0) == 0) {
+        return Double.compare(values[0], 0.0) == 0 ? 0.0
+            : (values[0] > 0 ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY);
+      }
+      return (values[0] - values[1]) / values[1];
+    }, df.getDoubles(DataFrame.COL_CURRENT), df.get(DataFrame.COL_VALUE)));
+
+    // defaults
+    df.addSeries(COL_ANOMALY, BooleanSeries.fillValues(df.size(), false));
+
+    // relative change
+    if (!Double.isNaN(this.percentageChange)) {
+      // consistent with pattern
+      if (pattern.equals(Pattern.UP_OR_DOWN)) {
+        df.addSeries(COL_PATTERN, BooleanSeries.fillValues(df.size(), true));
+      } else {
+        df.addSeries(COL_PATTERN,
+            this.pattern.equals(Pattern.UP) ? df.getDoubles(COL_CHANGE).gt(0)
+                : df.getDoubles(COL_CHANGE).lt(0));
+      }
+      df.addSeries(COL_CHANGE_VIOLATION,
+          df.getDoubles(COL_CHANGE).abs().gte(this.percentageChange));
+      df.mapInPlace(BooleanSeries.ALL_TRUE, COL_ANOMALY, COL_PATTERN, COL_CHANGE_VIOLATION);
+    }
+
+    MetricSlice slice = MetricSlice
+        .from(-1, window.getStartMillis(), window.getEndMillis(), null,
+            timeGranularity);
+
+    List<MergedAnomalyResultDTO> anomalies = DetectionUtils.makeAnomalies(slice, df, COL_ANOMALY);
+    DataFrame baselineWithBoundaries = constructPercentageChangeBoundaries(df);
+    return DetectionResult.from(anomalies, TimeSeries.fromDataFrame(baselineWithBoundaries));
+  }
+
+  private DataFrame constructPercentageChangeBoundaries(DataFrame dfBase) {
+    if (!Double.isNaN(this.percentageChange)) {
+      switch (this.pattern) {
+        case UP:
+          fillPercentageChangeBound(dfBase, DataFrame.COL_UPPER_BOUND, 1 + this.percentageChange);
+          dfBase.addSeries(DataFrame.COL_LOWER_BOUND, DoubleSeries.zeros(dfBase.size()));
+          break;
+        case DOWN:
+          dfBase.addSeries(
+              DataFrame.COL_UPPER_BOUND, DoubleSeries.fillValues(dfBase.size(), POSITIVE_INFINITY));
+          fillPercentageChangeBound(dfBase, DataFrame.COL_LOWER_BOUND, 1 - this.percentageChange);
+          break;
+        case UP_OR_DOWN:
+          fillPercentageChangeBound(dfBase, DataFrame.COL_UPPER_BOUND, 1 + this.percentageChange);
+          fillPercentageChangeBound(dfBase, DataFrame.COL_LOWER_BOUND, 1 - this.percentageChange);
+          break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    }
+    return dfBase;
+  }
+
+  private void fillPercentageChangeBound(DataFrame dfBase, String colBound, double multiplier) {
+    dfBase.addSeries(colBound,
+        map((DoubleFunction) values -> values[0] * multiplier, dfBase.getDoubles(
+            DataFrame.COL_VALUE)));
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/AnomalyDetectorOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/AnomalyDetectorOperator.java
@@ -1,0 +1,53 @@
+package org.apache.pinot.thirdeye.detection.v2.operator;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.thirdeye.detection.v2.results.GroupedDetectionResults;
+import org.apache.pinot.thirdeye.spi.detection.v2.BaseComponent;
+import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.spi.detection.v2.components.detector.AnomalyDetector;
+import org.joda.time.Interval;
+
+public class AnomalyDetectorOperator extends DetectionPipelineOperator<DataTable> {
+
+  private static String DEFAULT_OUTPUT_KEY = "AnomalyDetectorResult";
+  private static String CURRENT_KEY = "current";
+  private static String BASELINE_KEY = "baseline";
+
+  public AnomalyDetectorOperator() {
+    super();
+  }
+
+  @Override
+  public void init(final OperatorContext context) {
+    super.init(context);
+  }
+
+  @Override
+  public void execute() throws Exception {
+    // The last exception of the detection windows. It will be thrown out to upper level.
+    for (Object key : this.getComponents().keySet()) {
+      final BaseComponent component = this.getComponents().get(key);
+      if (component instanceof AnomalyDetector) {
+        for (Interval interval : getMonitoringWindows()) {
+          final GroupedDetectionResults detectionResult = (GroupedDetectionResults) ((AnomalyDetector) component)
+              .runDetection(interval,
+                  (DataTable) inputMap.get(BASELINE_KEY),
+                  (DataTable) inputMap.get(CURRENT_KEY));
+          String outputKey = key + "_" + DEFAULT_OUTPUT_KEY;
+          setOutput(outputKey, detectionResult);
+        }
+      }
+    }
+  }
+
+  private List<Interval> getMonitoringWindows() {
+    return Collections.singletonList(new Interval(startTime, endTime));
+  }
+
+  @Override
+  public String getOperatorName() {
+    return "AnomalyDetectorOperator";
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.thirdeye.detection.DetectionUtils;
 import org.apache.pinot.thirdeye.spi.api.v2.DetectionPlanApi;
 import org.apache.pinot.thirdeye.spi.api.v2.DetectionPlanApi.OutputApi;

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/AnomalyDetectorPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/AnomalyDetectorPlanNode.java
@@ -1,0 +1,81 @@
+package org.apache.pinot.thirdeye.detection.v2.plan;
+
+import java.util.Map;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.pinot.thirdeye.detection.DetectionUtils;
+import org.apache.pinot.thirdeye.detection.v2.operator.AnomalyDetectorOperator;
+import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.v2.Operator;
+import org.apache.pinot.thirdeye.spi.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.spi.detection.v2.PlanNodeContext;
+
+public class AnomalyDetectorPlanNode extends DetectionPipelinePlanNode {
+
+  private static final String PROP_DETECTOR = "detector";
+  private static final String PROP_METRIC_URN = "metricUrn";
+
+  public AnomalyDetectorPlanNode() {
+    super();
+  }
+
+  @Override
+  public void init(final PlanNodeContext planNodeContext) {
+    super.init(planNodeContext);
+  }
+
+  @Override
+  void setNestedProperties(final Map<String, Object> properties) {
+    // inject detector to nested property if possible
+    String detectorComponentRefKey = MapUtils.getString(detectionPlanApi.getParams(),
+        PROP_DETECTOR);
+    if (detectorComponentRefKey != null) {
+      String detectorComponentName = DetectionUtils.getComponentKey(detectorComponentRefKey);
+      properties.put(PROP_DETECTOR, detectorComponentRefKey);
+    }
+
+    // inject metricUrn to nested property if possible
+    String nestedUrn = MapUtils.getString(detectionPlanApi.getParams(), PROP_METRIC_URN);
+    if (nestedUrn != null) {
+      properties.put(PROP_METRIC_URN, nestedUrn);
+    }
+  }
+
+  @Override
+  public String getType() {
+    return "AnomalyDetector";
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Map<String, Object> getParams() {
+    return detectionPlanApi.getParams();
+  }
+
+  @Override
+  public Operator<DataTable> run() throws Exception {
+    long startTime;
+    try {
+      startTime = Long.parseLong(getParams().get("startTime").toString());
+    } catch (Exception e) {
+      startTime = this.startTime;
+    }
+    long endTime;
+    try {
+      endTime = Long.parseLong(getParams().get("endTime").toString());
+    } catch (Exception e) {
+      endTime = this.endTime;
+    }
+    final AnomalyDetectorOperator anomalyDetectorOperator = new AnomalyDetectorOperator();
+    anomalyDetectorOperator.init(new OperatorContext()
+        .setStartTime(startTime)
+        .setEndTime(endTime)
+        .setInputsMap(inputsMap)
+        .setDetectionPlanApi(detectionPlanApi)
+    );
+    return anomalyDetectorOperator;
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DataTableUtils.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DataTableUtils.java
@@ -1,0 +1,76 @@
+package org.apache.pinot.thirdeye.detection.v2.results;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType;
+import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.v2.SimpleDataTable.SimpleDataTableBuilder;
+
+public class DataTableUtils {
+
+  private static final String DIMENSION_NAMES = "dimension_names";
+  private static final String DIMENSION_VALUES = "dimension_values";
+
+  public static Map<DimensionInfo, DataTable> splitDataTable(DataTable dataTable) {
+    Map<DimensionInfo, SimpleDataTableBuilder> splitDataTableBuilder = new HashMap<>();
+    int dimensionNamesIndex = dataTable.getColumns().indexOf(DIMENSION_NAMES);
+    int dimensionValuesIndex = dataTable.getColumns().indexOf(DIMENSION_VALUES);
+    if (dimensionNamesIndex >= 0 && dimensionValuesIndex >= 0) {
+      for (int row = 0; row < dataTable.getRowCount(); row++) {
+        String dimNames = dataTable.getString(row, dimensionNamesIndex);
+        String dimValues = dataTable.getString(row, dimensionValuesIndex);
+
+        DimensionInfo dimensionInfo = new DimensionInfo(Arrays.asList(dimNames.split(",")),
+            Arrays.asList(dimValues.split(",")));
+
+        if (!splitDataTableBuilder.containsKey(dimensionInfo)) {
+          splitDataTableBuilder.put(dimensionInfo, createDimensionDataTableBuilder(dataTable));
+        }
+        final SimpleDataTableBuilder dataTableBuilder = splitDataTableBuilder.get(dimensionInfo);
+        final Object[] objects = dataTableBuilder.newRow();
+        for (int columnIdx = 0; columnIdx < objects.length; columnIdx++) {
+          final String columnName = dataTableBuilder.getColumns().get(columnIdx);
+          final int newColIdx = dataTable.getColumns().indexOf(columnName);
+          switch (dataTableBuilder.getColumnTypes().get(columnIdx).getType()) {
+            case "LONG":
+              objects[columnIdx] = dataTable.getLong(row, newColIdx);
+              break;
+            case "DOUBLE":
+              objects[columnIdx] = dataTable.getDouble(row, newColIdx);
+              break;
+            default:
+              objects[columnIdx] = dataTable.getString(row, newColIdx);
+              break;
+          }
+        }
+      }
+      Map<DimensionInfo, DataTable> splitDataTable = new HashMap<>();
+      for (DimensionInfo info : splitDataTableBuilder.keySet()) {
+        splitDataTable.put(info, splitDataTableBuilder.get(info).build());
+      }
+      return splitDataTable;
+    } else {
+      return ImmutableMap.of(new DimensionInfo(new ArrayList<>(), new ArrayList<>()), dataTable);
+    }
+  }
+
+  private static SimpleDataTableBuilder createDimensionDataTableBuilder(
+      final DataTable dataTable) {
+    List<String> newColumns = new ArrayList<>();
+    List<ColumnType> newColumnTypes = new ArrayList<>();
+    for (int i = 0; i < dataTable.getColumns().size(); i++) {
+      final String columnName = dataTable.getColumns().get(i);
+      final ColumnType columnType = dataTable.getColumnTypes().get(i);
+      if (DIMENSION_NAMES.equals(columnName) || DIMENSION_VALUES.equals(columnName)) {
+        continue;
+      }
+      newColumns.add(columnName);
+      newColumnTypes.add(columnType);
+    }
+    return new SimpleDataTableBuilder(newColumns, newColumnTypes);
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DetectionResult.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DetectionResult.java
@@ -1,0 +1,104 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ *
+ */
+package org.apache.pinot.thirdeye.detection.v2.results;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import org.apache.pinot.thirdeye.detection.spi.model.TimeSeries;
+import org.apache.pinot.thirdeye.spi.api.AnomalyApi;
+import org.apache.pinot.thirdeye.spi.api.DetectionEvaluationApi;
+import org.apache.pinot.thirdeye.spi.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.spi.detection.v2.DetectionPipelineResult;
+import org.apache.pinot.thirdeye.spi.util.ApiBeanMapper;
+
+/**
+ * The detection result. Contains a list of anomalies detected and time series
+ * (which can include time stamps, predicted baseline, current value, upper/lower bounds)
+ */
+public class DetectionResult implements DetectionPipelineResult {
+
+  private final List<MergedAnomalyResultDTO> anomalies;
+  private final TimeSeries timeseries;
+
+  private DetectionResult(List<MergedAnomalyResultDTO> anomalies, TimeSeries timeseries) {
+    this.anomalies = anomalies;
+    this.timeseries = timeseries;
+  }
+
+  /**
+   * Create a empty detection result
+   *
+   * @return the empty detection result
+   */
+  public static DetectionResult empty() {
+    return new DetectionResult(Collections.emptyList(), TimeSeries.empty());
+  }
+
+  /**
+   * Create a detection result from a list of anomalies
+   *
+   * @param anomalies the list of anomalies generated
+   * @return the detection result contains the list of anomalies
+   */
+  public static DetectionResult from(List<MergedAnomalyResultDTO> anomalies) {
+    return new DetectionResult(anomalies, TimeSeries.empty());
+  }
+
+  /**
+   * Create a detection result from a list of anomalies and time series
+   *
+   * @param anomalies the list of anomalies generated
+   * @param timeSeries the time series which including the current, predicted baseline and
+   *     optionally upper and lower bounds
+   * @return the detection result contains the list of anomalies and the time series
+   */
+  public static DetectionResult from(List<MergedAnomalyResultDTO> anomalies,
+      TimeSeries timeSeries) {
+    return new DetectionResult(anomalies, timeSeries);
+  }
+
+  public List<MergedAnomalyResultDTO> getAnomalies() {
+    return anomalies;
+  }
+
+  public TimeSeries getTimeseries() {
+    return timeseries;
+  }
+
+  @Override
+  public String toString() {
+    return "DetectionResult{" + "anomalies=" + anomalies + ", timeseries=" + timeseries + '}';
+  }
+
+  public DetectionEvaluationApi toApi() {
+    DetectionEvaluationApi api = new DetectionEvaluationApi();
+    final List<AnomalyApi> anomalyApis = new ArrayList<>();
+    for (MergedAnomalyResultDTO anomalyDto : this.anomalies) {
+      anomalyApis.add(ApiBeanMapper.toApi(anomalyDto));
+    }
+    api.setAnomalies(anomalyApis);
+    return api;
+  }
+
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DimensionInfo.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/DimensionInfo.java
@@ -1,0 +1,45 @@
+package org.apache.pinot.thirdeye.detection.v2.results;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class DimensionInfo {
+
+  private List<String> dimensionColumns;
+  private List<Object> dimensionValues;
+
+  public DimensionInfo(final List<String> dimensionColumns,
+      final List<Object> dimensionValues) {
+    this.dimensionColumns = dimensionColumns;
+    this.dimensionValues = dimensionValues;
+  }
+
+  public List<String> getDimensionColumns() {
+    return dimensionColumns;
+  }
+
+  public List<Object> getDimensionValues() {
+    return dimensionValues;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DimensionInfo that = (DimensionInfo) o;
+    return Arrays.toString(dimensionColumns.toArray())
+        .equals(Arrays.toString(that.dimensionColumns.toArray()))
+        && Arrays.toString(dimensionValues.toArray())
+        .equals(Arrays.toString(that.dimensionValues.toArray()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dimensionColumns, dimensionValues);
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/GroupedDetectionResults.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/results/GroupedDetectionResults.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ *
+ */
+package org.apache.pinot.thirdeye.detection.v2.results;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.thirdeye.spi.detection.v2.DetectionPipelineResult;
+
+/**
+ * The detection result. Contains a list of DetectionResult.
+ */
+public class GroupedDetectionResults implements DetectionPipelineResult {
+
+  private final List<DetectionResult> detectionResults;
+
+  public GroupedDetectionResults(List<DetectionResult> detectionResults) {
+    this.detectionResults = detectionResults;
+  }
+
+  /**
+   * Create a empty detection result
+   *
+   * @return the empty detection result
+   */
+  public static GroupedDetectionResults empty() {
+    return new GroupedDetectionResults(Collections.emptyList());
+  }
+
+  /**
+   * Create a detection result from a list of DetectionResult
+   *
+   * @param detectionResults the list of DetectionResult generated
+   * @return the detection result contains the list of DetectionResult
+   */
+  public static GroupedDetectionResults from(List<DetectionResult> detectionResults) {
+    return new GroupedDetectionResults(detectionResults);
+  }
+
+  public List<DetectionResult> getDetectionResults() {
+    return detectionResults;
+  }
+
+  @Override
+  public String toString() {
+    return "DetectionResult{" + "detectionResults=" + detectionResults + '}';
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/spec/PercentageChangeRuleDetectorSpec.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/spec/PercentageChangeRuleDetectorSpec.java
@@ -1,0 +1,95 @@
+package org.apache.pinot.thirdeye.detection.v2.spec;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.thirdeye.spi.dataframe.util.MetricSlice;
+import org.apache.pinot.thirdeye.spi.detection.spec.AbstractSpec;
+
+public class PercentageChangeRuleDetectorSpec extends AbstractSpec {
+
+  private double percentageChange = Double.NaN;
+  private String offset = "wo1w";
+  private String timezone = DEFAULT_TIMEZONE;
+  private String pattern = "UP_OR_DOWN";
+  private String weekStart = "WEDNESDAY";
+  private String timestamp = "timestamp";
+  private String metric = "value";
+  private List<String> dimensions = Collections.emptyList();
+  private String monitoringGranularity = MetricSlice.NATIVE_GRANULARITY
+      .toAggregationGranularityString(); // use native granularity by default
+
+  public String getMonitoringGranularity() {
+    return monitoringGranularity;
+  }
+
+  public void setMonitoringGranularity(String monitoringGranularity) {
+    this.monitoringGranularity = monitoringGranularity;
+  }
+
+  public String getPattern() {
+    return pattern;
+  }
+
+  public void setPattern(String pattern) {
+    this.pattern = pattern;
+  }
+
+  public String getTimezone() {
+    return timezone;
+  }
+
+  public void setTimezone(String timezone) {
+    this.timezone = timezone;
+  }
+
+  public String getOffset() {
+    return offset;
+  }
+
+  public void setOffset(String offset) {
+    this.offset = offset;
+  }
+
+  public double getPercentageChange() {
+    return percentageChange;
+  }
+
+  public void setPercentageChange(double percentageChange) {
+    this.percentageChange = percentageChange;
+  }
+
+  public String getWeekStart() {
+    return weekStart;
+  }
+
+  public void setWeekStart(String weekStart) {
+    this.weekStart = weekStart;
+  }
+
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  public PercentageChangeRuleDetectorSpec setTimestamp(final String timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  public String getMetric() {
+    return metric;
+  }
+
+  public PercentageChangeRuleDetectorSpec setMetric(final String metric) {
+    this.metric = metric;
+    return this;
+  }
+
+  public List<String> getDimensions() {
+    return dimensions;
+  }
+
+  public PercentageChangeRuleDetectorSpec setDimensions(final List<String> dimensions) {
+    this.dimensions = dimensions;
+    return this;
+  }
+}

--- a/thirdeye-integration-tests/pom.xml
+++ b/thirdeye-integration-tests/pom.xml
@@ -43,7 +43,6 @@
     <dependency>
       <groupId>org.apache.pinot.thirdeye</groupId>
       <artifactId>thirdeye-datasources</artifactId>
-      <scope>compile</scope>
     </dependency>
 
     <!-- test dependencies -->

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/detection/v2/components/detector/AnomalyDetector.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/detection/v2/components/detector/AnomalyDetector.java
@@ -1,0 +1,20 @@
+package org.apache.pinot.thirdeye.spi.detection.v2.components.detector;
+
+import org.apache.pinot.thirdeye.spi.detection.spec.AbstractSpec;
+import org.apache.pinot.thirdeye.spi.detection.spi.exception.DetectorException;
+import org.apache.pinot.thirdeye.spi.detection.v2.BaseComponent;
+import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.v2.DetectionPipelineResult;
+import org.joda.time.Interval;
+
+public interface AnomalyDetector<T extends AbstractSpec> extends BaseComponent<T> {
+
+  /**
+   * Run detection for a given interval with provided baseline and current DataTable. Then returns
+   * the detection result.
+   *
+   * @return the detection result which contains anomalies.
+   */
+  DetectionPipelineResult runDetection(Interval interval, DataTable baseline, DataTable current)
+      throws DetectorException;
+}


### PR DESCRIPTION
Sample plan:
```
{
  "alert": {
    "name": "percentage-change-template",
    "description": "Percentage drop template",
    "cron": "0 0/1 * 1/1 * ? *"
  },
  "nodes": [
    {
      "planNodeName": "root",
      "type": "AnomalyDetector",
      "params": {
        "component.detector.className": "org.apache.pinot.thirdeye.detection.v2.components.detector.PercentageChangeRuleDetector",
        "component.detector.percentageChange": "0.1",
        "component.detector.offset": "mo1m",
        "component.detector.pattern": "down",
        "component.detector.timestamp": "ts",
        "component.detector.metric": "met",
        "component.detector.dimensions": [],
        "startTime": "20200202",
        "endTime": "20200214"
      },
      "inputs": [
        {
          "targetProperty": "baseline",
          "sourcePlanNode": "baselineDataFetcher",
          "sourceProperty": "baselineOutput"
        },
        {
          "targetProperty": "current",
          "sourcePlanNode": "currentDataFetcher",
          "sourceProperty": "currentOutput"
        }
      ],
      "outputs": []
    },
    {
      "planNodeName": "baselineDataFetcher",
      "type": "DataFetcher",
      "params": {
        "component.pinot.className": "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.GenericDataFetcher",
        "component.pinot.dataSource": "PinotThirdEyeDataSource",
        "component.pinot.query": "SELECT \"date\" as ts, sum(views) as met FROM pageviews WHERE \"date\" >= 20200202 AND \"date\" < 20200214 GROUP BY \"date\" ORDER BY \"date\" LIMIT 100",
        "component.pinot.tableName": "pageviews",
        "startTime": "20200202",
        "endTime": "20200214"
      },
      "inputs": [],
      "outputs": [
        {
          "outputKey": "pinot",
          "outputName": "baselineOutput"
        }
      ]
    },
    {
      "planNodeName": "currentDataFetcher",
      "type": "DataFetcher",
      "params": {
        "component.pinot.className": "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.GenericDataFetcher",
        "component.pinot.dataSource": "PinotThirdEyeDataSource",
        "component.pinot.query": "SELECT \"date\" as ts, sum(views) as met FROM pageviews WHERE \"date\" >= 20200302 AND \"date\" < 20200314 GROUP BY \"date\" ORDER BY \"date\" LIMIT 100",
        "component.pinot.tableName": "pageviews",
        "startTime": "20200202",
        "endTime": "20200214"
      },
      "inputs": [],
      "outputs": [
        {
          "outputKey": "pinot",
          "outputName": "currentOutput"
        }
      ]
    }
  ],
  "start": "1621300000000",
  "end": "1621200000000"
}

```
Sample output:
```
{
  "detector_AnomalyDetectorResult": {
    "0": {
      "anomalies": [
        {
          "startTime": 20200304,
          "endTime": 20200305,
          "avgCurrentVal": 0,
          "avgBaselineVal": 0,
          "score": 0,
          "weight": 0,
          "impactToGlobal": 0,
          "sourceType": "DEFAULT_ANOMALY_DETECTION",
          "created": 1622888279360,
          "notified": false,
          "alert": {}
        },
        {
          "startTime": 20200307,
          "endTime": 20200309,
          "avgCurrentVal": 0,
          "avgBaselineVal": 0,
          "score": 0,
          "weight": 0,
          "impactToGlobal": 0,
          "sourceType": "DEFAULT_ANOMALY_DETECTION",
          "created": 1622888279361,
          "notified": false,
          "alert": {}
        },
        {
          "startTime": 20200311,
          "endTime": 20200312,
          "avgCurrentVal": 0,
          "avgBaselineVal": 0,
          "score": 0,
          "weight": 0,
          "impactToGlobal": 0,
          "sourceType": "DEFAULT_ANOMALY_DETECTION",
          "created": 1622888279361,
          "notified": false,
          "alert": {}
        }
      ]
    }
  }
}
```