### PR TITLE
fix(anomaly-view): show only the current anomlay in chart

### DIFF
--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
@@ -24,6 +24,7 @@ import { AlertEvaluation } from "../../rest/dto/alert.interfaces";
 import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
 import {
     createAlertEvaluation,
+    filterAnomaliesByTime,
     getUiAnomaly,
 } from "../../utils/anomalies/anomalies.util";
 import { isValidNumberId } from "../../utils/params/params.util";
@@ -60,8 +61,19 @@ export const AnomaliesViewPage: FunctionComponent = () => {
     }, [anomaly]);
 
     useEffect(() => {
-        !!evaluation && setAlertEvaluation(evaluation);
-    }, [evaluation]);
+        if (!evaluation || !anomaly) {
+            return;
+        }
+        // Only filter for the current anomaly
+        const anomalyDetectionResults =
+            evaluation.detectionEvaluations.output_AnomalyDetectorResult_0;
+        anomalyDetectionResults.anomalies = filterAnomaliesByTime(
+            anomalyDetectionResults.anomalies,
+            anomaly.startTime,
+            anomaly.endTime
+        );
+        setAlertEvaluation(evaluation);
+    }, [evaluation, anomaly]);
 
     useEffect(() => {
         // Fetched alert changed, fetch alert evaluation


### PR DESCRIPTION
Filtering for just the current anomaly being viewed using existing filter util function.

Before:
![Anomaly-451751-ThirdEye (2)](https://user-images.githubusercontent.com/2080348/149382969-47af0d9f-aaa0-42b3-ab0f-78f7fbb94386.png)


After:
![Anomaly-451751-ThirdEye (1)](https://user-images.githubusercontent.com/2080348/149382867-2cd63c79-a988-48d4-89ac-cc5c9ceca11b.png)
