### PR TITLE
Exposing coordinator externally

### DIFF
--- a/kubernetes/helm/templates/coordinator/ingress-route.yaml
+++ b/kubernetes/helm/templates/coordinator/ingress-route.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.traefik.coordinator.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ printf "%s-%s" (include "thirdeye.traefik.fullname" . ) "thirdeye-coordinator" | trunc -63 }}
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`{{ .Release.Name }}-coordinator.{{ .Release.Namespace }}.{{ required "domain is required." .Values.domain }}`)
+      kind: Rule
+      services:
+        - name: {{ include "thirdeye.coordinator.headless" . }}
+          namespace: {{ .Release.Namespace }}
+          port: {{ .Values.coordinator.port }}
+{{- end }}

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -103,4 +103,6 @@ config:
 
 # Optional: Enable for ingress
 traefik:
-  enabled: false
+  coordinator:
+    enabled: false
+  enabled: true


### PR DESCRIPTION
Coordinator's external exposure can be configured form `values.yaml`
```
traefik:
  coordinator:
    enabled: false
```