### PR TITLE
[thirdeye-spi] change start/end time type to long in OperatorContext

### DIFF
--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/operator/DetectionPipelineOperator.java
@@ -20,7 +20,6 @@
 package org.apache.pinot.thirdeye.detection.v2.operator;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.apache.pinot.thirdeye.spi.util.SpiUtils.optional;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -72,8 +71,8 @@ public abstract class DetectionPipelineOperator implements Operator {
   @Override
   public void init(final OperatorContext context) {
     planNode = context.getPlanNode();
-    startTime = optional(context.getStartTime()).map(TIME_CONVERTER::convert).orElse(-1L);
-    endTime = optional(context.getEndTime()).map(TIME_CONVERTER::convert).orElse(-1L);
+    startTime = context.getStartTime();
+    endTime = context.getEndTime();
     checkArgument(startTime <= endTime, "start time cannot be greater than end time");
 
     resultMap = new HashMap<>();

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/AnomalyDetectorPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/AnomalyDetectorPlanNode.java
@@ -33,8 +33,8 @@ public class AnomalyDetectorPlanNode extends DetectionPipelinePlanNode {
   public Operator buildOperator() throws Exception {
     final AnomalyDetectorOperator anomalyDetectorOperator = new AnomalyDetectorOperator();
     anomalyDetectorOperator.init(new OperatorContext()
-        .setStartTime(String.valueOf(this.startTime))
-        .setEndTime(String.valueOf(this.endTime))
+        .setStartTime(this.startTime)
+        .setEndTime(this.endTime)
         .setInputsMap(inputsMap)
         .setPlanNode(planNodeBean)
     );

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/CombinerPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/CombinerPlanNode.java
@@ -38,12 +38,8 @@ public class CombinerPlanNode extends DetectionPipelinePlanNode {
   public Operator buildOperator() throws Exception {
     final CombinerOperator operator = new CombinerOperator();
     operator.init(new OperatorContext()
-        .setStartTime(params
-            .getOrDefault("startTime", String.valueOf(this.startTime))
-            .toString())
-        .setEndTime(params
-            .getOrDefault("endTime", String.valueOf(this.endTime))
-            .toString())
+        .setStartTime((Long) getParams().getOrDefault("startTime", startTime))
+        .setEndTime((Long) getParams().getOrDefault("endTime", endTime))
         .setInputsMap(inputsMap)
         .setPlanNode(planNodeBean)
     );

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DataFetcherPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/DataFetcherPlanNode.java
@@ -39,8 +39,8 @@ public class DataFetcherPlanNode extends DetectionPipelinePlanNode {
   public Operator buildOperator() throws Exception {
     final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
     dataFetcherOperator.init(new OperatorContext()
-        .setStartTime(String.valueOf(this.startTime))
-        .setEndTime(String.valueOf(this.endTime))
+        .setStartTime(this.startTime)
+        .setEndTime(this.endTime)
         .setPlanNode(planNodeBean)
         .setProperties(ImmutableMap.of(DATA_SOURCE_CACHE_REF_KEY, dataSourceCache))
     );

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/EchoPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/EchoPlanNode.java
@@ -33,8 +33,8 @@ public class EchoPlanNode extends DetectionPipelinePlanNode {
   public Operator buildOperator() throws Exception {
     final EchoOperator operator = new EchoOperator();
     operator.init(new OperatorContext()
-        .setStartTime(String.valueOf(this.startTime))
-        .setEndTime(String.valueOf(this.endTime))
+        .setStartTime(this.startTime)
+        .setEndTime(this.endTime)
         .setInputsMap(inputsMap)
         .setPlanNode(planNodeBean)
     );

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/EnumeratorPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/EnumeratorPlanNode.java
@@ -38,12 +38,8 @@ public class EnumeratorPlanNode extends DetectionPipelinePlanNode {
   public Operator buildOperator() throws Exception {
     final EnumeratorOperator operator = new EnumeratorOperator();
     operator.init(new OperatorContext()
-        .setStartTime(params
-            .getOrDefault("startTime", String.valueOf(this.startTime))
-            .toString())
-        .setEndTime(params
-            .getOrDefault("endTime", String.valueOf(this.endTime))
-            .toString())
+        .setStartTime((Long) params.getOrDefault("startTime", this.startTime))
+        .setEndTime((Long) params.getOrDefault("endTime", this.endTime))
         .setInputsMap(inputsMap)
         .setPlanNode(planNodeBean)
     );

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/ForkJoinPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/ForkJoinPlanNode.java
@@ -48,12 +48,8 @@ public class ForkJoinPlanNode extends DetectionPipelinePlanNode {
 
     final ForkJoinOperator operator = new ForkJoinOperator();
     operator.init(new OperatorContext()
-        .setStartTime(getParams()
-            .getOrDefault("startTime", String.valueOf(startTime))
-            .toString())
-        .setEndTime(getParams()
-            .getOrDefault("endTime", String.valueOf(endTime))
-            .toString())
+        .setStartTime((Long) getParams().getOrDefault("startTime", startTime))
+        .setEndTime((Long) getParams().getOrDefault("endTime", endTime))
         .setInputsMap(inputsMap)
         .setPlanNode(planNodeBean)
         .setProperties(ImmutableMap.of(

--- a/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/IndexFillerPlanNode.java
+++ b/thirdeye-core/src/main/java/org/apache/pinot/thirdeye/detection/v2/plan/IndexFillerPlanNode.java
@@ -15,8 +15,8 @@ public class IndexFillerPlanNode extends DetectionPipelinePlanNode {
   public Operator buildOperator() throws Exception {
     final TimeIndexFillerOperator timeIndexFillerOperator = new TimeIndexFillerOperator();
     timeIndexFillerOperator.init(new OperatorContext()
-        .setStartTime(String.valueOf(this.startTime))
-        .setEndTime(String.valueOf(this.endTime))
+        .setStartTime(this.startTime)
+        .setEndTime(this.endTime)
         .setPlanNode(planNodeBean)
         .setInputsMap(inputsMap)
     );

--- a/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/DataFetcherOperatorTest.java
+++ b/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/DataFetcherOperatorTest.java
@@ -37,9 +37,8 @@ public class DataFetcherOperatorTest {
   @Test
   public void testNewInstance() {
     final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
-    final long currentTimeMillis = System.currentTimeMillis();
-    final String startTime = String.valueOf(currentTimeMillis);
-    final String endTime = String.valueOf(currentTimeMillis + 1000L);
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + 1000L;
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setParams(ImmutableMap.of("component.dataSource", dataSourceName))
         .setOutputs(ImmutableList.of());
@@ -50,8 +49,8 @@ public class DataFetcherOperatorTest {
         .setPlanNode(planNodeBean)
         .setProperties(properties);
     dataFetcherOperator.init(context);
-    Assert.assertEquals(String.valueOf(dataFetcherOperator.getStartTime()), startTime);
-    Assert.assertEquals(String.valueOf(dataFetcherOperator.getEndTime()), endTime);
+    Assert.assertEquals(dataFetcherOperator.getStartTime(), startTime);
+    Assert.assertEquals(dataFetcherOperator.getEndTime(), endTime);
   }
 
   @Test
@@ -65,9 +64,8 @@ public class DataFetcherOperatorTest {
         "org.apache.pinot.thirdeye.detection.v2.components.datafetcher.GenericDataFetcher");
 
     final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
-    final long currentTimeMillis = System.currentTimeMillis();
-    final String startTime = String.valueOf(currentTimeMillis);
-    final String endTime = String.valueOf(currentTimeMillis + 1000L);
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + 1000L;
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setOutputs(ImmutableList.of())
         .setInputs(ImmutableList.of())
@@ -81,8 +79,8 @@ public class DataFetcherOperatorTest {
         .setProperties(properties);
     dataFetcherOperator.init(context);
 
-    Assert.assertEquals(String.valueOf(dataFetcherOperator.getStartTime()), startTime);
-    Assert.assertEquals(String.valueOf(dataFetcherOperator.getEndTime()), endTime);
+    Assert.assertEquals(dataFetcherOperator.getStartTime(), startTime);
+    Assert.assertEquals(dataFetcherOperator.getEndTime(), endTime);
 
     final BaseComponent<DataFetcherSpec> pinotDataFetcher = dataFetcherOperator.getDataFetcher();
 

--- a/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperatorTest.java
+++ b/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/SqlExecutionOperatorTest.java
@@ -46,9 +46,8 @@ public class SqlExecutionOperatorTest {
     params.putAll(customParams);
 
     final DetectionPipelineOperator sqlExecutionOperator = new SqlExecutionOperator();
-    final long currentTimeMillis = System.currentTimeMillis();
-    final String startTime = String.valueOf(currentTimeMillis);
-    final String endTime = String.valueOf(currentTimeMillis + 1000L);
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + 1000L;
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setName("root")
         .setType("SqlExecution")
@@ -82,8 +81,8 @@ public class SqlExecutionOperatorTest {
         )))
         .setProperties(properties);
     sqlExecutionOperator.init(context);
-    Assert.assertEquals(String.valueOf(sqlExecutionOperator.getStartTime()), startTime);
-    Assert.assertEquals(String.valueOf(sqlExecutionOperator.getEndTime()), endTime);
+    Assert.assertEquals(sqlExecutionOperator.getStartTime(), startTime);
+    Assert.assertEquals(sqlExecutionOperator.getEndTime(), endTime);
     sqlExecutionOperator.execute();
     Assert.assertEquals(sqlExecutionOperator.getOutputs().size(), 3);
     Assert.assertEquals(sqlExecutionOperator.getOutputs()

--- a/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/TimeIndexFillerOperatorTest.java
+++ b/thirdeye-core/src/test/java/org/apache/pinot/thirdeye/detection/v2/operator/TimeIndexFillerOperatorTest.java
@@ -1,33 +1,16 @@
 package org.apache.pinot.thirdeye.detection.v2.operator;
 
-import static org.apache.pinot.thirdeye.detection.v2.plan.PlanNodeFactory.DATA_SOURCE_CACHE_REF_KEY;
-import static org.mockito.Matchers.same;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import org.apache.pinot.thirdeye.datasource.cache.DataSourceCache;
-import org.apache.pinot.thirdeye.detection.v2.components.datafetcher.GenericDataFetcher;
-import org.apache.pinot.thirdeye.detection.v2.spec.DataFetcherSpec;
 import org.apache.pinot.thirdeye.spi.dataframe.DataFrame;
 import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
-import org.apache.pinot.thirdeye.spi.datasource.ThirdEyeDataSource;
-import org.apache.pinot.thirdeye.spi.detection.BaseComponent;
-import org.apache.pinot.thirdeye.spi.detection.model.DetectionResult;
-import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType;
-import org.apache.pinot.thirdeye.spi.detection.v2.ColumnType.ColumnDataType;
 import org.apache.pinot.thirdeye.spi.detection.v2.DataTable;
-import org.apache.pinot.thirdeye.spi.detection.v2.DetectionPipelineResult;
 import org.apache.pinot.thirdeye.spi.detection.v2.OperatorContext;
 import org.apache.pinot.thirdeye.spi.detection.v2.SimpleDataTable;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TimeIndexFillerOperatorTest {
@@ -88,8 +71,8 @@ public class TimeIndexFillerOperatorTest {
   @Test
   public void testTimeIndexFillerExecutionFillLeftRightInferBoundsFromDetectionTime() throws Exception {
     final TimeIndexFillerOperator timeIndexFillerOperator = new TimeIndexFillerOperator();
-    final String startTime = String.valueOf(OCTOBER_23_MILLIS);
-    final String endTime = String.valueOf(OCTOBER_26_MILLIS);
+    final long startTime = OCTOBER_23_MILLIS;
+    final long endTime = OCTOBER_26_MILLIS;
 
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setName("root")
@@ -126,8 +109,8 @@ public class TimeIndexFillerOperatorTest {
         .setProperties(properties);
 
     timeIndexFillerOperator.init(context);
-    Assert.assertEquals(String.valueOf(timeIndexFillerOperator.getStartTime()), startTime);
-    Assert.assertEquals(String.valueOf(timeIndexFillerOperator.getEndTime()), endTime);
+    Assert.assertEquals(timeIndexFillerOperator.getStartTime(), startTime);
+    Assert.assertEquals(timeIndexFillerOperator.getEndTime(), endTime);
 
     timeIndexFillerOperator.execute();
 

--- a/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/detection/v2/OperatorContext.java
+++ b/thirdeye-spi/src/main/java/org/apache/pinot/thirdeye/spi/detection/v2/OperatorContext.java
@@ -1,31 +1,29 @@
 package org.apache.pinot.thirdeye.spi.detection.v2;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.apache.pinot.thirdeye.spi.datalayer.dto.PlanNodeBean;
-import org.apache.pinot.thirdeye.spi.util.SpiUtils.TimeFormat;
 
 public class OperatorContext {
-  private String startTime;
-  private String endTime;
+  private long startTime;
+  private long endTime;
   private PlanNodeBean planNode;
   private Map<String, Object> properties;
   private Map<String, DetectionPipelineResult> inputsMap;
 
-  public String getStartTime() {
+  public long getStartTime() {
     return startTime;
   }
 
-  public OperatorContext setStartTime(final String startTime) {
+  public OperatorContext setStartTime(final long startTime) {
     this.startTime = startTime;
     return this;
   }
 
-  public String getEndTime() {
+  public long getEndTime() {
     return endTime;
   }
 
-  public OperatorContext setEndTime(final String endTime) {
+  public OperatorContext setEndTime(final long endTime) {
     this.endTime = endTime;
     return this;
   }


### PR DESCRIPTION
prep - makes PlanNodeContext and OperatorContext more similar