### PR TITLE
chore(ui): default api proxy server to localhost:8080 if missing

### DIFF
--- a/thirdeye-ui/webpack.config.dev.js
+++ b/thirdeye-ui/webpack.config.dev.js
@@ -120,7 +120,8 @@ module.exports = {
         proxy: [
             {
                 context: "/api",
-                target: process.env.TE_DEV_PROXY_SERVER,
+                target:
+                    process.env.TE_DEV_PROXY_SERVER || "http://localhost:8080/",
                 changeOrigin: true,
             },
         ],


### PR DESCRIPTION
Default to `http://localhost:8080/` is no env is set