### PR TITLE
fix(ui): heatmap not loading when current is zero

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.utils.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.utils.tsx
@@ -61,7 +61,9 @@ export function formatTreemapData(
 
             return {
                 id: k,
-                size: comparisonData.current,
+                // when current is 0, treemap won't render anything
+                // fix: https://cortexdata.atlassian.net/browse/TE-453
+                size: comparisonData.current || 1,
                 parent: parentId,
                 extraData: comparisonAndDisplayData,
             };


### PR DESCRIPTION
Changes:

when current value is `0` in dimensions, Heatmap doesn't shown on the the UI.
JIRA: https://cortexdata.atlassian.net/browse/TE-453

Before:
<img width="1680" alt="Screenshot 2022-03-08 at 5 46 10 PM" src="https://user-images.githubusercontent.com/12962843/157236497-34b7c20b-54fa-46f4-915d-6298f1e573c7.png">

After:

<img width="1680" alt="Screenshot 2022-03-08 at 5 45 39 PM" src="https://user-images.githubusercontent.com/12962843/157236546-d226e94c-5d92-4750-b47f-3ad882b3f15d.png">

