### PR TITLE
(fix)ui: assign unique id to each notifications

### DIFF
--- a/thirdeye-ui/package-lock.json
+++ b/thirdeye-ui/package-lock.json
@@ -2833,6 +2833,12 @@
                 }
             }
         },
+        "@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
+        },
         "@types/webpack": {
             "version": "4.41.26",
             "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.26.tgz",
@@ -17037,9 +17043,7 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache": {
             "version": "2.2.0",

--- a/thirdeye-ui/package.json
+++ b/thirdeye-ui/package.json
@@ -75,6 +75,7 @@
         "react-hook-form": "^6.14.0",
         "react-i18next": "^11.8.5",
         "react-router-dom": "^6.2.1",
+        "uuid": "^8.3.2",
         "yup": "^0.32.8",
         "zustand": "^3.2.0"
     },
@@ -96,6 +97,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/react-test-renderer": "^17.0.0",
         "@types/testing-library__jest-dom": "^5.9.5",
+        "@types/uuid": "^8.3.4",
         "@types/yup": "^0.29.11",
         "@typescript-eslint/eslint-plugin": "^4.12.0",
         "@typescript-eslint/parser": "^4.12.0",

--- a/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-provider-v1/notification-provider-v1.component.tsx
+++ b/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-provider-v1/notification-provider-v1.component.tsx
@@ -9,6 +9,7 @@ import React, {
     useState,
 } from "react";
 import { useLocation } from "react-router-dom";
+import { v4 as uuidv4 } from "uuid";
 import {
     NotificationProviderV1ContextProps,
     NotificationProviderV1Props,
@@ -36,12 +37,13 @@ export const NotificationProviderV1: FunctionComponent<
         onDismiss?: () => void
     ): NotificationV1 => {
         const notification = {
-            id: Date.now(),
+            id: uuidv4(),
             type: type || NotificationTypeV1.Info,
             message: message || "",
             nonDismissible: Boolean(nonDismissible),
             scope: scope || NotificationScopeV1.Page,
             onDismiss: onDismiss,
+            createdAt: Date.now(),
         };
 
         setNotifications((draftNotifications) => {
@@ -107,7 +109,7 @@ export const NotificationProviderV1: FunctionComponent<
 
         if (notification1.nonDismissible === notification2.nonDismissible) {
             // Within dismissible and non dismissible notifications, show the latest first
-            return notification2.id - notification1.id;
+            return notification2.createdAt - notification1.createdAt;
         }
 
         return 0;

--- a/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-provider-v1/notification-provider-v1.interfaces.ts
+++ b/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-provider-v1/notification-provider-v1.interfaces.ts
@@ -19,12 +19,13 @@ export interface NotificationProviderV1ContextProps {
 }
 
 export interface NotificationV1 {
-    id: number;
+    id: string;
     type: NotificationTypeV1;
     message: string;
     nonDismissible: boolean;
     scope: NotificationScopeV1;
     onDismiss?: () => void;
+    createdAt: number;
 }
 
 export enum NotificationTypeV1 {

--- a/thirdeye-ui/src/app/rest/create-rest-action.ts
+++ b/thirdeye-ui/src/app/rest/create-rest-action.ts
@@ -25,6 +25,8 @@ function useHTTPAction<DataResponseType>(
 
     const makeRequest = useCallback(async (...options) => {
         setStatus(ActionStatus.Working);
+        // Reset error message to avoid displaying previous errors
+        setErrorMessages([]);
         try {
             const fetchedData = await restFunction(...options);
             setData(fetchedData);
@@ -35,8 +37,8 @@ function useHTTPAction<DataResponseType>(
         } catch (error) {
             const axiosError = error as AxiosError;
             setData(null);
-            setStatus(ActionStatus.Error);
             setErrorMessages(getErrorMessages(axiosError));
+            setStatus(ActionStatus.Error);
         }
 
         return undefined;


### PR DESCRIPTION
### Issues

> In the case of stacked notifications, each one has the same id due to `new Date()` id creation. When user try to close one notification all of them gets removed

### Fix

> Provide unique id to each notification in case of stacked too. using `uuid` package to generate unique id each time of notification creation

### Meta changes

> Clear `errorMessages` at time of new request to make sure `errorMessages` always have the latest errors & not the errors from the previous call
