### PR TITLE
Make Pinot dataframe to use SQL syntax instead of PQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pinot.version>0.7.0</pinot.version>
+    <pinot.version>0.7.1</pinot.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>1.8</jdk.version>
     <javac.version>9+181-r4173-1</javac.version>

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/datafetcher/GenericDataFetcher.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/components/datafetcher/GenericDataFetcher.java
@@ -18,7 +18,7 @@ public class GenericDataFetcher implements DataFetcher<DataFetcherSpec> {
    */
   private String tableName;
 
-  private ThirdEyeDataSource pinotDataSource;
+  private ThirdEyeDataSource thirdEyeDataSource;
 
   public String getQuery() {
     return query;
@@ -43,13 +43,13 @@ public class GenericDataFetcher implements DataFetcher<DataFetcherSpec> {
     this.query = dataFetcherSpec.getQuery();
     this.tableName = dataFetcherSpec.getTableName();
     if (dataFetcherSpec.getDataSourceCache() != null) {
-      this.pinotDataSource = dataFetcherSpec.getDataSourceCache()
+      this.thirdEyeDataSource = dataFetcherSpec.getDataSourceCache()
           .getDataSource(dataFetcherSpec.getDataSource());
     }
   }
 
   @Override
   public DataTable getDataTable() throws Exception {
-    return pinotDataSource.fetchDataTable(new ThirdEyeRequestV2(tableName, query, ImmutableMap.of()));
+    return thirdEyeDataSource.fetchDataTable(new ThirdEyeRequestV2(tableName, query, ImmutableMap.of()));
   }
 }

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
@@ -67,8 +67,10 @@ public abstract class DetectionPipelineOperator<T extends DetectionPipelineResul
     this.resultMap = new HashMap<>();
     this.instancesMap = new HashMap<>();
     this.inputMap = context.getInputsMap();
-    for (OutputApi outputApi : context.getDetectionPlanApi().getOutputs()) {
-      outputKeyMap.put(outputApi.getOutputKey(), outputApi.getOutputName());
+    if (context.getDetectionPlanApi().getOutputs() != null) {
+      for (OutputApi outputApi : context.getDetectionPlanApi().getOutputs()) {
+        outputKeyMap.put(outputApi.getOutputKey(), outputApi.getOutputName());
+      }
     }
     this.initComponents();
   }

--- a/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
+++ b/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
@@ -49,6 +49,8 @@ public class PinotControllerResponseCacheLoader extends PinotResponseCacheLoader
 
   private static final long CONNECTION_TIMEOUT = 60000;
   private static final String BROKER_PREFIX = "Broker_";
+  private static final String SQL_QUERY_FORMAT = "sql";
+  private static final String PQL_QUERY_FORMAT = "pql";
   private static int MAX_CONNECTIONS;
 
   static {
@@ -149,10 +151,10 @@ public class PinotControllerResponseCacheLoader extends PinotResponseCacheLoader
       try {
         synchronized (connection) {
           int activeConnections = this.activeConnections.incrementAndGet();
-
           long start = System.currentTimeMillis();
+          final String queryFormat = pinotQuery.isUseSql() ? SQL_QUERY_FORMAT : PQL_QUERY_FORMAT;
           ResultSetGroup resultSetGroup = connection
-              .execute(pinotQuery.getTableName(), new Request("pql", pinotQuery.getQuery()));
+              .execute(pinotQuery.getTableName(), new Request(queryFormat, pinotQuery.getQuery()));
           long end = System.currentTimeMillis();
           LOG.info("Query:{}  took:{} ms  connections:{}", pinotQuery.getQuery(), (end - start),
               activeConnections);

--- a/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotQuery.java
+++ b/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotQuery.java
@@ -25,9 +25,16 @@ public class PinotQuery extends RelationalQuery {
 
   private String tableName;
 
+  private boolean useSql = false;
+
   public PinotQuery(String pql, String tableName) {
-    super(pql);
+    this(pql, tableName, false);
+  }
+
+  public PinotQuery(String query, String tableName, boolean useSql) {
+    super(query);
     this.tableName = tableName;
+    this.useSql = useSql;
   }
 
   // TODO: Remove thirdeye-external's dependency on this method to getQuery() instead
@@ -43,11 +50,16 @@ public class PinotQuery extends RelationalQuery {
     this.tableName = tableName;
   }
 
+  public boolean isUseSql() {
+    return useSql;
+  }
+
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("PinotQuery{");
-    sb.append("pql='").append(query).append('\'');
+    sb.append("query='").append(query).append('\'');
     sb.append(", tableName='").append(tableName).append('\'');
+    sb.append(", useSql='").append(useSql).append('\'');
     sb.append('}');
     return sb.toString();
   }

--- a/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -455,10 +455,11 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
   @Override
   public DataTable fetchDataTable(final ThirdEyeRequestV2 request) throws Exception {
     try {
-      // TODO: this resultSet is still using PQL, we should move to use pinot SQL.
+      // Use pinot SQL.
       ThirdEyeResultSet thirdEyeResultSet = executeSQL(new PinotQuery(
           request.getQuery(),
-          request.getTable())).get(0);
+          request.getTable(),
+          true)).get(0);
       return new ThirdeyeResultSetDataTable(thirdEyeResultSet);
     } catch (ExecutionException e) {
       throw e;

--- a/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdeyeResultSetDataTable.java
+++ b/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdeyeResultSetDataTable.java
@@ -24,7 +24,7 @@ public class ThirdeyeResultSetDataTable implements DataTable {
     }
     for (int i = 0; i < thirdEyeResultSet.getColumnCount(); i++) {
       columns.add(thirdEyeResultSet.getColumnName(i));
-      columnTypes.add(new ColumnType("STRING", false));
+      columnTypes.add(new ColumnType("DOUBLE", false));
     }
   }
 
@@ -101,7 +101,7 @@ public class ThirdeyeResultSetDataTable implements DataTable {
 
     for (int i = 0; i < getColumnCount(); i++) {
       if (i < groupKeyLength) {
-        columnNameWithDataType.add(getColumns().get(i) + ":STRING");
+        columnNameWithDataType.add(getColumns().get(i));
       } else {
         columnNameWithDataType.add(getColumns().get(i));
       }
@@ -114,12 +114,12 @@ public class ThirdeyeResultSetDataTable implements DataTable {
 
     outer:
     for (int rowIdx = 0; rowIdx < getRowCount(); rowIdx++) {
-      String[] columnsOfTheRow = new String[totalColumnCount];
+      Object[] columnsOfTheRow = new Object[totalColumnCount];
       // GroupBy column value(i.e., dimension values)
       for (int groupByColumnIdx = 1; groupByColumnIdx <= groupByColumnCount; groupByColumnIdx++) {
         String valueString = null;
         try {
-          valueString = thirdEyeResultSet.getString(rowIdx, groupByColumnIdx);
+          valueString = thirdEyeResultSet.getGroupKeyColumnValue(rowIdx, groupByColumnIdx - 1);
         } catch (Exception e) {
           // Do nothing and subsequently insert a null value to the current series.
         }
@@ -127,16 +127,16 @@ public class ThirdeyeResultSetDataTable implements DataTable {
       }
       // Metric column's value
       for (int metricColumnIdx = 1; metricColumnIdx <= metricColumnCount; metricColumnIdx++) {
-        String valueString = null;
+        Double metricVal = null;
         try {
-          valueString = thirdEyeResultSet.getString(rowIdx, groupByColumnCount + metricColumnIdx);
-          if (valueString == null) {
+          metricVal = thirdEyeResultSet.getDouble(rowIdx, metricColumnIdx - 1);
+          if (metricVal == null) {
             break outer;
           }
         } catch (Exception e) {
           // Do nothing and subsequently insert a null value to the current series.
         }
-        columnsOfTheRow[metricColumnIdx + groupByColumnCount - 1] = valueString;
+        columnsOfTheRow[metricColumnIdx + groupByColumnCount - 1] = metricVal;
       }
       dfBuilder.append(columnsOfTheRow);
     }

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/util/ApiBeanMapper.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/util/ApiBeanMapper.java
@@ -411,7 +411,7 @@ public abstract class ApiBeanMapper {
   }
 
   public static AnomalyApi toApi(final MergedAnomalyResultDTO dto) {
-    return new AnomalyApi()
+    AnomalyApi anomalyApi = new AnomalyApi()
         .setId(dto.getId())
         .setStartTime(new Date(dto.getStartTime()))
         .setEndTime(new Date(dto.getEndTime()))
@@ -423,27 +423,30 @@ public abstract class ApiBeanMapper {
         .setImpactToGlobal(dto.getImpactToGlobal())
         .setSourceType(dto.getAnomalyResultSource())
         .setNotified(dto.isNotified())
-        .setMessage(dto.getMessage())
-        .setMetric(toMetricApi(dto.getMetricUrn())
-            .setName(dto.getMetric())
-            .setDataset(new DatasetApi()
-                .setName(dto.getCollection())
-            )
-        )
-        .setAlert(new AlertApi()
-            .setId(dto.getDetectionConfigId())
-            .setName(optional(dto.getProperties())
-                .map(p -> p.get("subEntityName"))
-                .orElse(null))
-        )
+        .setMessage(dto.getMessage());
+    if (dto.getMetricUrn() != null) {
+      anomalyApi
+          .setMetric(toMetricApi(dto.getMetricUrn())
+              .setName(dto.getMetric())
+              .setDataset(new DatasetApi()
+                  .setName(dto.getCollection())
+              )
+          );
+    }
+    anomalyApi.setAlert(new AlertApi()
+        .setId(dto.getDetectionConfigId())
+        .setName(optional(dto.getProperties())
+            .map(p -> p.get("subEntityName"))
+            .orElse(null))
+    )
         .setAlertNode(optional(dto.getProperties())
             .map(p -> p.get("detectorComponentName"))
             .map(ApiBeanMapper::toDetectionAlertNodeApi)
             .orElse(null))
         .setFeedback(optional(dto.getFeedback())
             .map(ApiBeanMapper::toApi)
-            .orElse(null))
-        ;
+            .orElse(null));
+    return anomalyApi;
   }
 
   private static AnomalyFeedbackApi toApi(final AnomalyFeedback feedbackDto) {


### PR DESCRIPTION
For v2 implementation, we will directly go Pinot SQL query syntax, some good feature is that we can rely on Pinot to do data sorting.