### PR TITLE
refactor(anomaly-breakdown-comparison-heatmap): remove timezone param in api call for dimension breakdown data

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
@@ -188,7 +188,6 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<AnomalyBreakdo
 
     useEffect(() => {
         getMetricBreakdownForCurrent(anomalyId, {
-            timezone: "UTC",
             filters: [
                 ...anomalyFilters.map(
                     (option) => `${option.key}=${option.value}`
@@ -197,7 +196,6 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<AnomalyBreakdo
         });
 
         getMetricBreakdownForComparison(anomalyId, {
-            timezone: "UTC",
             offset: comparisonOffset,
             filters: [
                 ...anomalyFilters.map(


### PR DESCRIPTION
Cyril is planning on deprecating the timezone param and we haven't really been using it