### PR TITLE
fix(ui): display <empty_value> for treemap component

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 import { AnomalyBreakdownAPIOffsetValues } from "../../pages/anomalies-view-page/anomalies-view-page.interfaces";
 import { ActionStatus } from "../../rest/actions.interfaces";
 import { useGetAnomalyMetricBreakdown } from "../../rest/rca/rca.actions";
+import { EMPTY_STRING_DISPLAY } from "../../utils/anomalies/anomalies.util";
 import { formatDateAndTime } from "../../utils/date-time/date-time.util";
 import { Treemap } from "../visualizations/treemap/treemap.component";
 import { TreemapData } from "../visualizations/treemap/treemap.interfaces";
@@ -317,7 +318,9 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<AnomalyBreakdo
                                 freeSolo
                                 multiple
                                 getOptionLabel={(option: AnomalyFilterOption) =>
-                                    isString(option.value) ? option.value : ""
+                                    isString(option.value)
+                                        ? option.value || EMPTY_STRING_DISPLAY
+                                        : ""
                                 }
                                 groupBy={(option: AnomalyFilterOption) =>
                                     isString(option.key) ? option.key : ""
@@ -344,7 +347,8 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<AnomalyBreakdo
                                                 className="filter-chip"
                                                 key={`${index}_${option.value}`}
                                                 label={`${option.key}=${
-                                                    option.value || `""`
+                                                    option.value ||
+                                                    EMPTY_STRING_DISPLAY
                                                 }`}
                                                 onDelete={() =>
                                                     handleNodeClick(option)

--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/dimension-heatmap-tooltip/dimension-heatmap-tooltip.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/dimension-heatmap-tooltip/dimension-heatmap-tooltip.component.tsx
@@ -1,6 +1,7 @@
 import { Grid, Typography } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
+import { EMPTY_STRING_DISPLAY } from "../../../utils/anomalies/anomalies.util";
 import { formatLargeNumber } from "../../../utils/number/number.util";
 import { SafariMuiGridFix } from "../../safari-mui-grid-fix/safari-mui-grid-fix.component";
 import { TreemapData } from "../../visualizations/treemap/treemap.interfaces";
@@ -35,7 +36,7 @@ export const DimensionHeatmapTooltip: FunctionComponent<
                             }
                         >
                             <Typography variant="overline">
-                                {props.id}
+                                {props.id || EMPTY_STRING_DISPLAY}
                             </Typography>
                         </Grid>
                     </Grid>

--- a/thirdeye-ui/src/app/components/visualizations/treemap/treemap.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/treemap/treemap.component.tsx
@@ -15,7 +15,10 @@ import {
 } from "@visx/visx";
 import { HierarchyNode, HierarchyRectangularNode } from "d3-hierarchy";
 import React, { MouseEvent } from "react";
-import { getShortText } from "../../../utils/anomalies/anomalies.util";
+import {
+    EMPTY_STRING_DISPLAY,
+    getShortText,
+} from "../../../utils/anomalies/anomalies.util";
 import { TooltipWithBounds } from "../tooltip-with-bounds/tooltip-with-bounds.component";
 import { GenericTreemapTooltip } from "./generic-treemap-tooltip";
 import {
@@ -33,6 +36,7 @@ const margin = {
     right: 0,
     bottom: 0,
 };
+const GRAY = "#EEEEEE";
 
 function Treemap<Data>({
     height = DEFAULT_TREEMAP_HEIGHT,
@@ -100,7 +104,7 @@ function TreemapInternal<Data>({
     );
     const colorScale = scaleLinear<string>({
         domain: [Math.min(...colorValues), -1, 0, 1, Math.max(...colorValues)],
-        range: [purple[500], "#eee", "#eee", "#eee", theme.palette.error.main],
+        range: [purple[500], GRAY, GRAY, GRAY, theme.palette.error.main],
     });
 
     const root = hierarchy(data).sort(
@@ -223,7 +227,8 @@ function TreemapInternal<Data>({
                                                     y={nodeHeight / 2}
                                                 >
                                                     {getShortText(
-                                                        node.data.id || "",
+                                                        node.data.id ||
+                                                            EMPTY_STRING_DISPLAY,
                                                         nodeWidth,
                                                         nodeHeight
                                                     )}

--- a/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
+++ b/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
@@ -8,6 +8,8 @@ import { formatDateAndTime, formatDuration } from "../date-time/date-time.util";
 import { formatLargeNumber, formatPercentage } from "../number/number.util";
 import { deepSearchStringProperty } from "../search/search.util";
 
+export const EMPTY_STRING_DISPLAY = "<EMPTY_VALUE>";
+
 export const getAnomalyName = (anomaly: Anomaly): string => {
     if (!anomaly || isNil(anomaly.id)) {
         return i18n.t("label.anomaly");


### PR DESCRIPTION
For values that are `""` the UI will now display `<EMPTY_VALUE>` in the tile, the filter pill, and the tooltip. The underlying value will still be `""`

![Anomalies-Anomaly-76728-ThirdEye](https://user-images.githubusercontent.com/2080348/148298187-5f06c3f7-4061-4173-be9e-14a794b19ef7.png)
