### PR TITLE
refactor(ui): switch to heatmap endpoint from soon to be deprecated breakdown endpoint

### DIFF
--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.interfaces.ts
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.interfaces.ts
@@ -4,7 +4,7 @@ export interface AnomaliesViewPageParams {
 
 export enum AnomalyBreakdownAPIOffsetValues {
     CURRENT = "current",
-    ONE_WEEK_AGO = "wo1w",
-    TWO_WEEKS_AGO = "wo2w",
-    THREE_WEEKS_AGO = "wo3w",
+    ONE_WEEK_AGO = "P1W",
+    TWO_WEEKS_AGO = "P2W",
+    THREE_WEEKS_AGO = "P3W",
 }

--- a/thirdeye-ui/src/app/rest/dto/rca.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/rca.interfaces.ts
@@ -1,13 +1,30 @@
 import { AnomalyBreakdownAPIOffsetValues } from "../../pages/anomalies-view-page/anomalies-view-page.interfaces";
 
 export interface AnomalyBreakdown {
-    [key: string]: {
-        [key: string]: number;
+    metric: {
+        name: string;
+        dataset: {
+            name: string;
+        };
+    };
+    current: {
+        breakdown: {
+            [key: string]: {
+                [key: string]: number;
+            };
+        };
+    };
+    baseline: {
+        breakdown: {
+            [key: string]: {
+                [key: string]: number;
+            };
+        };
     };
 }
 
 export interface AnomalyBreakdownRequest {
-    offset?: AnomalyBreakdownAPIOffsetValues;
+    baselineOffset?: AnomalyBreakdownAPIOffsetValues;
     timezone?: string;
     filters?: string[];
     limit?: number;

--- a/thirdeye-ui/src/app/rest/rca/rca.actions.test.ts
+++ b/thirdeye-ui/src/app/rest/rca/rca.actions.test.ts
@@ -30,7 +30,8 @@ describe("RCA Actions", () => {
 
             await act(async () => {
                 const promise = result.current.getMetricBreakdown(123, {
-                    offset: AnomalyBreakdownAPIOffsetValues.ONE_WEEK_AGO,
+                    baselineOffset:
+                        AnomalyBreakdownAPIOffsetValues.ONE_WEEK_AGO,
                 });
 
                 // Wait for state update

--- a/thirdeye-ui/src/app/rest/rca/rca.rest.ts
+++ b/thirdeye-ui/src/app/rest/rca/rca.rest.ts
@@ -11,7 +11,7 @@ export const getAnomalyMetricBreakdown = async (
     params: AnomalyBreakdownRequest
 ): Promise<AnomalyBreakdown> => {
     const response = await axios.get(
-        `${BASE_URL_RCA}/metrics/breakdown/anomaly/${id}`,
+        `${BASE_URL_RCA}/metrics/heatmap/anomaly/${id}`,
         {
             params,
             paramsSerializer: (params) => {


### PR DESCRIPTION
Cyril introduced a new endpoint which includes both baseline and current in the data payload: https://github.com/startreedata/thirdeye/pull/196