### PR TITLE
fix(ui): heatmap bug where parent container conflicts with a tile id

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
@@ -74,13 +74,15 @@ function summarizeDimensionValueData(
 function formatTreemapData(
     dimensionData: AnomalyBreakdownComparisonDataByDimensionColumn
 ): TreemapData<AnomalyBreakdownComparisonData>[] {
+    const parentId = `${dimensionData.column}-parent`;
+
     return [
-        { id: dimensionData.column, size: 0, parent: null },
+        { id: parentId, size: 0, parent: null },
         ...map(dimensionData.dimensionComparisonData, (comparisonData, k) => {
             return {
                 id: k,
                 size: comparisonData.current,
-                parent: dimensionData.column,
+                parent: parentId,
                 extraData: comparisonData,
             };
         }),


### PR DESCRIPTION
Fixing a bug where a the value of a column could match the column name. 


Error as of Jan 20, 2021 9:20am
http://104.40.6.58:8081/anomalies/view/id/458117?time_range=CUSTOM&start_time=1577865600000&end_time=1641023999999