### PR TITLE
feat(ui): save last used query search string infrastructure

### DIFF
--- a/thirdeye-ui/src/app/stores/last-used-params/last-used-search-params.interfaces.ts
+++ b/thirdeye-ui/src/app/stores/last-used-params/last-used-search-params.interfaces.ts
@@ -1,0 +1,8 @@
+export interface LastUsedSearchParamsStore {
+    pathsToQueryStrings: {
+        [k: string]: string;
+    };
+    setLastUsedForPath: (path: string, searchString: string) => void;
+    getLastUsedForPath: (path: string) => string | undefined;
+    reset: () => void;
+}

--- a/thirdeye-ui/src/app/stores/last-used-params/last-used-search-params.store.test.ts
+++ b/thirdeye-ui/src/app/stores/last-used-params/last-used-search-params.store.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useLastUsedSearchParams } from "./last-used-search-params.store";
+
+describe("Last Used Search Params Store", () => {
+    // Reset the state after every test
+    afterEach(() => {
+        const { result } = renderHook(() => useLastUsedSearchParams());
+        act(() => result.current.reset());
+    });
+
+    it("should initialize default values", () => {
+        const { result } = renderHook(() => useLastUsedSearchParams());
+
+        expect(result.current.pathsToQueryStrings).toEqual({});
+    });
+
+    it("setLastUsedForPath should update search string for path", () => {
+        const { result } = renderHook(() => useLastUsedSearchParams());
+
+        expect(result.current.pathsToQueryStrings).toEqual({});
+
+        act(() => {
+            result.current.setLastUsedForPath("hello", "world");
+            result.current.setLastUsedForPath("foo", "bar");
+        });
+
+        expect(result.current.pathsToQueryStrings).toEqual({
+            hello: "world",
+            foo: "bar",
+        });
+
+        act(() => {
+            result.current.setLastUsedForPath("hello", "123");
+        });
+
+        expect(result.current.pathsToQueryStrings).toEqual({
+            hello: "123",
+            foo: "bar",
+        });
+    });
+
+    it("setLastUsedForPath should not update if search string is empty", () => {
+        const { result } = renderHook(() => useLastUsedSearchParams());
+
+        expect(result.current.pathsToQueryStrings).toEqual({});
+
+        act(() => {
+            result.current.setLastUsedForPath("hello", "");
+        });
+
+        expect(result.current.pathsToQueryStrings).toEqual({});
+    });
+
+    it("getLastUsedForPath should return undefined if path does not exist", () => {
+        const { result } = renderHook(() => useLastUsedSearchParams());
+
+        expect(result.current.pathsToQueryStrings).toEqual({});
+        expect(result.current.getLastUsedForPath("hello")).toBeUndefined();
+    });
+
+    it("getLastUsedForPath should return correct value if entry exists", () => {
+        const { result } = renderHook(() => useLastUsedSearchParams());
+
+        expect(result.current.pathsToQueryStrings).toEqual({});
+
+        act(() => {
+            result.current.setLastUsedForPath("hello", "world");
+            result.current.setLastUsedForPath("foo", "bar");
+        });
+
+        expect(result.current.getLastUsedForPath("hello")).toEqual("world");
+    });
+});

--- a/thirdeye-ui/src/app/stores/last-used-params/last-used-search-params.store.tsx
+++ b/thirdeye-ui/src/app/stores/last-used-params/last-used-search-params.store.tsx
@@ -1,0 +1,37 @@
+import create from "zustand";
+import { LastUsedSearchParamsStore } from "./last-used-search-params.interfaces";
+
+/**
+ * Simple key value store whose keys are expected to be path names and values
+ * are query search strings "/hello/world": "param1=value1&param2=value2"
+ */
+export const useLastUsedSearchParams = create<LastUsedSearchParamsStore>(
+    (set, get) => ({
+        pathsToQueryStrings: {},
+
+        reset: () => {
+            set({
+                pathsToQueryStrings: {},
+            });
+        },
+
+        setLastUsedForPath: (path: string, searchString: string) => {
+            if (searchString === "") {
+                return;
+            }
+            const { pathsToQueryStrings } = get();
+            set({
+                pathsToQueryStrings: {
+                    ...pathsToQueryStrings,
+                    [path]: searchString,
+                },
+            });
+        },
+
+        getLastUsedForPath: (path: string) => {
+            const { pathsToQueryStrings } = get();
+
+            return pathsToQueryStrings[path];
+        },
+    })
+);

--- a/thirdeye-ui/src/app/utils/routes/redirect-with-default-params/redirect-with-default-params.component.tsx
+++ b/thirdeye-ui/src/app/utils/routes/redirect-with-default-params/redirect-with-default-params.component.tsx
@@ -1,34 +1,59 @@
 import React, { FunctionComponent, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { resolvePath, useLocation, useNavigate } from "react-router-dom";
 import { useTimeRange } from "../../../components/time-range/time-range-provider/time-range-provider.component";
 import { TimeRangeQueryStringKey } from "../../../components/time-range/time-range-provider/time-range-provider.interfaces";
+import { useLastUsedSearchParams } from "../../../stores/last-used-params/last-used-search-params.store";
 import { RedirectWithDefaultParamsProps } from "./redirect-with-default-params.interfaces";
 
 /**
- * Redirects to the given path with the time range parameters in the search params
+ * Redirects to the given path with the time range parameters in the search params.
+ * If useStoredLastUsedParamsPathKey is passed, try to use the last stored search
+ * params for the path if it exists
  *
  * @param {string} to - Path to redirect to
  * @param {boolean} replace - Indicates to replace the history entry with the new path
+ * @param {string} useStoredLastUsedParamsPathKey - [Optional] If passed, use the stored last used
+ * @param {string} pathKeyOverride - [Optional] use this as the key to find in the store
+ * search string if it exists
  */
 export const RedirectWithDefaultParams: FunctionComponent<
     RedirectWithDefaultParamsProps
-> = ({ to, replace = true, children }) => {
+> = ({
+    to,
+    replace = true,
+    children,
+    useStoredLastUsedParamsPathKey,
+    pathKeyOverride,
+}) => {
+    const location = useLocation();
     const navigate = useNavigate();
+    const { getLastUsedForPath } = useLastUsedSearchParams();
     const { timeRangeDuration } = useTimeRange();
-    const timeRangeQuery = new URLSearchParams([
-        [TimeRangeQueryStringKey.TIME_RANGE, timeRangeDuration.timeRange],
-        [
-            TimeRangeQueryStringKey.START_TIME,
-            timeRangeDuration.startTime.toString(),
-        ],
-        [
-            TimeRangeQueryStringKey.END_TIME,
-            timeRangeDuration.endTime.toString(),
-        ],
-    ]);
+    let searchString: string | undefined;
+
+    if (useStoredLastUsedParamsPathKey) {
+        const pathKey =
+            pathKeyOverride || resolvePath(to, location.pathname).pathname;
+        searchString = getLastUsedForPath(pathKey);
+    }
+
+    if (!searchString) {
+        const timeRangeQuery = new URLSearchParams([
+            [TimeRangeQueryStringKey.TIME_RANGE, timeRangeDuration.timeRange],
+            [
+                TimeRangeQueryStringKey.START_TIME,
+                timeRangeDuration.startTime.toString(),
+            ],
+            [
+                TimeRangeQueryStringKey.END_TIME,
+                timeRangeDuration.endTime.toString(),
+            ],
+        ]);
+        searchString = timeRangeQuery.toString();
+    }
 
     useEffect(() => {
-        navigate(`${to}?${timeRangeQuery.toString()}`, { replace });
+        navigate(`${to}?${searchString}`, { replace });
     });
 
     return <>{children}</>;

--- a/thirdeye-ui/src/app/utils/routes/redirect-with-default-params/redirect-with-default-params.interfaces.ts
+++ b/thirdeye-ui/src/app/utils/routes/redirect-with-default-params/redirect-with-default-params.interfaces.ts
@@ -1,4 +1,6 @@
 export interface RedirectWithDefaultParamsProps {
     to: string;
     replace?: boolean;
+    useStoredLastUsedParamsPathKey?: boolean;
+    pathKeyOverride?: string;
 }

--- a/thirdeye-ui/src/app/utils/routes/save-last-used-search-params/save-last-used-search-params.component.tsx
+++ b/thirdeye-ui/src/app/utils/routes/save-last-used-search-params/save-last-used-search-params.component.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent, useEffect } from "react";
+import { useLocation, useSearchParams } from "react-router-dom";
+import { useLastUsedSearchParams } from "../../../stores/last-used-params/last-used-search-params.store";
+import { SaveLastUsedSearchParamsProps } from "./save-last-used-search-params.interfaces";
+
+/**
+ * Determine the key to use for the search query string by either using the
+ * provided `pathKeyOverride` value or the location's pathname property
+ *
+ * @param pathKeyOverride - Use this value as the key if provided
+ */
+export const SaveLastUsedSearchParams: FunctionComponent<
+    SaveLastUsedSearchParamsProps
+> = ({ pathKeyOverride, children }) => {
+    const location = useLocation();
+    const { setLastUsedForPath } = useLastUsedSearchParams();
+    const [searchParams] = useSearchParams();
+    const pathKey = pathKeyOverride || location.pathname;
+
+    useEffect(() => {
+        setLastUsedForPath(pathKey, searchParams.toString());
+    }, [searchParams]);
+
+    return <>{children}</>;
+};

--- a/thirdeye-ui/src/app/utils/routes/save-last-used-search-params/save-last-used-search-params.interfaces.ts
+++ b/thirdeye-ui/src/app/utils/routes/save-last-used-search-params/save-last-used-search-params.interfaces.ts
@@ -1,0 +1,3 @@
+export interface SaveLastUsedSearchParamsProps {
+    pathKeyOverride?: string;
+}


### PR DESCRIPTION
# Summary
Adding infrastructure to enable saving the last used query search string in the url for a page via simply adding the right util components in the route definition

# Examples

Expected usage is like so:

## Example 1
```tsx
<Route
      element={<Outlet />}
      path={`${AppRouteRelative.ALERTS_ALERT}/*`}
  >
      <Route
          index
          element={
              <RedirectWithDefaultParams
                  useStoredLastUsedParamsPathKey
                  to={AppRouteRelative.ALERTS_VIEW}
              />
          }
      />

      <Route
          element={
              <RedirectValidation
                  queryParams={[
                      "timeRange",
                      "startTime",
                      "endTime",
                  ]}
                  to=".."
              >
                  <SaveLastUsedSearchParams>
                      <AlertsViewPage />
                  </SaveLastUsedSearchParams>
              </RedirectValidation>
          }
          path={AppRouteRelative.ALERTS_VIEW}
      />
</Route>
```

## Example 2
```tsx
<Route path={AppRouteRelative.ANOMALIES_ALL}>
    <Route
        index
        element={
            <RedirectWithDefaultParams
                replace
                useStoredLastUsedParamsPathKey
                pathKeyOverride={AppRoute.ANOMALIES_ALL_RANGE}
                to={AppRouteRelative.ANOMALIES_ALL_RANGE}
            />
        }
    />
    <Route
        element={
            <RedirectValidation
                queryParams={[
                    TimeRangeQueryStringKey.TIME_RANGE,
                    TimeRangeQueryStringKey.START_TIME,
                    TimeRangeQueryStringKey.END_TIME,
                ]}
                to=".."
            >
                <SaveLastUsedSearchParams>
                    <AnomaliesAllPage />
                </SaveLastUsedSearchParams>
            </RedirectValidation>
        }
        path={AppRouteRelative.ANOMALIES_ALL_RANGE}
    />
</Route>
```