### PR TITLE
chore(ui): remove rect having height 0 form heatmap

### DIFF
--- a/thirdeye-ui/src/app/components/visualizations/treemap/treemap.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/treemap/treemap.component.tsx
@@ -187,9 +187,15 @@ function TreemapInternal<Data>({
                                     .descendants()
                                     .reverse()
                                     .map((node, i) => {
-                                        const nodeWidth = node.x1 - node.x0 - 1;
-                                        const nodeHeight =
-                                            node.y1 - node.y0 - 1;
+                                        const nodeWidth = Math.max(
+                                            node.x1 - node.x0 - 1,
+                                            0
+                                        );
+                                        const nodeHeight = Math.max(
+                                            node.y1 - node.y0 - 1,
+                                            0
+                                        );
+
                                         let colorValue = -1;
 
                                         if (!isOtherDimension(node.data.id)) {
@@ -207,18 +213,12 @@ function TreemapInternal<Data>({
                                                 fill={colorScale(
                                                     colorValue || 0
                                                 )}
-                                                height={Math.max(
-                                                    node.y1 - node.y0 - 1,
-                                                    0
-                                                )}
-                                                width={Math.max(
-                                                    node.x1 - node.x0 - 1,
-                                                    0
-                                                )}
+                                                height={nodeHeight}
+                                                width={nodeWidth}
                                             />
                                         );
 
-                                        return (
+                                        return !nodeHeight ? null : (
                                             <Group
                                                 className={
                                                     props.onDimensionClickHandler


### PR DESCRIPTION
Changes:

Hide Heat-map nodes where height is 0, It will block labels to get overflow from node

Before:
![image](https://user-images.githubusercontent.com/12962843/157047231-21777cd8-77d8-4e90-b650-09391bc7336f.png)


After: 

![image](https://user-images.githubusercontent.com/12962843/157047082-b8963cba-0016-4583-8a5b-fecc96b54e15.png)
