### PR TITLE
refactor(ui): rename predicted and comparison to baseline

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
@@ -267,7 +267,7 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<AnomalyBreakdo
                             <Grid item xs={6}>
                                 <div>
                                     <strong>
-                                        &quot;{t("label.comparison")}&quot;
+                                        &quot;{t("label.baseline")}&quot;
                                     </strong>
                                     <span>
                                         {" "}

--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/dimension-heatmap-tooltip/dimension-heatmap-tooltip.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/dimension-heatmap-tooltip/dimension-heatmap-tooltip.component.tsx
@@ -123,7 +123,7 @@ export const DimensionHeatmapTooltip: FunctionComponent<
                                         dimensionHeatmapTooltipStyles.tableCellLabel
                                     }
                                 >
-                                    {t("label.comparison")}
+                                    {t("label.baseline")}
                                 </th>
                                 <td
                                     className={

--- a/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.component.tsx
@@ -119,10 +119,11 @@ export const AnomalyListV1: FunctionComponent<AnomalyListV1Props> = (
                 sortable: true,
                 minWidth: 150,
             },
+            // We're using Baseline as the title for `predicted` as of 1/20/21
             {
                 key: "predicted",
                 dataKey: "predicted",
-                header: t("label.predicted"),
+                header: t("label.baseline"),
                 sortable: true,
                 minWidth: 150,
             },

--- a/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
@@ -186,12 +186,12 @@ export const AnomalyCard: FunctionComponent<AnomalyCardProps> = (
                             />
                         </Grid>
 
-                        {/* Current/Predicted */}
+                        {/* Current/Baseline */}
                         <Grid item md={3} xs={6}>
                             <NameValueDisplayCard<string>
                                 name={`${t("label.current")}${t(
                                     "label.pair-separator"
-                                )}${t("label.predicted")}`}
+                                )}${t("label.baseline")}`}
                                 searchWords={props.searchWords}
                                 values={[
                                     `${props.uiAnomaly.current}${t(


### PR DESCRIPTION
Changing the `Comparison` and `Predicted` title to `Baseline`

![baseline-2](https://user-images.githubusercontent.com/2080348/150391381-21685641-12af-4b95-b18b-b996b5d9750d.png)

![baseline-change-1](https://user-images.githubusercontent.com/2080348/150391366-82a514e0-0fa3-4689-8b8b-426bc4c8c6c2.png)

![baseline-3](https://user-images.githubusercontent.com/2080348/150391561-3aa124cf-1c45-4e48-b6b0-72363d15fd08.png)

