### PR TITLE
[helm] Dynamic secret generation from values and passing them as env variables

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/common/holiday-loader-secret.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/common/holiday-loader-secret.yaml
@@ -1,9 +1,0 @@
-{{- if .Values.config.holidayLoaderKey }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: holiday-loader-key
-type: Opaque
-data:
-  holiday-loader-key.json: {{ .Values.config.holidayLoaderKey }}
-{{- end }}

--- a/kubernetes/helm/startree-thirdeye/templates/common/secrets.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/common/secrets.yaml
@@ -1,0 +1,12 @@
+{{ range $secret := .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secret.name }}
+type: Opaque
+data:
+  {{- range $pair := $secret.data }}
+  {{ $pair.key }}: {{ if $pair.encoded -}} {{ $pair.value }} {{- else -}} {{ $pair.value | b64enc }} {{- end }}
+  {{- end }}
+---
+{{ end }}

--- a/kubernetes/helm/startree-thirdeye/templates/common/sendgrid-secret.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/common/sendgrid-secret.yaml
@@ -1,9 +1,0 @@
-{{- if .Values.sendgrid }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: sendgrid-api-key
-type: Opaque
-data:
-  key: {{ .Values.sendgrid.key | b64enc }}
-{{- end }}

--- a/kubernetes/helm/startree-thirdeye/templates/common/smtp-secret.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/common/smtp-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: smtp-credentials
-type: Opaque
-data:
-  username: {{ .Values.smtp.username | b64enc }}
-  password: {{ .Values.smtp.password | b64enc }}

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
@@ -66,27 +66,21 @@ spec:
         args: 
         - "server"
         env:
+          {{- range $secret := .Values.secrets }}
+          {{- range $pair := $secret.data }}
+          {{- if and $pair.env $pair.value }}
+          - name: {{ $pair.env }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $secret.name }}
+                key: {{ $pair.key }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           - name: SMTP_HOST
             value: {{ .Values.smtp.host | quote }}
           - name: SMTP_PORT
             value: {{ .Values.smtp.port  | quote }}
-          - name: SMTP_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.smtp.secretKeyRef.name }}
-                key: username
-          - name: SMTP_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.smtp.secretKeyRef.name }}
-                key: password
-          {{- if .Values.sendgrid }}
-          - name: SENDGRID_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: sendgrid-api-key
-                key: key
-          {{- end }}
           {{- if .Values.tls.enabled }}
           - name: JAVA_OPTS
             value: >

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
@@ -68,6 +68,17 @@ spec:
         - "server"
         {{- if .Values.scheduler.tls.enabled }}
         env:
+          {{- range $secret := .Values.secrets }}
+          {{- range $pair := $secret.data }}
+          {{- if and $pair.env $pair.value }}
+          - name: {{ $pair.env }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $secret.name }}
+                key: {{ $pair.key }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           - name: JAVA_OPTS
             value: >
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore

--- a/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
@@ -67,20 +67,21 @@ spec:
         args:
         - "server"
         env:
+          {{- range $secret := .Values.secrets }}
+          {{- range $pair := $secret.data }}
+          {{- if and $pair.env $pair.value }}
+          - name: {{ $pair.env }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $secret.name }}
+                key: {{ $pair.key }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           - name: SMTP_HOST
             value: {{ .Values.smtp.host | quote }}
           - name: SMTP_PORT
             value: {{ .Values.smtp.port  | quote }}
-          - name: SMTP_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.smtp.secretKeyRef.name }}
-                key: username
-          - name: SMTP_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.smtp.secretKeyRef.name }}
-                key: password
           {{- if .Values.sendgrid }}
           - name: SENDGRID_API_KEY
             valueFrom:


### PR DESCRIPTION
Secrets will be created based on values provided in the `values.yaml`
Sample:
```
secrets:
  - name: holiday-loader-key
    data:
    - key: holiday-loader-key.json
      encoded: true
      value: <base 64 encoded json key>
  - name: smtp-credentials
    data:
    - key: username
      env: SMTP_USER
      value: shounak
    - key: password
      env: SMTP_PASSWORD
      value: pass
  - name: sendgrid-api-key
    data:
    - key: key
      env: SENDGRID_API_KEY
      value: <sendgrid key>
```
Notes:

1. Secret will be created for each entry in `secrets` with :
    - Secret name as `name`
    - Secret data as `data` provided
    - data entries will take `key` as data key and `value` as data value
2. The secret will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.
3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts.
4. It is recommended to pass values other than simple string (e.g. JSON payload) as base64 encoded value to avoid any parsing issues.