### PR TITLE
fix(ui): hide loading for emplty anomaly response

### DIFF
--- a/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
@@ -25,14 +25,24 @@ import { SEARCH_TERM_QUERY_PARAM_KEY } from "../../utils/params/params.util";
 export const AnomaliesAllPage: FunctionComponent = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const {
+        anomalies: fetchedAnomalies,
         getAnomalies,
         status: getAnomaliesRequestStatus,
         errorMessages: anomaliesRequestErrors,
     } = useGetAnomalies();
-    const [anomalies, setAnomalies] = useState<Anomaly[] | null>(null);
+
+    // We need internal state to avoid refetch of anomalies after action like delete
+    const [anomalies, setAnomalies] = useState<Anomaly[] | null>(
+        fetchedAnomalies
+    );
     const { showDialog } = useDialog();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
+
+    // Always sync anomalies with fetched one
+    useEffect(() => {
+        setAnomalies(fetchedAnomalies);
+    }, [fetchedAnomalies]);
 
     useEffect(() => {
         // Time range refreshed, fetch anomalies
@@ -55,16 +65,10 @@ export const AnomaliesAllPage: FunctionComponent = () => {
     }, [getAnomaliesRequestStatus, anomalies]);
 
     const fetchAnomaliesByTime = (): void => {
-        setAnomalies(null);
-
         const start = searchParams.get(TimeRangeQueryStringKey.START_TIME);
         const end = searchParams.get(TimeRangeQueryStringKey.END_TIME);
 
-        getAnomalies({ startTime: Number(start), endTime: Number(end) }).then(
-            (anomalies) => {
-                setAnomalies(anomalies ?? []);
-            }
-        );
+        getAnomalies({ startTime: Number(start), endTime: Number(end) });
     };
 
     const handleAnomalyDelete = (anomaly: Anomaly): void => {


### PR DESCRIPTION
### Issue

> Loading goes to infinite-state for empty response

### Fix

> Instead of setting `null`, set it to empty data so that loading indicator will go away

JIRA Ticket: https://cortexdata.atlassian.net/browse/TE-521

<img width="1680" alt="Screenshot 2022-04-06 at 7 55 57 PM" src="https://user-images.githubusercontent.com/12962843/161997800-48399207-a936-461d-87ae-ccd5f56a6f37.png">
