### PR TITLE
infoURL response overrides the auth.enable flag

### DIFF
--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/auth/AuthConfiguration.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/auth/AuthConfiguration.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AuthConfiguration {
 
+  public static final String ISSUER_KEY = "issuer";
+  public static final String ISSUER_URL_KEY = "oidcIssuerUrl";
+  public static final String OIDC_CONFIG_KEY = "openidConfiguration";
+  public static final String JWKS_KEY = "jwks_uri";
+
   private boolean enabled = true;
 
   @JsonProperty("oauth")

--- a/thirdeye-server/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServerModule.java
+++ b/thirdeye-server/src/main/java/org/apache/pinot/thirdeye/ThirdEyeServerModule.java
@@ -1,10 +1,19 @@
 package org.apache.pinot.thirdeye;
 
+import static org.apache.pinot.thirdeye.auth.AuthConfiguration.ISSUER_KEY;
+import static org.apache.pinot.thirdeye.auth.AuthConfiguration.ISSUER_URL_KEY;
+import static org.apache.pinot.thirdeye.auth.AuthConfiguration.JWKS_KEY;
+import static org.apache.pinot.thirdeye.auth.AuthConfiguration.OIDC_CONFIG_KEY;
+
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Optional;
 import org.apache.pinot.thirdeye.auth.AuthConfiguration;
+import org.apache.pinot.thirdeye.auth.OAuthConfig;
+import org.apache.pinot.thirdeye.auth.OidcUtils;
 import org.apache.pinot.thirdeye.config.ThirdEyeServerConfiguration;
 import org.apache.pinot.thirdeye.events.MockEventsConfiguration;
 import org.apache.tomcat.jdbc.pool.DataSource;
@@ -16,7 +25,7 @@ public class ThirdEyeServerModule extends AbstractModule {
   private final MetricRegistry metricRegistry;
 
   public ThirdEyeServerModule(final ThirdEyeServerConfiguration configuration,
-      final DataSource dataSource, final MetricRegistry metricRegistry) {
+    final DataSource dataSource, final MetricRegistry metricRegistry) {
     this.configuration = configuration;
     this.dataSource = dataSource;
     this.metricRegistry = metricRegistry;
@@ -33,7 +42,22 @@ public class ThirdEyeServerModule extends AbstractModule {
   @Singleton
   @Provides
   public AuthConfiguration getAuthConfiguration() {
-    return configuration.getAuthConfiguration();
+    AuthConfiguration authConfig = configuration.getAuthConfiguration();
+    if (authConfig.getInfoURL() != null && !authConfig.getInfoURL().trim().isEmpty()) {
+      HashMap<String, Object> info = OidcUtils.getAuthInfo(authConfig.getInfoURL());
+      if (info == null || info.get(ISSUER_URL_KEY).toString().isEmpty()) {
+        authConfig.setEnabled(false);
+      } else {
+        HashMap<String, Object> oidcConfig = (HashMap<String, Object>) info.get(OIDC_CONFIG_KEY);
+        authConfig.setEnabled(true);
+        OAuthConfig oauth = authConfig.getOAuthConfig();
+        Optional.ofNullable(oidcConfig.get(ISSUER_KEY))
+          .ifPresent(iss -> oauth.getExactMatch().put("iss", iss.toString()));
+        Optional.ofNullable(oidcConfig.get(JWKS_KEY))
+          .ifPresent(jwkUrl -> oauth.setKeysUrl(jwkUrl.toString()));
+      }
+    }
+    return authConfig;
   }
 
   @Singleton


### PR DESCRIPTION
If an `infoURL` is provided to `auth` config, then based on its response the auth behaviour will be decided. This is how the UI decides the auth behaviour too. If `infoURL` is not provided then auth behaviour will fall back to provided `auth` configurations.