### PR TITLE
Adding support for Sql execution plan node and operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ examples/batch/
 pom.xml.releaseBackup
 dependency-reduced-pom.xml
 release.properties
+
+# hsqldb in-memory temp files
+**/mem.lck
+**/mem.properties
+**/mem.script
+

--- a/thirdeye-coordinator/src/test/resources/scratch/evaluatev2.http
+++ b/thirdeye-coordinator/src/test/resources/scratch/evaluatev2.http
@@ -467,3 +467,93 @@ Content-Type: application/json
   "start": "1577865600000",
   "end": "1590994800000"
 }
+
+###
+
+POST http://localhost:8080/api/alerts/evaluate
+accept: application/json
+Content-Type: application/json
+
+{
+  "alert": {
+    "name": "percentage-change-template",
+    "description": "Percentage drop template",
+    "cron": "0 0/1 * 1/1 * ? *",
+    "template": {
+      "nodes": [
+        {
+          "name": "root",
+          "type": "SqlExecution",
+          "params": {
+            "sql.queries": [
+              "SELECT ts as timestamp, met as value FROM baseline",
+              "SELECT ts as timestamp, met as value FROM current"
+            ]
+          },
+          "inputs": [
+            {
+              "targetProperty": "baseline",
+              "sourcePlanNode": "baselineDataFetcher",
+              "sourceProperty": "baselineOutput"
+            },
+            {
+              "targetProperty": "current",
+              "sourcePlanNode": "currentDataFetcher",
+              "sourceProperty": "currentOutput"
+            }
+          ],
+          "outputs": [
+            {
+              "outputKey": "0",
+              "outputName": "sql0"
+            },
+            {
+              "outputKey": "1",
+              "outputName": "sql1"
+            }
+          ]
+        },
+        {
+          "name": "baselineDataFetcher",
+          "type": "DataFetcher",
+          "params": {
+            "component.pinot.className": "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.GenericDataFetcher",
+            "component.pinot.dataSource": "pinotQuickStartLocal",
+            "component.pinot.query": "SELECT \"date\" as ts, sum(views) as met FROM pageviews WHERE \"date\" >= 20200202 AND \"date\" <= 20200723 GROUP BY \"date\" ORDER BY \"date\" LIMIT 1000",
+            "component.pinot.tableName": "pageviews",
+            "startTime": "20200202",
+            "endTime": "20200723"
+          },
+          "inputs": [],
+          "outputs": [
+            {
+              "outputKey": "pinot",
+              "outputName": "baselineOutput"
+            }
+          ]
+        },
+        {
+          "name": "currentDataFetcher",
+          "type": "DataFetcher",
+          "params": {
+            "component.pinot.className": "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.GenericDataFetcher",
+            "component.pinot.dataSource": "pinotQuickStartLocal",
+            "component.pinot.query": "SELECT \"date\" as ts, sum(views) as met FROM pageviews WHERE \"date\" >= 20200209 AND \"date\" <= 20200730 GROUP BY \"date\" ORDER BY \"date\" LIMIT 1000",
+            "component.pinot.tableName": "pageviews",
+            "startTime": "20200209",
+            "endTime": "20200730"
+          },
+          "inputs": [],
+          "outputs": [
+            {
+              "outputKey": "pinot",
+              "outputName": "currentOutput"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "start": "1577865600000",
+  "end": "1590994800000"
+}

--- a/thirdeye-core/pom.xml
+++ b/thirdeye-core/pom.xml
@@ -97,7 +97,6 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperator.java
@@ -1,0 +1,294 @@
+package org.apache.pinot.thirdeye.detection.v2.operator;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
+import org.apache.pinot.thirdeye.spi.detection.AbstractSpec;
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType;
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType.ColumnDataType;
+import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.v2.DetectionPipelineResult;
+import org.apache.pinot.thirdeye.spi.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.spi.detection.v2.SimpleDataTable.SimpleDataTableBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Connecting to a temporary SQL workspace with all the inputs data as tables and perform SQL
+ * operations on top.
+ */
+public class SqlExecutionOperator extends DetectionPipelineOperator<DataTable> {
+
+  public static final Logger LOGGER = LoggerFactory.getLogger(SqlExecutionOperator.class);
+  private static final String JDBC_DRIVER_CLASSNAME = "jdbc.driver.classname";
+  private static final String JDBC_CONNECTION = "jdbc.connection";
+  private static final String SQL_QUERIES = "sql.queries";
+  private String jdbcDriverClassName = "org.hsqldb.jdbc.JDBCDriver";
+  private String jdbcConnection = "jdbc:hsqldb:mem";
+  private List<String> queries;
+
+  public SqlExecutionOperator() {
+    super();
+  }
+
+  @Override
+  protected AbstractSpec getComponentSpec(Map<String, Object> componentSpecs, String componentKey) {
+    final AbstractSpec componentSpec = super.getComponentSpec(componentSpecs, componentKey);
+    return componentSpec;
+  }
+
+  @Override
+  public void init(final OperatorContext context) {
+    super.init(context);
+    for (OutputBean outputBean : context.getDetectionPlanApi().getOutputs()) {
+      outputKeyMap.put(outputBean.getOutputKey(), outputBean.getOutputName());
+    }
+    if (config.getParams().containsKey(SQL_QUERIES)) {
+      queries = (List<String>) config.getParams().get(SQL_QUERIES);
+    } else {
+      throw new IllegalArgumentException(
+          "Missing property '" + SQL_QUERIES + "' in SqlExecutionOperator");
+    }
+    if (config.getParams().containsKey(JDBC_DRIVER_CLASSNAME)) {
+      jdbcDriverClassName = config.getParams().get(JDBC_DRIVER_CLASSNAME).toString();
+    }
+    if (config.getParams().containsKey(JDBC_CONNECTION)) {
+      jdbcConnection = config.getParams().get(JDBC_CONNECTION).toString();
+    }
+  }
+
+  @Override
+  public void execute() throws Exception {
+    try {
+      Class.forName(jdbcDriverClassName);
+    } catch (Exception e) {
+      LOGGER.error("ERROR: failed to load JDBC driver class {}.", jdbcDriverClassName, e);
+      throw e;
+    }
+    Connection c = DriverManager.getConnection(jdbcConnection);
+    LOGGER.debug("Successfully connected to JDBC connection: {} with driver class: {} ",
+        jdbcConnection,
+        jdbcDriverClassName);
+
+    List<String> insertedTable = new ArrayList<>();
+    for (String tableName : inputMap.keySet()) {
+      DetectionPipelineResult detectionPipelineResult = inputMap.get(tableName);
+      if (detectionPipelineResult instanceof DataTable) {
+        insertInput(c, tableName, (DataTable) detectionPipelineResult);
+        insertedTable.add(tableName);
+      }
+    }
+    int i = 0;
+    for (String query : queries) {
+      try {
+        final Statement stmt = c.createStatement();
+        final ResultSet resultSet = stmt.executeQuery(query);
+        final DataTable dataTableFromResultSet = getDataTableFromResultSet(resultSet);
+        setOutput(Integer.toString(i++), dataTableFromResultSet);
+      } catch (SQLException e) {
+        LOGGER.error("Got exceptions when executing SQL query: {}", query, e);
+        throw e;
+      }
+    }
+
+    // Destroy database
+    LOGGER.debug("trying to drop all the tables to clean up the environment.");
+    for (String tableName : insertedTable) {
+      destroyTable(c, tableName);
+    }
+  }
+
+  private DataTable getDataTableFromResultSet(final ResultSet resultSet) throws SQLException {
+    final List<String> columns = new ArrayList<>();
+    final List<ColumnType> columnTypes = new ArrayList<>();
+    final ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+    final int columnCount = resultSetMetaData.getColumnCount();
+    for (int i = 0; i < columnCount; i++) {
+      columns.add(resultSetMetaData.getColumnLabel(i + 1));
+      columnTypes.add(convertToColumnType(resultSetMetaData.getColumnType(i + 1)));
+    }
+    final SimpleDataTableBuilder simpleDataTableBuilder = new SimpleDataTableBuilder(columns,
+        columnTypes);
+    while (resultSet.next()) {
+      Object[] rowData = simpleDataTableBuilder.newRow();
+      for (int i = 0; i < columnCount; i++) {
+        final ColumnType columnType = columnTypes.get(i);
+        if (columnType.isArray()) {
+          rowData[i] = resultSet.getArray(i + 1);
+          continue;
+        }
+        switch (columnType.getType()) {
+          case INT:
+            rowData[i] = resultSet.getInt(i + 1);
+            continue;
+          case LONG:
+            rowData[i] = resultSet.getLong(i + 1);
+            continue;
+          case DOUBLE:
+            rowData[i] = resultSet.getDouble(i + 1);
+            continue;
+          case STRING:
+            rowData[i] = resultSet.getString(i + 1);
+            continue;
+          case DATE:
+            rowData[i] = resultSet.getDate(i + 1);
+            continue;
+          case BOOLEAN:
+            rowData[i] = resultSet.getBoolean(i + 1);
+            continue;
+          case BYTES:
+            rowData[i] = resultSet.getBytes(i + 1);
+            continue;
+          default:
+            throw new RuntimeException("Unrecognized data type - " + columnTypes.get(i + 1));
+        }
+      }
+    }
+    return simpleDataTableBuilder.build();
+  }
+
+  private ColumnType convertToColumnType(final int columnType) {
+    switch (columnType) {
+      case Types.DATE:
+      case Types.TIME:
+      case Types.TIMESTAMP:
+        return new ColumnType(ColumnDataType.DATE);
+      case Types.ARRAY:
+      case Types.BINARY:
+      case Types.DATALINK:
+      case Types.BLOB:
+      case Types.DISTINCT:
+      case Types.JAVA_OBJECT:
+      case Types.NULL:
+      case Types.OTHER:
+      case Types.REF:
+      case Types.STRUCT:
+      case Types.VARBINARY:
+      case Types.LONGVARBINARY:
+        return new ColumnType(ColumnDataType.BYTES);
+      case Types.BIT:
+      case Types.BOOLEAN:
+        return new ColumnType(ColumnDataType.BOOLEAN);
+      case Types.DECIMAL:
+      case Types.DOUBLE:
+      case Types.FLOAT:
+      case Types.NUMERIC:
+      case Types.REAL:
+        return new ColumnType(ColumnDataType.DOUBLE);
+      case Types.INTEGER:
+      case Types.SMALLINT:
+        return new ColumnType(ColumnDataType.INT);
+      case Types.BIGINT:
+        return new ColumnType(ColumnDataType.LONG);
+      case Types.CHAR:
+      case Types.VARCHAR:
+      case Types.CLOB:
+      case Types.LONGVARCHAR:
+        return new ColumnType(ColumnDataType.STRING);
+    }
+    throw new UnsupportedOperationException("Unknown JDBC data type - " + columnType);
+  }
+
+  private void destroyTable(final Connection c, final String tableName) throws SQLException {
+    String dropTableStatement = "DROP TABLE " + tableName + " IF EXISTS";
+    try {
+      c.prepareCall(dropTableStatement).execute();
+    } catch (SQLException e) {
+      LOGGER.error("Failed to drop table: {} with sql: {}",
+          tableName,
+          dropTableStatement,
+          e);
+      throw e;
+    }
+  }
+
+  private void insertInput(final Connection c, final String tableName,
+      final DataTable dataTable) throws SQLException {
+    // Drop the table in case.
+    destroyTable(c, tableName);
+    // Create the table.
+    final String tableCreationStatement = getTableCreationStatement(tableName,
+        dataTable.getColumns(),
+        dataTable.getColumnTypes());
+    try {
+      c.prepareCall(tableCreationStatement).execute();
+      LOGGER.debug("Trying to create table with sql: {}", tableCreationStatement);
+    } catch (SQLException e) {
+      LOGGER.error("Failed to create table: {} with sql: {}",
+          tableName,
+          tableCreationStatement,
+          e);
+      throw e;
+    }
+
+    // Insert all rows into the table
+    for (int rowIdx = 0; rowIdx < dataTable.getRowCount(); rowIdx++) {
+      final String insertionStatement = getRowInsertionStatement(tableName, rowIdx, dataTable);
+      try {
+        c.prepareCall(insertionStatement).execute();
+      } catch (SQLException e) {
+        LOGGER.error("Failed to insert row idx: {}, insertion sql: {}",
+            rowIdx,
+            insertionStatement,
+            e);
+        throw e;
+      }
+    }
+  }
+
+  private String getRowInsertionStatement(final String tableName, final int rowIdx,
+      final DataTable dataTable) {
+    String insertionStatement = "INSERT INTO " + tableName + " VALUES (";
+    for (int colIdx = 0; colIdx < dataTable.getColumnCount(); colIdx++) {
+      insertionStatement += dataTable.getObject(rowIdx, colIdx);
+      if (colIdx < dataTable.getColumnCount() - 1) {
+        insertionStatement += ", ";
+      }
+    }
+    insertionStatement += ")";
+    return insertionStatement;
+  }
+
+  private String getTableCreationStatement(final String tableName, final List<String> columns,
+      final List<ColumnType> columnTypes) {
+    String tableCreationStatement = "CREATE TABLE " + tableName + " (";
+    for (int i = 0; i < columns.size(); i++) {
+      tableCreationStatement += columns.get(i) + " " + getColumnType(columnTypes.get(i));
+      if (i < columns.size() - 1) {
+        tableCreationStatement += ", ";
+      }
+    }
+    tableCreationStatement += ")";
+    return tableCreationStatement;
+  }
+
+  private String getColumnType(final ColumnType columnType) {
+    switch (columnType.getType()) {
+      case INT:
+      case LONG:
+        return "BIGINT";
+      case FLOAT:
+      case DOUBLE:
+        return "DOUBLE";
+      case STRING:
+        return "VARCHAR(128)";
+      case BYTES:
+      case OBJECT:
+        return "VARBINARY(128)";
+    }
+    return columnType.getType().toString();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return "SqlExecutionOperator";
+  }
+}

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/SqlExecutionPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/SqlExecutionPlanNode.java
@@ -1,0 +1,49 @@
+package org.apache.pinot.thirdeye.detection.v2.plan;
+
+import java.util.Map;
+import org.apache.pinot.thirdeye.detection.v2.operator.SqlExecutionOperator;
+import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
+import org.apache.pinot.thirdeye.spi.detection.v2.Operator;
+import org.apache.pinot.thirdeye.spi.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.spi.detection.v2.PlanNodeContext;
+
+public class SqlExecutionPlanNode extends DetectionPipelinePlanNode {
+
+  public SqlExecutionPlanNode() {
+    super();
+  }
+
+  @Override
+  public void init(final PlanNodeContext planNodeContext) {
+    super.init(planNodeContext);
+  }
+
+  @Override
+  void setNestedProperties(final Map<String, Object> properties) {
+  }
+
+  @Override
+  public String getType() {
+    return "SqlExecution";
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Map<String, Object> getParams() {
+    return planNodeBean.getParams();
+  }
+
+  @Override
+  public Operator<DataTable> run() throws Exception {
+    final SqlExecutionOperator sqlExecutionOperator = new SqlExecutionOperator();
+    sqlExecutionOperator.init(new OperatorContext()
+        .setDetectionPlanApi(planNodeBean)
+        .setInputsMap(inputsMap)
+    );
+    return sqlExecutionOperator;
+  }
+}

--- a/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperatorTest.java
+++ b/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperatorTest.java
@@ -1,0 +1,181 @@
+package org.apache.pinot.thirdeye.detection.v2.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean;
+import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
+import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType;
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType.ColumnDataType;
+import org.apache.pinot.thirdeye.spi.detection.v2.OperatorContext;
+import org.apache.pinot.thirdeye.spi.detection.v2.SimpleDataTable;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SqlExecutionOperatorTest {
+
+  @Test
+  public void testSqlExecution() throws Exception {
+    final SqlExecutionOperator sqlExecutionOperator = new SqlExecutionOperator();
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + 1000L;
+    final PlanNodeBean planNodeBean = new PlanNodeBean()
+        .setName("root")
+        .setType("SqlExecution")
+        .setParams(ImmutableMap.of("sql.queries", ImmutableList.of(
+            "SELECT ts as timestamp, met as value FROM baseline",
+            "SELECT ts as timestamp, met as value FROM current",
+            "SELECT ts, met FROM baseline UNION ALL SELECT ts, met FROM current"
+        ), "jdbc.connection", "jdbc:hsqldb:mem:SqlExecutionOperatorTest"))
+        .setInputs(ImmutableList.of(
+            new InputBean().setTargetProperty("baseline")
+                .setSourceProperty("baselineOutput")
+                .setSourcePlanNode("baselineDataFetcher"),
+            new InputBean().setTargetProperty("current")
+                .setSourceProperty("currentOutput")
+                .setSourcePlanNode("currentDataFetcher")
+        ))
+        .setOutputs(ImmutableList.of(
+            new OutputBean().setOutputKey("0").setOutputName("sql_0"),
+            new OutputBean().setOutputKey("1").setOutputName("sql_1")
+        ));
+    final Map<String, Object> properties = ImmutableMap.of();
+    final OperatorContext context = new OperatorContext().setStartTime(startTime)
+        .setEndTime(endTime)
+        .setDetectionPlanApi(planNodeBean)
+        .setInputsMap(ImmutableMap.of("baseline", new SimpleDataTable(
+            ImmutableList.of("ts", "met"),
+            ImmutableList.of(new ColumnType(ColumnDataType.LONG),
+                new ColumnType(ColumnDataType.DOUBLE)),
+            ImmutableList.of(new Object[]{123L, 0.123})
+        ), "current", new SimpleDataTable(
+            ImmutableList.of("ts", "met"),
+            ImmutableList.of(new ColumnType(ColumnDataType.LONG),
+                new ColumnType(ColumnDataType.DOUBLE)),
+            ImmutableList.of(new Object[]{456L, 0.456})
+        )))
+        .setProperties(properties);
+    sqlExecutionOperator.init(context);
+    Assert.assertEquals(sqlExecutionOperator.getStartTime(), startTime);
+    Assert.assertEquals(sqlExecutionOperator.getEndTime(), endTime);
+    sqlExecutionOperator.execute();
+    Assert.assertEquals(sqlExecutionOperator.getOutputs().size(), 3);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_0")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .size(), 2);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_0")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("timestamp")
+        .size(), 1);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_0")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("value")
+        .size(), 1);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_0")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("timestamp")
+        .get(0), 123L);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_0")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("value")
+        .get(0), 0.123);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_1")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .size(), 2);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_1")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("timestamp")
+        .size(), 1);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_1")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("value")
+        .size(), 1);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_1")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("timestamp")
+        .get(0), 456L);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("sql_1")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("value")
+        .get(0), 0.456);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("2")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .size(), 2);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("2")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("ts")
+        .size(), 2);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("2")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("met")
+        .size(), 2);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("2")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("ts")
+        .get(0), 123L);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("2")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("met")
+        .get(0), 0.123);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("2")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("ts")
+        .get(1), 456L);
+    Assert.assertEquals(sqlExecutionOperator.getOutputs()
+        .get("2")
+        .getDetectionResults()
+        .get(0)
+        .getRawData()
+        .get("met")
+        .get(1), 0.456);
+  }
+}

--- a/thirdeye-integration-tests/pom.xml
+++ b/thirdeye-integration-tests/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
- Adding Sql execution plan node and operator
- Default implementation is hsqldb (JDBC driver: `org.hsqldb.jdbc.JDBCDriver`) in-memory mode(connection: `jdbc:hsqldb:mem`).
- SqlExecutionOperator:
-- Create one table for every input
-- Execute SQL in the given order in `sql.queries`
-- Drop all input tables
- Default output keys are based on the query sequence id (e.g. 0, 1, 2, ...)