### PR TITLE
(fix) (CCP-1315) update alert shown wrong alert properties

### DIFF
--- a/thirdeye-ui/src/app/pages/alerts-update-page/alerts-update-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-update-page/alerts-update-page.component.tsx
@@ -55,11 +55,6 @@ export const AlertsUpdatePage: FunctionComponent = () => {
     }, [alert]);
 
     useEffect(() => {
-        const init = async (): Promise<void> => {
-            setLoading(false);
-        };
-
-        init();
         fetchAlert();
     }, []);
 


### PR DESCRIPTION
Show loading indicator until we fetch the alert
<img width="1680" alt="Screenshot 2021-09-24 at 8 31 56 PM" src="https://user-images.githubusercontent.com/12962843/134697034-99b97ab3-f46a-4140-a0e5-265e386bcf59.png">

