### PR TITLE
fix(ui): account for evaluate api failure

### DIFF
--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -149,7 +149,8 @@
         "value": "Value",
         "alert-performance": "Alert Performance",
         "root-cause-analysis": "Root Cause Analysis",
-        "heatmap-data": "Heatmap Data"
+        "heatmap-data": "Heatmap Data",
+        "chart-data": "Chart Data"
     },
     "message": {
         "page-not-found": "Requested page could not be found",

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, Grid } from "@material-ui/core";
+import { Box, Card, CardContent, CardHeader, Grid } from "@material-ui/core";
 import {
     AppLoadingIndicatorV1,
     JSONEditorV1,
@@ -209,7 +209,9 @@ export const AlertsViewPage: FunctionComponent = () => {
                     {evaluationRequestStatus === ActionStatus.Error && (
                         <Card variant="outlined">
                             <CardContent>
-                                <NoDataIndicator />
+                                <Box pb={20} pt={20}>
+                                    <NoDataIndicator />
+                                </Box>
                             </CardContent>
                         </Card>
                     )}

--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
@@ -1,4 +1,4 @@
-import { Grid } from "@material-ui/core";
+import { Box, Card, CardContent, Grid } from "@material-ui/core";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
@@ -14,9 +14,11 @@ import { useAppBreadcrumbs } from "../../components/app-breadcrumbs/app-breadcru
 import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
 import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { AnomalyCard } from "../../components/entity-cards/anomaly-card/anomaly-card.component";
+import { NoDataIndicator } from "../../components/no-data-indicator/no-data-indicator.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import { useTimeRange } from "../../components/time-range/time-range-provider/time-range-provider.component";
 import { AlertEvaluationTimeSeriesCard } from "../../components/visualizations/alert-evaluation-time-series-card/alert-evaluation-time-series-card.component";
+import { ActionStatus } from "../../rest/actions.interfaces";
 import { useGetEvaluation } from "../../rest/alerts/alerts.actions";
 import { deleteAnomaly } from "../../rest/anomalies/anomalies.rest";
 import { useGetAnomaly } from "../../rest/anomalies/anomaly.actions";
@@ -32,7 +34,11 @@ import { getAnomaliesAllPath } from "../../utils/routes/routes.util";
 import { AnomaliesViewPageParams } from "./anomalies-view-page.interfaces";
 
 export const AnomaliesViewPage: FunctionComponent = () => {
-    const { evaluation, getEvaluation } = useGetEvaluation();
+    const {
+        evaluation,
+        getEvaluation,
+        status: getEvaluationRequestStatus,
+    } = useGetEvaluation();
     const { anomaly, getAnomaly } = useGetAnomaly();
     const [uiAnomaly, setUiAnomaly] = useState<UiAnomaly | null>(null);
     const [
@@ -79,6 +85,17 @@ export const AnomaliesViewPage: FunctionComponent = () => {
         // Fetched alert changed, fetch alert evaluation
         fetchAlertEvaluation();
     }, [anomaly]);
+
+    useEffect(() => {
+        if (getEvaluationRequestStatus === ActionStatus.Error) {
+            notify(
+                NotificationTypeV1.Error,
+                t("message.error-while-fetching", {
+                    entity: t("label.chart-data"),
+                })
+            );
+        }
+    }, [getEvaluationRequestStatus]);
 
     if (!isValidNumberId(params.id)) {
         // Invalid id
@@ -147,12 +164,23 @@ export const AnomaliesViewPage: FunctionComponent = () => {
 
                 {/* Alert evaluation time series */}
                 <Grid item xs={12}>
-                    <AlertEvaluationTimeSeriesCard
-                        alertEvaluation={alertEvaluation}
-                        alertEvaluationTimeSeriesHeight={500}
-                        maximizedTitle={uiAnomaly ? uiAnomaly.name : ""}
-                        onRefresh={fetchAlertEvaluation}
-                    />
+                    {getEvaluationRequestStatus === ActionStatus.Error && (
+                        <Card variant="outlined">
+                            <CardContent>
+                                <Box pb={20} pt={20}>
+                                    <NoDataIndicator />
+                                </Box>
+                            </CardContent>
+                        </Card>
+                    )}
+                    {getEvaluationRequestStatus === ActionStatus.Done && (
+                        <AlertEvaluationTimeSeriesCard
+                            alertEvaluation={alertEvaluation}
+                            alertEvaluationTimeSeriesHeight={500}
+                            maximizedTitle={uiAnomaly ? uiAnomaly.name : ""}
+                            onRefresh={fetchAlertEvaluation}
+                        />
+                    )}
                 </Grid>
 
                 <Grid item xs={12}>

--- a/thirdeye-ui/src/app/pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.component.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Grid, Paper } from "@material-ui/core";
+import { Box, Card, CardContent, Grid, Paper } from "@material-ui/core";
 import {
     AppLoadingIndicatorV1,
     NotificationTypeV1,
@@ -35,7 +35,11 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
         getAnomaly,
         status: getAnomalyRequestStatus,
     } = useGetAnomaly();
-    const { evaluation, getEvaluation } = useGetEvaluation();
+    const {
+        evaluation,
+        getEvaluation,
+        status: getEvaluationRequestStatus,
+    } = useGetEvaluation();
     const [uiAnomaly, setUiAnomaly] = useState<UiAnomaly | null>(null);
     const [
         alertEvaluation,
@@ -67,6 +71,17 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
     useEffect(() => {
         fetchAlertEvaluation();
     }, [uiAnomaly]);
+
+    useEffect(() => {
+        if (getEvaluationRequestStatus === ActionStatus.Error) {
+            notify(
+                NotificationTypeV1.Error,
+                t("message.error-while-fetching", {
+                    entity: t("label.chart-data"),
+                })
+            );
+        }
+    }, [getEvaluationRequestStatus]);
 
     useEffect(() => {
         if (evaluation && anomaly) {
@@ -143,12 +158,23 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
                 {/* Trending */}
                 <Grid item xs={12}>
                     <Paper elevation={0}>
-                        <AlertEvaluationTimeSeriesCard
-                            alertEvaluation={alertEvaluation}
-                            alertEvaluationTimeSeriesHeight={500}
-                            maximizedTitle={uiAnomaly ? uiAnomaly.name : ""}
-                            onRefresh={fetchAlertEvaluation}
-                        />
+                        {getEvaluationRequestStatus === ActionStatus.Error && (
+                            <Card variant="outlined">
+                                <CardContent>
+                                    <Box pb={20} pt={20}>
+                                        <NoDataIndicator />
+                                    </Box>
+                                </CardContent>
+                            </Card>
+                        )}
+                        {getEvaluationRequestStatus === ActionStatus.Done && (
+                            <AlertEvaluationTimeSeriesCard
+                                alertEvaluation={alertEvaluation}
+                                alertEvaluationTimeSeriesHeight={500}
+                                maximizedTitle={uiAnomaly ? uiAnomaly.name : ""}
+                                onRefresh={fetchAlertEvaluation}
+                            />
+                        )}
                     </Paper>
                 </Grid>
 


### PR DESCRIPTION
Show `<NoDataIndicator />` when the evaluate api fails and notify the user