### PR TITLE
fix(ui): make datasets and datasources tile icons different

### DIFF
--- a/thirdeye-ui/src/app/pages/home-page/home-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/home-page/home-page.component.tsx
@@ -1,4 +1,6 @@
 import { Grid, useTheme } from "@material-ui/core";
+import GridOnIcon from "@material-ui/icons/GridOn";
+import StorageIcon from "@material-ui/icons/Storage";
 import {
     PageContentsGridV1,
     PageV1,
@@ -93,9 +95,7 @@ export const HomePage: FunctionComponent = () => {
                 <Grid item>
                     <TileButtonV1 href={getDatasetsPath()}>
                         <TileButtonIconV1>
-                            <SubscriptionGroupIcon
-                                fill={theme.palette.primary.main}
-                            />
+                            <GridOnIcon color="primary" />
                         </TileButtonIconV1>
                         <TileButtonTextV1>
                             {t("label.datasets")}
@@ -107,9 +107,7 @@ export const HomePage: FunctionComponent = () => {
                 <Grid item>
                     <TileButtonV1 href={getDatasourcesPath()}>
                         <TileButtonIconV1>
-                            <SubscriptionGroupIcon
-                                fill={theme.palette.primary.main}
-                            />
+                            <StorageIcon color="primary" />
                         </TileButtonIconV1>
                         <TileButtonTextV1>
                             {t("label.datasources")}


### PR DESCRIPTION
![Home-ThirdEye](https://user-images.githubusercontent.com/2080348/153683703-18f2d8e3-a003-4655-91ac-9330682d5d44.png)
