### PR TITLE
chore(ui): remove reference to dev api server

### DIFF
--- a/thirdeye-ui/webpack.config.dev.js
+++ b/thirdeye-ui/webpack.config.dev.js
@@ -120,7 +120,7 @@ module.exports = {
         proxy: [
             {
                 context: "/api",
-                target: "http://23.99.9.151:8080/",
+                target: process.env.TE_DEV_PROXY_SERVER,
                 changeOrigin: true,
             },
         ],


### PR DESCRIPTION
Removing hardcoded server address in favor of `TE_DEV_PROXY_SERVER ` environment variable

https://cortexdata.atlassian.net/browse/TE-514