### PR TITLE
fix(ui): fix label cutoff in heatmap component

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
@@ -328,7 +328,6 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<AnomalyBreakdo
                                     <TextField
                                         {...params}
                                         fullWidth
-                                        label={t("label.add-a-dimension")}
                                         placeholder={t(
                                             "message.anomaly-filter-search"
                                         )}

--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -73,7 +73,6 @@
         "end": "End",
         "from": "From",
         "to": "To",
-        "add-a-dimension": "Add a Dimension",
         "last-15-minutes": "Last 15 Minutes",
         "last-1-hour": "Last 1 Hour",
         "last-12-hours": "Last 12 Hours",


### PR DESCRIPTION
Removing the label in the filtering input box which is always crossed out but the line of the box

Before:
![Anomaly-76728-ThirdEye (1)](https://user-images.githubusercontent.com/2080348/150026495-06e9ef03-7e73-4f04-bc2c-c1b789a43db6.png)


After:
![Anomaly-76728-ThirdEye](https://user-images.githubusercontent.com/2080348/150026516-8506732a-0622-4639-92f7-98e2f0868f4c.png)
