### PR TITLE
Adding type support for thirdeye results

### DIFF
--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperator.java
@@ -6,14 +6,12 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
 import org.apache.pinot.thirdeye.spi.detection.AbstractSpec;
 import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType;
-import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType.ColumnDataType;
 import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
 import org.apache.pinot.thirdeye.spi.detection.v2.DetectionPipelineResult;
 import org.apache.pinot.thirdeye.spi.detection.v2.OperatorContext;
@@ -113,7 +111,7 @@ public class SqlExecutionOperator extends DetectionPipelineOperator<DataTable> {
     final int columnCount = resultSetMetaData.getColumnCount();
     for (int i = 0; i < columnCount; i++) {
       columns.add(resultSetMetaData.getColumnLabel(i + 1));
-      columnTypes.add(convertToColumnType(resultSetMetaData.getColumnType(i + 1)));
+      columnTypes.add(ColumnType.jdbcTypeToColumnType(resultSetMetaData.getColumnType(i + 1)));
     }
     final SimpleDataTableBuilder simpleDataTableBuilder = new SimpleDataTableBuilder(columns,
         columnTypes);
@@ -153,48 +151,6 @@ public class SqlExecutionOperator extends DetectionPipelineOperator<DataTable> {
       }
     }
     return simpleDataTableBuilder.build();
-  }
-
-  private ColumnType convertToColumnType(final int columnType) {
-    switch (columnType) {
-      case Types.DATE:
-      case Types.TIME:
-      case Types.TIMESTAMP:
-        return new ColumnType(ColumnDataType.DATE);
-      case Types.ARRAY:
-      case Types.BINARY:
-      case Types.DATALINK:
-      case Types.BLOB:
-      case Types.DISTINCT:
-      case Types.JAVA_OBJECT:
-      case Types.NULL:
-      case Types.OTHER:
-      case Types.REF:
-      case Types.STRUCT:
-      case Types.VARBINARY:
-      case Types.LONGVARBINARY:
-        return new ColumnType(ColumnDataType.BYTES);
-      case Types.BIT:
-      case Types.BOOLEAN:
-        return new ColumnType(ColumnDataType.BOOLEAN);
-      case Types.DECIMAL:
-      case Types.DOUBLE:
-      case Types.FLOAT:
-      case Types.NUMERIC:
-      case Types.REAL:
-        return new ColumnType(ColumnDataType.DOUBLE);
-      case Types.INTEGER:
-      case Types.SMALLINT:
-        return new ColumnType(ColumnDataType.INT);
-      case Types.BIGINT:
-        return new ColumnType(ColumnDataType.LONG);
-      case Types.CHAR:
-      case Types.VARCHAR:
-      case Types.CLOB:
-      case Types.LONGVARCHAR:
-        return new ColumnType(ColumnDataType.STRING);
-    }
-    throw new UnsupportedOperationException("Unknown JDBC data type - " + columnType);
   }
 
   private void destroyTable(final Connection c, final String tableName) throws SQLException {

--- a/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdeyeResultSetDataTable.java
+++ b/thirdeye-datasources/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resultset/ThirdeyeResultSetDataTable.java
@@ -23,11 +23,11 @@ public class ThirdeyeResultSetDataTable implements DataTable {
     this.groupKeyLength = thirdEyeResultSet.getGroupKeyLength();
     for (int i = 0; i < thirdEyeResultSet.getGroupKeyLength(); i++) {
       columns.add(thirdEyeResultSet.getGroupKeyColumnName(i));
-      columnTypes.add(new ColumnType(ColumnDataType.STRING));
+      columnTypes.add(thirdEyeResultSet.getGroupKeyColumnType(i));
     }
     for (int i = 0; i < thirdEyeResultSet.getColumnCount(); i++) {
       columns.add(thirdEyeResultSet.getColumnName(i));
-      columnTypes.add(new ColumnType(ColumnDataType.DOUBLE));
+      columnTypes.add(thirdEyeResultSet.getColumnType(i));
     }
   }
 

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/datasource/pinot/resultset/ThirdEyeResultSet.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/datasource/pinot/resultset/ThirdEyeResultSet.java
@@ -19,6 +19,9 @@
 
 package org.apache.pinot.thirdeye.spi.datasource.pinot.resultset;
 
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType;
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType.ColumnDataType;
+
 /**
  * An interface to mimic {@link org.apache.pinot.client.ResultSet}. Note that this class is used to
  * decouple
@@ -37,6 +40,8 @@ public interface ThirdEyeResultSet {
 
   String getColumnName(int columnIdx);
 
+  ColumnType getColumnType(int columnIdx);
+
   long getLong(int rowIdx);
 
   double getDouble(int rowIdx);
@@ -52,6 +57,8 @@ public interface ThirdEyeResultSet {
   int getGroupKeyLength();
 
   String getGroupKeyColumnName(int columnIdx);
+
+  ColumnType getGroupKeyColumnType(int columnIdx);
 
   String getGroupKeyColumnValue(int rowIdx, int columnIdx);
 }

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/datasource/pinot/resultset/ThirdEyeResultSetMetaData.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/datasource/pinot/resultset/ThirdEyeResultSetMetaData.java
@@ -23,35 +23,57 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
+import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType;
 
 public class ThirdEyeResultSetMetaData {
 
   private final List<String> groupKeyColumnNames;
   private final List<String> metricColumnNames;
   private final List<String> allColumnNames;
+  private final List<ColumnType> groupKeyColumnTypes;
+  private final List<ColumnType> metricColumnTypes;
+  private final List<ColumnType> allColumnTypes;
 
   public ThirdEyeResultSetMetaData(List<String> groupKeyColumnNames,
-      List<String> metricColumnNames) {
+      List<String> metricColumnNames, List<ColumnType> groupKeyColumnTypes,
+      List<ColumnType> metricColumnTypes) {
     Preconditions.checkNotNull(groupKeyColumnNames);
     Preconditions.checkNotNull(metricColumnNames);
 
     this.groupKeyColumnNames = ImmutableList.copyOf(groupKeyColumnNames);
     this.metricColumnNames = ImmutableList.copyOf(metricColumnNames);
-    this.allColumnNames =
-        ImmutableList.<String>builder().addAll(this.groupKeyColumnNames)
-            .addAll(this.metricColumnNames).build();
+    this.allColumnNames = ImmutableList.<String>builder().addAll(this.groupKeyColumnNames)
+        .addAll(this.metricColumnNames)
+        .build();
+    this.groupKeyColumnTypes = ImmutableList.copyOf(groupKeyColumnTypes);
+    this.metricColumnTypes = ImmutableList.copyOf(metricColumnTypes);
+    this.allColumnTypes = ImmutableList.<ColumnType>builder().addAll(this.groupKeyColumnTypes)
+        .addAll(this.metricColumnTypes)
+        .build();
   }
 
   public List<String> getGroupKeyColumnNames() {
     return groupKeyColumnNames;
   }
 
+  public List<ColumnType> getGroupKeyColumnTypes() {
+    return groupKeyColumnTypes;
+  }
+
   public List<String> getMetricColumnNames() {
     return metricColumnNames;
   }
 
+  public List<ColumnType> getMetricColumnTypes() {
+    return metricColumnTypes;
+  }
+
   public List<String> getAllColumnNames() {
     return allColumnNames;
+  }
+
+  public List<ColumnType> getAllColumnTypes() {
+    return allColumnTypes;
   }
 
   @Override
@@ -63,24 +85,34 @@ public class ThirdEyeResultSetMetaData {
       return false;
     }
     ThirdEyeResultSetMetaData metaData = (ThirdEyeResultSetMetaData) o;
-    return Objects.equals(getGroupKeyColumnNames(), metaData.getGroupKeyColumnNames()) && Objects
-        .equals(
-            getMetricColumnNames(), metaData.getMetricColumnNames()) && Objects
-        .equals(getAllColumnNames(),
-            metaData.getAllColumnNames());
+    return Objects.equals(getGroupKeyColumnNames(), metaData.getGroupKeyColumnNames())
+        && Objects.equals(getMetricColumnNames(), metaData.getMetricColumnNames())
+        && Objects.equals(getAllColumnNames(), metaData.getAllColumnNames()) && Objects.equals(
+        getGroupKeyColumnTypes(),
+        metaData.getGroupKeyColumnTypes()) && Objects.equals(getMetricColumnTypes(),
+        metaData.getMetricColumnTypes()) && Objects.equals(getAllColumnTypes(),
+        metaData.getAllColumnTypes());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getGroupKeyColumnNames(), getMetricColumnNames(), getAllColumnNames());
+    return Objects.hash(getGroupKeyColumnNames(),
+        getMetricColumnNames(),
+        getAllColumnNames(),
+        getGroupKeyColumnTypes(),
+        getMetricColumnTypes(),
+        getAllColumnTypes());
   }
 
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("ThirdEyeResultSetMetaData{");
     sb.append("groupKeyColumnNames=").append(groupKeyColumnNames);
+    sb.append(", groupKeyColumnTypes=").append(groupKeyColumnTypes);
     sb.append(", metricColumnNames=").append(metricColumnNames);
+    sb.append(", metricColumnTypes=").append(metricColumnTypes);
     sb.append(", allColumnNames=").append(allColumnNames);
+    sb.append(", allColumnTypes=").append(allColumnTypes);
     sb.append('}');
     return sb.toString();
   }

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/detection/v2/ColumnType.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/detection/v2/ColumnType.java
@@ -1,5 +1,8 @@
 package org.apache.pinot.thirdeye.spi.detection.v2;
 
+import java.sql.Types;
+import java.util.Objects;
+
 public class ColumnType {
 
   private final ColumnDataType columnDataType;
@@ -9,12 +12,82 @@ public class ColumnType {
     this.columnDataType = columnDataType;
   }
 
+  public static ColumnType pinotTypeToColumnType(final String columnDataType) {
+    return new ColumnType(ColumnDataType.valueOf(columnDataType));
+  }
+
+  public static ColumnType jdbcTypeToColumnType(final int columnType) {
+    switch (columnType) {
+      case Types.DATE:
+      case Types.TIME:
+      case Types.TIMESTAMP:
+        return new ColumnType(ColumnDataType.DATE);
+      case Types.ARRAY:
+      case Types.BINARY:
+      case Types.DATALINK:
+      case Types.BLOB:
+      case Types.DISTINCT:
+      case Types.JAVA_OBJECT:
+      case Types.NULL:
+      case Types.OTHER:
+      case Types.REF:
+      case Types.STRUCT:
+      case Types.VARBINARY:
+      case Types.LONGVARBINARY:
+        return new ColumnType(ColumnDataType.BYTES);
+      case Types.BIT:
+      case Types.BOOLEAN:
+        return new ColumnType(ColumnDataType.BOOLEAN);
+      case Types.DECIMAL:
+      case Types.DOUBLE:
+      case Types.FLOAT:
+      case Types.NUMERIC:
+      case Types.REAL:
+        return new ColumnType(ColumnDataType.DOUBLE);
+      case Types.INTEGER:
+      case Types.SMALLINT:
+        return new ColumnType(ColumnDataType.INT);
+      case Types.BIGINT:
+        return new ColumnType(ColumnDataType.LONG);
+      case Types.CHAR:
+      case Types.VARCHAR:
+      case Types.CLOB:
+      case Types.LONGVARCHAR:
+        return new ColumnType(ColumnDataType.STRING);
+    }
+    throw new UnsupportedOperationException("Unknown JDBC data type - " + columnType);
+  }
+
   public ColumnDataType getType() {
     return columnDataType;
   }
 
   public boolean isArray() {
     return columnDataType.name().endsWith(ARRAY_TYPE_SUFFIX);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ColumnType that = (ColumnType) o;
+    return columnDataType == that.columnDataType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(columnDataType);
+  }
+
+  @Override
+  public String toString() {
+    return "ColumnType{" +
+        "columnDataType=" + columnDataType +
+        '}';
   }
 
   public enum ColumnDataType {


### PR DESCRIPTION
Adding type support for ThirdeyeDataFrameResultSet.

Pinot old query API has no type info, so we can ignore them and still do default mapping: groupkey -> STRING, columns-> DOUBLE

For the new Pinot SQL API, we read column data types and saves them.
