### PR TITLE
fix(anomaly-breakdown-comparison-heatmap): flip colors for negative and positive difference

### DIFF
--- a/thirdeye-ui/src/app/components/visualizations/treemap/treemap.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/treemap/treemap.component.tsx
@@ -102,7 +102,7 @@ function TreemapInternal<Data>({
     );
     const colorScale = scaleLinear<string>({
         domain: [Math.min(...colorValues), -1, 0, 1, Math.max(...colorValues)],
-        range: [purple[500], GRAY, GRAY, GRAY, theme.palette.error.main],
+        range: [theme.palette.error.main, GRAY, GRAY, GRAY, purple[500]],
     });
 
     const root = hierarchy(data)


### PR DESCRIPTION
![Anomaly-451751-ThirdEye](https://user-images.githubusercontent.com/2080348/149372741-13a569cc-68b9-4390-8491-da343bebad96.png)

 Flipping negative contribution change to red and positive to purple as requested