### PR TITLE
chore(ui): change proxy in dev configs to new demo backend

### DIFF
--- a/thirdeye-ui/webpack.config.dev.js
+++ b/thirdeye-ui/webpack.config.dev.js
@@ -120,7 +120,7 @@ module.exports = {
         proxy: [
             {
                 context: "/api",
-                target: "http://13.93.137.231:8081/",
+                target: "http://23.99.9.151:8080/",
                 changeOrigin: true,
             },
         ],


### PR DESCRIPTION
Cyril mentioned the backend IP address has changed to `http://23.99.9.151:8080/`