### PR TITLE
feat(ui): hide success icon for json editor

### DIFF
--- a/thirdeye-ui/src/app/components/alert-template-wizard/altert-template-wizard.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-template-wizard/altert-template-wizard.component.tsx
@@ -179,6 +179,7 @@ function AlertTemplateWizard<NewOrExistingTemplate>(
                             {/* Datasource configuration editor */}
                             <Grid item sm={12}>
                                 <JSONEditorV1<NewOrExistingTemplate>
+                                    hideValidationSuccessIcon
                                     error={alertTemplateConfigurationError}
                                     helperText={
                                         alertTemplateConfigurationHelperText
@@ -197,6 +198,7 @@ function AlertTemplateWizard<NewOrExistingTemplate>(
                             {/* Datasource information */}
                             <Grid item sm={12}>
                                 <JSONEditorV1<NewOrExistingTemplate>
+                                    hideValidationSuccessIcon
                                     readOnly
                                     value={newAlertTemplate}
                                 />

--- a/thirdeye-ui/src/app/components/alert-wizard/alert-wizard-configuration-new.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard/alert-wizard-configuration-new.component.tsx
@@ -102,6 +102,7 @@ function AlertWizardConfigurationNew({
             )}
 
             <JSONEditorV1<EditableAlert>
+                hideValidationSuccessIcon
                 error={error}
                 helperText={helperText}
                 value={currentWorkingConfiguration}

--- a/thirdeye-ui/src/app/components/alert-wizard/alert-wizard.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard/alert-wizard.component.tsx
@@ -337,6 +337,7 @@ function AlertWizard<NewOrExistingAlert extends EditableAlert | Alert>(
                                     <Grid item sm={12}>
                                         {!props.createNewMode && (
                                             <JSONEditorV1<EditableAlert>
+                                                hideValidationSuccessIcon
                                                 error={
                                                     detectionConfigurationError
                                                 }
@@ -418,6 +419,7 @@ function AlertWizard<NewOrExistingAlert extends EditableAlert | Alert>(
                                     {/* Alert information */}
                                     <Grid item sm={12}>
                                         <JSONEditorV1<EditableAlert>
+                                            hideValidationSuccessIcon
                                             readOnly
                                             value={newAlert}
                                         />

--- a/thirdeye-ui/src/app/components/datasource-wizard/datasource-wizard.component.tsx
+++ b/thirdeye-ui/src/app/components/datasource-wizard/datasource-wizard.component.tsx
@@ -174,6 +174,7 @@ export const DatasourceWizard: FunctionComponent<DatasourceWizardProps> = (
                             {/* Datasource configuration editor */}
                             <Grid item sm={12}>
                                 <JSONEditorV1<Datasource>
+                                    hideValidationSuccessIcon
                                     error={datasourceConfigurationError}
                                     helperText={
                                         datasourceConfigurationHelperText
@@ -192,6 +193,7 @@ export const DatasourceWizard: FunctionComponent<DatasourceWizardProps> = (
                             {/* Datasource information */}
                             <Grid item sm={12}>
                                 <JSONEditorV1<Datasource>
+                                    hideValidationSuccessIcon
                                     readOnly
                                     value={newDatasource}
                                 />

--- a/thirdeye-ui/src/app/pages/alert-templates-view-page/alert-templates-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alert-templates-view-page/alert-templates-view-page.component.tsx
@@ -189,6 +189,7 @@ export const AlertTemplatesViewPage: FunctionComponent = () => {
                         <CardContent>
                             {alertTemplate && (
                                 <JSONEditorV1<AlertTemplate>
+                                    hideValidationSuccessIcon
                                     readOnly
                                     value={alertTemplate}
                                 />

--- a/thirdeye-ui/src/app/pages/datasources-view-page/datasources-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/datasources-view-page/datasources-view-page.component.tsx
@@ -119,6 +119,7 @@ export const DatasourcesViewPage: FunctionComponent = () => {
                 {/* Datasource JSON viewer */}
                 <Grid item sm={12}>
                     <JSONEditorV1<Datasource>
+                        hideValidationSuccessIcon
                         readOnly
                         value={uiDatasource?.datasource as Datasource}
                     />

--- a/thirdeye-ui/src/app/platform/components/json-editor-v1/json-editor-v1.component.tsx
+++ b/thirdeye-ui/src/app/platform/components/json-editor-v1/json-editor-v1.component.tsx
@@ -35,6 +35,7 @@ export function JSONEditorV1<T = string>({
     disableAutoFormat,
     allowEmpty,
     disableValidation,
+    hideValidationSuccessIcon,
     validationDelay = DELAY_VALIDATION_DEFAULT,
     className,
     onChange,
@@ -213,19 +214,22 @@ export function JSONEditorV1<T = string>({
             )}
 
             {/* Valid icon */}
-            {showValidationIcon() && !error && valid && (
-                <div
-                    className={classNames(
-                        jsonEditorV1Classes.validationIcon,
-                        "json-editor-v1-valid-icon"
-                    )}
-                >
-                    <CheckCircleIcon
-                        fontSize="medium"
-                        htmlColor={theme.palette.success.main}
-                    />
-                </div>
-            )}
+            {showValidationIcon() &&
+                !error &&
+                valid &&
+                !hideValidationSuccessIcon && (
+                    <div
+                        className={classNames(
+                            jsonEditorV1Classes.validationIcon,
+                            "json-editor-v1-valid-icon"
+                        )}
+                    >
+                        <CheckCircleIcon
+                            fontSize="medium"
+                            htmlColor={theme.palette.success.main}
+                        />
+                    </div>
+                )}
 
             {/* Invalid icon */}
             {showValidationIcon() && (error || !valid) && (

--- a/thirdeye-ui/src/app/platform/components/json-editor-v1/json-editor-v1.interfaces.ts
+++ b/thirdeye-ui/src/app/platform/components/json-editor-v1/json-editor-v1.interfaces.ts
@@ -5,6 +5,7 @@ export interface JSONEditorV1Props<T = string> {
     helperText?: string;
     error?: boolean;
     readOnly?: boolean;
+    hideValidationSuccessIcon?: boolean;
     disableAutoFormat?: boolean;
     allowEmpty?: boolean;
     disableValidation?: boolean;


### PR DESCRIPTION
Changes:

> Support to hide success icon for json editor

> Hide success icon for all json editor used within app

Screenshot with changes:

<img width="1680" alt="Screenshot 2022-03-11 at 11 43 55 PM" src="https://user-images.githubusercontent.com/12962843/157925886-3f8701e1-2e83-461c-b90b-559bb259cae2.png">
