### PR TITLE
UI - build optimisations

### DIFF
--- a/thirdeye-ui/webpack.config.prod.js
+++ b/thirdeye-ui/webpack.config.prod.js
@@ -13,12 +13,13 @@ module.exports = {
     mode: "production",
 
     // Input configuration
-    entry: path.join(__dirname, "src/app/index.tsx"),
+    entry: {
+        "thirdeye-ui": path.join(__dirname, "src/app/index.tsx"),
+    },
 
     // Output configuration
     output: {
         path: outputPath,
-        filename: "thirdeye-ui.js",
         chunkFilename: "[name].js",
         publicPath: "/", // Ensures bundle is served from absolute path as opposed to relative
     },
@@ -66,6 +67,14 @@ module.exports = {
     resolve: {
         // File types to be handled
         extensions: [".ts", ".tsx", ".js", ".css", ".scss", ".svg", ".ttf"],
+    },
+
+    // Create separate chunks for commonly used libs
+    // Refer: https://webpack.js.org/guides/code-splitting/#splitchunksplugin
+    optimization: {
+        splitChunks: {
+            chunks: "all",
+        },
     },
 
     plugins: [


### PR DESCRIPTION
### Issue
- Webpack warning at time of production build

### Solutions
1. Separate out common libs into respective JS like react, material-ui & other dependencies  on `index.tsx`
2. Use `SplitChunksPlugin` to separate out common libs to JS

### Approach used & Why?

 - Going with second approach: Let webpack handles chunks & dependency

> Idea here is to make build process future proof, For the first approach we might need to revisit this in future if dependencies increases on `index.tsx`

### Final output of the changes:

![image](https://user-images.githubusercontent.com/12962843/125786810-a0a096ea-affc-4707-858f-472150e52b3b.png)


### Build code running as expacted?

- `403.js` is chunk with all dependencies of `index.tsx`
- `thirdeye-ui.js` is entry-point for application with rest of the code (other than dependancies)
 
<img width="1680" alt="Screenshot 2021-07-15 at 5 53 15 PM" src="https://user-images.githubusercontent.com/12962843/125787479-281d12b5-c3f5-46d4-8499-6cbbcf40eab8.png">
