### PR TITLE
Report error if dataset is not found

### DIFF
--- a/thirdeye-server/src/main/java/org/apache/pinot/thirdeye/resources/DataSourceResource.java
+++ b/thirdeye-server/src/main/java/org/apache/pinot/thirdeye/resources/DataSourceResource.java
@@ -91,6 +91,7 @@ public class DataSourceResource extends CrudResource<DataSourceApi, DataSourceDT
     ensureExists(dataSource, ThirdEyeStatus.ERR_DATASOURCE_NOT_LOADED, dataSourceName);
 
     final DatasetConfigDTO datasetConfigDTO = dataSource.onboardDataset(datasetName);
+    ensureExists(datasetConfigDTO, ThirdEyeStatus.ERR_DATASET_NOT_FOUND, datasetName);
 
     return respondOk(ApiBeanMapper.toApi(datasetConfigDTO));
   }


### PR DESCRIPTION
When dataset is not present on the datasource the below response will be received with a `400` code:
call : `/api/data-sources/onboard-dataset`
Response: 
```
{
  "list": [
    {
      "code": "ERR_DATASET_NOT_FOUND",
      "msg": "Dataset not found! <provided dataset name>"
    }
  ]
}
```