### PR TITLE
fix(ui): show error message for action hooks

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-breakdown-comparison-heatmap/anomaly-breakdown-comparison-heatmap.component.tsx
@@ -56,6 +56,7 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<
         anomalyMetricBreakdown,
         getMetricBreakdown,
         status: anomalyBreakdownReqStatus,
+        errorMessages: anomalyBreakdownReqErrors,
     } = useGetAnomalyMetricBreakdown();
     const [breakdownComparisonData, setBreakdownComparisonData] = useState<
         AnomalyBreakdownComparisonDataByDimensionColumn[] | null
@@ -177,17 +178,6 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<
         });
     }, [anomalyId, comparisonOffset, anomalyFilters]);
 
-    useEffect(() => {
-        if (anomalyBreakdownReqStatus === ActionStatus.Error) {
-            notify(
-                NotificationTypeV1.Error,
-                t("message.error-while-fetching", {
-                    entity: t("label.heatmap-data"),
-                })
-            );
-        }
-    }, [anomalyBreakdownReqStatus]);
-
     const handleNodeClick = (
         tileData: HierarchyNode<TreemapData<AnomalyBreakdownComparisonData>>,
         dimensionColumn: string
@@ -247,6 +237,21 @@ export const AnomalyBreakdownComparisonHeatmap: FunctionComponent<
             e.target.value as AnomalyBreakdownAPIOffsetValues
         );
     };
+
+    useEffect(() => {
+        if (anomalyBreakdownReqStatus === ActionStatus.Error) {
+            !isEmpty(anomalyBreakdownReqErrors)
+                ? anomalyBreakdownReqErrors.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  )
+                : notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.heatmap-data"),
+                      })
+                  );
+        }
+    }, [anomalyBreakdownReqStatus, anomalyBreakdownReqErrors]);
 
     return (
         <Card variant="outlined">

--- a/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
@@ -1,8 +1,13 @@
 import { Card, CardContent, Grid } from "@material-ui/core";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
 import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
+import { isEmpty } from "lodash";
 import React, { FunctionComponent, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import {
+    NotificationTypeV1,
+    useNotificationProviderV1,
+} from "../../../../platform/components";
 import { ActionStatus } from "../../../../rest/actions.interfaces";
 import { useGetAlert } from "../../../../rest/alerts/alerts.actions";
 import { useCommonStyles } from "../../../../utils/material-ui/common.styles";
@@ -13,10 +18,11 @@ import { useAnomalySummaryCardStyles } from "./anomaly-summary-card.styles";
 export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = (
     props
 ) => {
-    const { alert, getAlert, status } = useGetAlert();
+    const { alert, getAlert, status, errorMessages } = useGetAlert();
     const anomalySummaryCardStyles = useAnomalySummaryCardStyles();
     const commonClasses = useCommonStyles();
     const { t } = useTranslation();
+    const { notify } = useNotificationProviderV1();
     const { uiAnomaly } = props;
 
     useEffect(() => {
@@ -24,6 +30,21 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = (
             getAlert(uiAnomaly.alertId);
         }
     }, [uiAnomaly]);
+
+    useEffect(() => {
+        if (status === ActionStatus.Error) {
+            isEmpty(errorMessages)
+                ? notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.alert"),
+                      })
+                  )
+                : errorMessages.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  );
+        }
+    }, [status, errorMessages]);
 
     return (
         <Card className={props.className} variant="outlined">

--- a/thirdeye-ui/src/app/pages/alert-templates-update-page/alert-templates-update-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alert-templates-update-page/alert-templates-update-page.component.tsx
@@ -26,6 +26,7 @@ export const AlertTemplatesUpdatePage: FunctionComponent = () => {
         alertTemplate,
         getAlertTemplate,
         status: alertTemplateRequestStatus,
+        errorMessages: alertTemplateErrors,
     } = useGetAlertTemplate();
     const { id: alertTemplateId } = useParams<AlertTemplatesUpdatePageParams>();
     const navigate = useNavigate();
@@ -76,6 +77,21 @@ export const AlertTemplatesUpdatePage: FunctionComponent = () => {
                       );
             });
     };
+
+    useEffect(() => {
+        if (alertTemplateRequestStatus === ActionStatus.Error) {
+            isEmpty(alertTemplateErrors)
+                ? notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.alert-template"),
+                      })
+                  )
+                : alertTemplateErrors.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  );
+        }
+    }, [alertTemplateRequestStatus, alertTemplateErrors]);
 
     if (alertTemplateRequestStatus === ActionStatus.Working) {
         return <AppLoadingIndicatorV1 />;

--- a/thirdeye-ui/src/app/pages/alert-templates-view-page/alert-templates-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alert-templates-view-page/alert-templates-view-page.component.tsx
@@ -8,7 +8,7 @@ import {
     MenuItem,
 } from "@material-ui/core";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
-import { isNumber } from "lodash";
+import { isEmpty, isNumber } from "lodash";
 import React, {
     FunctionComponent,
     MouseEvent,
@@ -45,6 +45,7 @@ export const AlertTemplatesViewPage: FunctionComponent = () => {
         alertTemplate,
         getAlertTemplate,
         status: getAlertRequestStatus,
+        errorMessages: alertTemplateErrors,
     } = useGetAlertTemplate();
     const [
         alertTemplateOptionsAnchorElement,
@@ -64,14 +65,18 @@ export const AlertTemplatesViewPage: FunctionComponent = () => {
 
     useEffect(() => {
         if (getAlertRequestStatus === ActionStatus.Error) {
-            notify(
-                NotificationTypeV1.Error,
-                t("message.error-while-fetching", {
-                    entity: t("label.alert-template"),
-                })
-            );
+            isEmpty(alertTemplateErrors)
+                ? notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.alert-template"),
+                      })
+                  )
+                : alertTemplateErrors.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  );
         }
-    }, [getAlertRequestStatus]);
+    }, [getAlertRequestStatus, alertTemplateErrors]);
 
     const handleDatasetOptionsClick = (
         event: MouseEvent<HTMLElement>

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -52,7 +52,12 @@ export const AlertsViewPage: FunctionComponent = () => {
         errorMessages,
         status: evaluationRequestStatus,
     } = useGetEvaluation();
-    const { anomalies, getAnomalies } = useGetAnomalies();
+    const {
+        anomalies,
+        getAnomalies,
+        status: anomaliesRequestStatus,
+        errorMessages: anomaliesRequestErrors,
+    } = useGetAnomalies();
     const [uiAlert, setUiAlert] = useState<UiAlert | null>(null);
     const [subscriptionGroups, setSubscriptionGroups] = useState<
         SubscriptionGroup[]
@@ -235,6 +240,21 @@ export const AlertsViewPage: FunctionComponent = () => {
     const onAnomalyBarClick = (anomaly: Anomaly): void => {
         navigate(getAnomaliesAnomalyPath(anomaly.id));
     };
+
+    useEffect(() => {
+        if (anomaliesRequestStatus === ActionStatus.Error) {
+            !isEmpty(anomaliesRequestErrors)
+                ? anomaliesRequestErrors.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  )
+                : notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.anomalies"),
+                      })
+                  );
+        }
+    }, [anomaliesRequestStatus, anomaliesRequestErrors]);
 
     return !uiAlert || evaluationRequestStatus === ActionStatus.Working ? (
         <AppLoadingIndicatorV1 />

--- a/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
@@ -1,4 +1,5 @@
 import { Grid } from "@material-ui/core";
+import { isEmpty } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
@@ -25,8 +26,11 @@ import { SEARCH_TERM_QUERY_PARAM_KEY } from "../../utils/params/params.util";
 export const AnomaliesAllPage: FunctionComponent = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const [uiAnomalies, setUiAnomalies] = useState<UiAnomaly[] | null>(null);
-    const { getAnomalies, status: getAnomaliesRequestStatus } =
-        useGetAnomalies();
+    const {
+        getAnomalies,
+        status: getAnomaliesRequestStatus,
+        errorMessages: anomaliesRequestErrors,
+    } = useGetAnomalies();
     const { showDialog } = useDialog();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
@@ -108,6 +112,21 @@ export const AnomaliesAllPage: FunctionComponent = () => {
         }
         setSearchParams(searchParams);
     };
+
+    useEffect(() => {
+        if (getAnomaliesRequestStatus === ActionStatus.Error) {
+            !isEmpty(anomaliesRequestErrors)
+                ? anomaliesRequestErrors.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  )
+                : notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.anomalies"),
+                      })
+                  );
+        }
+    }, [getAnomaliesRequestStatus, anomaliesRequestErrors]);
 
     return (
         <PageV1>

--- a/thirdeye-ui/src/app/pages/anomalies-view-index-page/anomalies-view-index-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-index-page/anomalies-view-index-page.component.tsx
@@ -1,11 +1,17 @@
-import { toNumber } from "lodash";
+import { isEmpty, toNumber } from "lodash";
 import React, { FunctionComponent, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import {
     TimeRange,
     TimeRangeQueryStringKey,
 } from "../../components/time-range/time-range-provider/time-range-provider.interfaces";
-import { AppLoadingIndicatorV1 } from "../../platform/components";
+import {
+    AppLoadingIndicatorV1,
+    NotificationTypeV1,
+    useNotificationProviderV1,
+} from "../../platform/components";
+import { ActionStatus } from "../../platform/rest/actions.interfaces";
 import { useGetAnomaly } from "../../rest/anomalies/anomaly.actions";
 import { isValidNumberId } from "../../utils/params/params.util";
 import { getAnomaliesAnomalyViewPath } from "../../utils/routes/routes.util";
@@ -17,9 +23,16 @@ import { AnomaliesViewPageParams } from "../anomalies-view-page/anomalies-view-p
  * to redirect to the anomalies view page to
  */
 export const AnomaliesViewIndexPage: FunctionComponent = () => {
-    const { anomaly, getAnomaly } = useGetAnomaly();
+    const {
+        anomaly,
+        getAnomaly,
+        status: anomalyRequestStatus,
+        errorMessages,
+    } = useGetAnomaly();
     const params = useParams<AnomaliesViewPageParams>();
     const navigate = useNavigate();
+    const { notify } = useNotificationProviderV1();
+    const { t } = useTranslation();
 
     useEffect(() => {
         params.id &&
@@ -50,6 +63,21 @@ export const AnomaliesViewIndexPage: FunctionComponent = () => {
             );
         }
     }, [anomaly]);
+
+    useEffect(() => {
+        if (anomalyRequestStatus === ActionStatus.Error) {
+            isEmpty(errorMessages)
+                ? notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.anomaly"),
+                      })
+                  )
+                : errorMessages.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  );
+        }
+    }, [anomalyRequestStatus, errorMessages]);
 
     return <AppLoadingIndicatorV1 />;
 };

--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
@@ -41,7 +41,12 @@ export const AnomaliesViewPage: FunctionComponent = () => {
         errorMessages,
         status: getEvaluationRequestStatus,
     } = useGetEvaluation();
-    const { anomaly, getAnomaly } = useGetAnomaly();
+    const {
+        anomaly,
+        getAnomaly,
+        status: anomalyRequestStatus,
+        errorMessages: anomalyRequestErrors,
+    } = useGetAnomaly();
     const [uiAnomaly, setUiAnomaly] = useState<UiAnomaly | null>(null);
     const [alertEvaluation, setAlertEvaluation] =
         useState<AlertEvaluation | null>(null);
@@ -142,6 +147,21 @@ export const AnomaliesViewPage: FunctionComponent = () => {
             navigate(getAnomaliesAllPath());
         });
     };
+
+    useEffect(() => {
+        if (anomalyRequestStatus === ActionStatus.Error) {
+            isEmpty(anomalyRequestErrors)
+                ? notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.anomaly"),
+                      })
+                  )
+                : anomalyRequestErrors.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  );
+        }
+    }, [anomalyRequestStatus, anomalyRequestErrors]);
 
     return (
         <PageV1>

--- a/thirdeye-ui/src/app/pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.component.tsx
@@ -36,6 +36,7 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
         anomaly,
         getAnomaly,
         status: getAnomalyRequestStatus,
+        errorMessages: anomalyRequestErrors,
     } = useGetAnomaly();
     const {
         evaluation,
@@ -70,17 +71,6 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
     useEffect(() => {
         fetchAlertEvaluation();
     }, [uiAnomaly, searchParams]);
-
-    useEffect(() => {
-        if (getEvaluationRequestStatus === ActionStatus.Error) {
-            notify(
-                NotificationTypeV1.Error,
-                t("message.error-while-fetching", {
-                    entity: t("label.chart-data"),
-                })
-            );
-        }
-    }, [getEvaluationRequestStatus]);
 
     useEffect(() => {
         if (evaluation && anomaly) {
@@ -132,6 +122,21 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
                   );
         }
     }, [errorMessages, getEvaluationRequestStatus]);
+
+    useEffect(() => {
+        if (getAnomalyRequestStatus === ActionStatus.Error) {
+            isEmpty(anomalyRequestErrors)
+                ? notify(
+                      NotificationTypeV1.Error,
+                      t("message.error-while-fetching", {
+                          entity: t("label.anomaly"),
+                      })
+                  )
+                : anomalyRequestErrors.map((msg) =>
+                      notify(NotificationTypeV1.Error, msg)
+                  );
+        }
+    }, [getAnomalyRequestStatus, anomalyRequestErrors]);
 
     return (
         <PageV1>


### PR DESCRIPTION
Error handled for below APIs, In case of API failure will show server errors if any else generic fetch error will be shown

1. getAlert 
2. getAlertTemplate
3. getAlertTemplates
4. getAnomaly
5. getAnomalies
6. getMetricBreakdown
