### PR TITLE
Moved static annotations inside deployment file

### DIFF
--- a/kubernetes/helm/templates/coordinator/deployment.yaml
+++ b/kubernetes/helm/templates/coordinator/deployment.yaml
@@ -41,6 +41,8 @@ spec:
         release: {{ .Release.Name }}
         component: {{ .Values.coordinator.name }}
       annotations:
+        prometheus.io/port: {{ .Values.coordinator.port | quote }}
+        prometheus.io/path: "/admin/prometheus"
 {{ toYaml .Values.coordinator.podAnnotations | indent 8 }}
     spec:
       {{- if .Values.image.pullSecretsName }}

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -55,9 +55,7 @@ coordinator:
   tolerations: []
   affinity: {}
   podAnnotations:
-    prometheus.io/port: "8080"
     prometheus.io/scrape: "false"
-    prometheus.io/path: "/admin/prometheus"
 
 # Expose prometheus metrics. Should be true if prometheus.io/scrape (above) is true.
 prometheus:


### PR DESCRIPTION
Was not that complicated as I thought it would be.

So now there will be 2 flags exposed at values.yaml:

1.  `prometheus.io/scrape` decides whether prometheus should scrape the pod metrics or not.
2.  `prometheus.enabled` decides whether thirdeye should export prometheus compatible metrics or not.