### PR TITLE
chore(ui): use dialogProviderV1

### DIFF
--- a/thirdeye-ui/src/app/components/anomlay-feedback/anomaly-feedback.component.tsx
+++ b/thirdeye-ui/src/app/components/anomlay-feedback/anomaly-feedback.component.tsx
@@ -13,13 +13,13 @@ import React, { FunctionComponent, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
     NotificationTypeV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { updateAnomalyFeedback } from "../../rest/anomalies/anomalies.rest";
 import { AnomalyFeedbackType } from "../../rest/dto/anomaly.interfaces";
 import { getErrorMessages } from "../../utils/rest/rest.util";
-import { useDialog } from "../dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../dialogs/dialog-provider/dialog-provider.interfaces";
 import { AnomalyFeedbackProps } from "./anomaly-feedback.interfaces";
 
 const OPTION_TO_DESCRIPTIONS = {
@@ -43,7 +43,7 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
         anomalyFeedback.comment
     );
     const [updateHasError, setUpdateHasError] = useState(false);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { notify } = useNotificationProviderV1();
     const { t } = useTranslation();
     /*
@@ -64,10 +64,11 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
         ) {
             showDialog({
                 type: DialogType.ALERT,
-                text: t("message.change-confirmation-to", {
+                contents: t("message.change-confirmation-to", {
                     value: `"${OPTION_TO_DESCRIPTIONS[newSelectedFeedbackType]}"`,
                 }),
-                okButtonLabel: t("label.change"),
+                okButtonText: t("label.change"),
+                cancelButtonText: t("label.cancel"),
                 onOk: () =>
                     handleFeedbackChangeOk(
                         newSelectedFeedbackType,
@@ -80,8 +81,11 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
     const handleCommentUpdateClick = (): void => {
         showDialog({
             type: DialogType.CUSTOM,
-            title: t("label.update-entity", { entity: t("label.comment") }),
-            children: (
+            headerText: t("label.update-entity", {
+                entity: t("label.comment"),
+            }),
+            cancelButtonText: t("label.cancel"),
+            contents: (
                 <>
                     {updateHasError && (
                         <Box
@@ -102,7 +106,7 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
                     />
                 </>
             ),
-            okButtonLabel: t("label.change"),
+            okButtonText: t("label.change"),
             onOk: () =>
                 handleFeedbackChangeOk(
                     currentlySelected,

--- a/thirdeye-ui/src/app/index.tsx
+++ b/thirdeye-ui/src/app/index.tsx
@@ -4,13 +4,13 @@ import React, { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./app";
-import { DialogProvider } from "./components/dialogs/dialog-provider/dialog-provider.component";
 import { TimeRangeProvider } from "./components/time-range/time-range-provider/time-range-provider.component";
 import "./platform/assets/styles/fonts.scss";
 import "./platform/assets/styles/layout.scss";
 import {
     AuthProviderV1,
     AuthRedirectMethodV1,
+    DialogProviderV1,
     NotificationProviderV1,
 } from "./platform/components";
 import { lightV1 } from "./platform/utils";
@@ -45,9 +45,9 @@ ReactDOM.render(
                         ]}
                     >
                         <TimeRangeProvider>
-                            <DialogProvider>
+                            <DialogProviderV1>
                                 <App />
-                            </DialogProvider>
+                            </DialogProviderV1>
                         </TimeRangeProvider>
                     </AuthProviderV1>
                 </NotificationProviderV1>

--- a/thirdeye-ui/src/app/pages/alert-templates-all-page/alert-templates-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alert-templates-all-page/alert-templates-all-page.component.tsx
@@ -4,14 +4,14 @@ import React, { FunctionComponent, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTemplateListV1 } from "../../components/alert-template-list-v1/alert-template-list-v1.component";
 import { ConfigurationPageHeader } from "../../components/configuration-page-header/configuration-page-header.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { ActionStatus } from "../../platform/rest/actions.interfaces";
 import { useGetAlertTemplates } from "../../rest/alert-templates/alert-templates.actions";
 import {
@@ -22,7 +22,7 @@ import { AlertTemplate } from "../../rest/dto/alert-template.interfaces";
 import { getErrorMessages } from "../../utils/rest/rest.util";
 
 export const AlertTemplatesAllPage: FunctionComponent = () => {
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
     const {
@@ -59,10 +59,11 @@ export const AlertTemplatesAllPage: FunctionComponent = () => {
     const handleAlertTemplateDelete = (alertTemplate: AlertTemplate): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", {
+            contents: t("message.delete-confirmation", {
                 name: alertTemplate.name,
             }),
-            okButtonLabel: t("label.delete"),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleAlertTemplateDeleteOk(alertTemplate),
         });
     };

--- a/thirdeye-ui/src/app/pages/alert-templates-view-page/alert-templates-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alert-templates-view-page/alert-templates-view-page.component.tsx
@@ -17,8 +17,6 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { NoDataIndicator } from "../../components/no-data-indicator/no-data-indicator.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import {
@@ -27,8 +25,10 @@ import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { ActionStatus } from "../../rest/actions.interfaces";
 import { useGetAlertTemplate } from "../../rest/alert-templates/alert-templates.actions";
 import { deleteAlertTemplate } from "../../rest/alert-templates/alert-templates.rest";
@@ -40,7 +40,7 @@ import {
 import { AlertsTemplatesViewPageParams } from "./alert-templates-view-page.interfaces";
 
 export const AlertTemplatesViewPage: FunctionComponent = () => {
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const {
         alertTemplate,
         getAlertTemplate,
@@ -97,10 +97,11 @@ export const AlertTemplatesViewPage: FunctionComponent = () => {
         alertTemplate &&
             showDialog({
                 type: DialogType.ALERT,
-                text: t("message.delete-confirmation", {
+                contents: t("message.delete-confirmation", {
                     name: alertTemplate.name,
                 }),
-                okButtonLabel: t("label.delete"),
+                okButtonText: t("label.delete"),
+                cancelButtonText: t("label.cancel"),
                 onOk: () => handleAlertTemplateDeleteOk(alertTemplate),
             });
     };

--- a/thirdeye-ui/src/app/pages/alerts-all-page/alerts-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-all-page/alerts-all-page.component.tsx
@@ -3,15 +3,15 @@ import { isEmpty } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertListV1 } from "../../components/alert-list-v1/alert-list-v1.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import {
     deleteAlert,
     getAllAlerts,
@@ -30,7 +30,7 @@ export const AlertsAllPage: FunctionComponent = () => {
     const [subscriptionGroups, setSubscriptionGroups] = useState<
         SubscriptionGroup[]
     >([]);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
 
@@ -114,8 +114,11 @@ export const AlertsAllPage: FunctionComponent = () => {
     const handleAlertDelete = (uiAlert: UiAlert): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiAlert.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiAlert.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleAlertDeleteOk(uiAlert),
         });
     };

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -4,8 +4,6 @@ import { isEmpty, toNumber } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { AlertCard } from "../../components/entity-cards/alert-card/alert-card.component";
 import { NoDataIndicator } from "../../components/no-data-indicator/no-data-indicator.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
@@ -17,8 +15,10 @@ import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { ActionStatus } from "../../rest/actions.interfaces";
 import { useGetEvaluation } from "../../rest/alerts/alerts.actions";
 import {
@@ -65,7 +65,7 @@ export const AlertsViewPage: FunctionComponent = () => {
     const [alertEvaluation, setAlertEvaluation] =
         useState<AlertEvaluation | null>(null);
     const [searchParams] = useSearchParams();
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { id: alertId } = useParams<AlertsViewPageParams>();
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -219,8 +219,11 @@ export const AlertsViewPage: FunctionComponent = () => {
         }
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiAlert.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiAlert.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleAlertDeleteOk(uiAlert),
         });
     };

--- a/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
@@ -4,8 +4,6 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import { AnomalyListV1 } from "../../components/anomaly-list-v1/anomaly-list-v1.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import { TimeRangeQueryStringKey } from "../../components/time-range/time-range-provider/time-range-provider.interfaces";
 import {
@@ -15,8 +13,10 @@ import {
     PageContentsGridV1,
     PageV1,
     TooltipV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { ActionStatus } from "../../rest/actions.interfaces";
 import { deleteAnomaly } from "../../rest/anomalies/anomalies.rest";
 import { useGetAnomalies } from "../../rest/anomalies/anomaly.actions";
@@ -33,7 +33,7 @@ export const AnomaliesAllPage: FunctionComponent = () => {
         status: getAnomaliesRequestStatus,
         errorMessages: anomaliesRequestErrors,
     } = useGetAnomalies();
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
 
@@ -76,8 +76,11 @@ export const AnomaliesAllPage: FunctionComponent = () => {
     const handleAnomalyDelete = (uiAnomaly: UiAnomaly): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiAnomaly.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiAnomaly.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleAnomalyDeleteOk(uiAnomaly),
         });
     };

--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
@@ -4,8 +4,6 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { AnomalyFeedback } from "../../components/anomlay-feedback/anomaly-feedback.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { AnomalyCard } from "../../components/entity-cards/anomaly-card/anomaly-card.component";
 import { NoDataIndicator } from "../../components/no-data-indicator/no-data-indicator.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
@@ -18,8 +16,10 @@ import {
     PageContentsGridV1,
     PageV1,
     TooltipV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { ActionStatus } from "../../rest/actions.interfaces";
 import { useGetEvaluation } from "../../rest/alerts/alerts.actions";
 import { deleteAnomaly } from "../../rest/anomalies/anomalies.rest";
@@ -53,7 +53,7 @@ export const AnomaliesViewPage: FunctionComponent = () => {
     const [alertEvaluation, setAlertEvaluation] =
         useState<AlertEvaluation | null>(null);
     const [searchParams] = useSearchParams();
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { id: anomalyId } = useParams<AnomaliesViewPageParams>();
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -132,8 +132,11 @@ export const AnomaliesViewPage: FunctionComponent = () => {
     const handleAnomalyDelete = (uiAnomaly: UiAnomaly): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiAnomaly.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiAnomaly.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleAnomalyDeleteOk(uiAnomaly),
         });
     };

--- a/thirdeye-ui/src/app/pages/datasets-all-page/datasets-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/datasets-all-page/datasets-all-page.component.tsx
@@ -4,14 +4,14 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConfigurationPageHeader } from "../../components/configuration-page-header/configuration-page-header.component";
 import { DatasetListV1 } from "../../components/dataset-list-v1/dataset-list-v1.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import {
     deleteDataset,
     getAllDatasets,
@@ -23,7 +23,7 @@ import { getErrorMessages } from "../../utils/rest/rest.util";
 
 export const DatasetsAllPage: FunctionComponent = () => {
     const [uiDatasets, setUiDatasets] = useState<UiDataset[] | null>(null);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
 
@@ -60,8 +60,11 @@ export const DatasetsAllPage: FunctionComponent = () => {
     const handleDatasetDelete = (uiDataset: UiDataset): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiDataset.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiDataset.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleDatasetDeleteOk(uiDataset),
         });
     };

--- a/thirdeye-ui/src/app/pages/datasets-view-page/datasets-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/datasets-view-page/datasets-view-page.component.tsx
@@ -4,16 +4,16 @@ import { isEmpty, toNumber } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { DatasetCard } from "../../components/entity-cards/dataset-card/dataset-card.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { deleteDataset, getDataset } from "../../rest/datasets/datasets.rest";
 import { UiDataset } from "../../rest/dto/ui-dataset.interfaces";
 import { getUiDataset } from "../../utils/datasets/datasets.util";
@@ -27,7 +27,7 @@ import { DatasetsViewPageParams } from "./dataset-view-page.interfaces";
 
 export const DatasetsViewPage: FunctionComponent = () => {
     const [uiDataset, setUiDataset] = useState<UiDataset | null>(null);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const params = useParams<DatasetsViewPageParams>();
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -81,8 +81,11 @@ export const DatasetsViewPage: FunctionComponent = () => {
     const handleDatasetDelete = (uiDataset: UiDataset): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiDataset.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiDataset.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleDatasetDeleteOk(uiDataset),
         });
     };

--- a/thirdeye-ui/src/app/pages/datasources-all-page/datasources-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/datasources-all-page/datasources-all-page.component.tsx
@@ -4,14 +4,14 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConfigurationPageHeader } from "../../components/configuration-page-header/configuration-page-header.component";
 import { DatasourceListV1 } from "../../components/datasource-list-v1/datasource-list-v1.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import {
     deleteDatasource,
     getAllDatasources,
@@ -25,7 +25,7 @@ export const DatasourcesAllPage: FunctionComponent = () => {
     const [uiDatasources, setUiDatasources] = useState<UiDatasource[] | null>(
         null
     );
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
 
@@ -64,8 +64,11 @@ export const DatasourcesAllPage: FunctionComponent = () => {
     const handleDatasourceDelete = (uiDatasource: UiDatasource): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiDatasource.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiDatasource.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleDatasourceDeleteOk(uiDatasource),
         });
     };

--- a/thirdeye-ui/src/app/pages/datasources-view-page/datasources-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/datasources-view-page/datasources-view-page.component.tsx
@@ -4,8 +4,6 @@ import { isEmpty, toNumber } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { DatasourceCard } from "../../components/entity-cards/datasource-card/datasource-card.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import {
@@ -13,8 +11,10 @@ import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import {
     deleteDatasource,
     getDatasource,
@@ -29,7 +29,7 @@ import { DatasourcesViewPageParams } from "./datasources-view-page.interfaces";
 
 export const DatasourcesViewPage: FunctionComponent = () => {
     const [uiDatasource, setUiDatasource] = useState<UiDatasource | null>(null);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const params = useParams<DatasourcesViewPageParams>();
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -85,8 +85,11 @@ export const DatasourcesViewPage: FunctionComponent = () => {
     const handleDatasourceDelete = (uiDatasource: UiDatasource): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiDatasource.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiDatasource.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleDatasourceDeleteOk(uiDatasource),
         });
     };

--- a/thirdeye-ui/src/app/pages/metrics-all-page/metrics-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/metrics-all-page/metrics-all-page.component.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConfigurationPageHeader } from "../../components/configuration-page-header/configuration-page-header.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { MetricListV1 } from "../../components/metric-list-v1/metric-list-v1.component";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { Metric } from "../../rest/dto/metric.interfaces";
 import { UiMetric } from "../../rest/dto/ui-metric.interfaces";
 import { deleteMetric, getAllMetrics } from "../../rest/metrics/metrics.rest";
@@ -17,7 +17,7 @@ import { getUiMetrics } from "../../utils/metrics/metrics.util";
 
 export const MetricsAllPage: FunctionComponent = () => {
     const [uiMetrics, setUiMetrics] = useState<UiMetric[] | null>(null);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
 
@@ -40,8 +40,11 @@ export const MetricsAllPage: FunctionComponent = () => {
     const handleMetricDelete = (uiMetric: UiMetric): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiMetric.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiMetric.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleMetricDeleteOk(uiMetric),
         });
     };

--- a/thirdeye-ui/src/app/pages/metrics-view-page/metrics-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/metrics-view-page/metrics-view-page.component.tsx
@@ -3,16 +3,16 @@ import { toNumber } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { MetricCard } from "../../components/entity-cards/metric-card/metric-card.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { UiMetric } from "../../rest/dto/ui-metric.interfaces";
 import { deleteMetric, getMetric } from "../../rest/metrics/metrics.rest";
 import { getUiMetric } from "../../utils/metrics/metrics.util";
@@ -26,7 +26,7 @@ import { MetricsViewPageParams } from "./metrics-view-page.interfaces";
 export const MetricsViewPage: FunctionComponent = () => {
     const [uiMetric, setUiMetric] = useState<UiMetric | null>(null);
 
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const params = useParams<MetricsViewPageParams>();
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -66,8 +66,11 @@ export const MetricsViewPage: FunctionComponent = () => {
     const handleMetricDelete = (uiMetric: UiMetric): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", { name: uiMetric.name }),
-            okButtonLabel: t("label.delete"),
+            contents: t("message.delete-confirmation", {
+                name: uiMetric.name,
+            }),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleMetricDeleteOk(uiMetric),
         });
     };

--- a/thirdeye-ui/src/app/pages/subscription-groups-all-page/subscription-groups-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/subscription-groups-all-page/subscription-groups-all-page.component.tsx
@@ -3,15 +3,15 @@ import { isEmpty } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConfigurationPageHeader } from "../../components/configuration-page-header/configuration-page-header.component";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { SubscriptionGroupListV1 } from "../../components/subscription-group-list-v1/subscription-group-list-v1.component";
 import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { getAllAlerts } from "../../rest/alerts/alerts.rest";
 import { Alert } from "../../rest/dto/alert.interfaces";
 import { SubscriptionGroup } from "../../rest/dto/subscription-group.interfaces";
@@ -28,7 +28,7 @@ export const SubscriptionGroupsAllPage: FunctionComponent = () => {
     const [uiSubscriptionGroups, setUiSubscriptionGroups] = useState<
         UiSubscriptionGroup[] | null
     >(null);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
 
@@ -95,10 +95,11 @@ export const SubscriptionGroupsAllPage: FunctionComponent = () => {
     ): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", {
+            contents: t("message.delete-confirmation", {
                 name: uiSubscriptionGroup.name,
             }),
-            okButtonLabel: t("label.delete"),
+            okButtonText: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
             onOk: () => handleSubscriptionGroupDeleteOk(uiSubscriptionGroup),
         });
     };

--- a/thirdeye-ui/src/app/pages/subscription-groups-view-page/subscription-groups-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/subscription-groups-view-page/subscription-groups-view-page.component.tsx
@@ -4,8 +4,6 @@ import { cloneDeep, isEmpty, toNumber } from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
-import { useDialog } from "../../components/dialogs/dialog-provider/dialog-provider.component";
-import { DialogType } from "../../components/dialogs/dialog-provider/dialog-provider.interfaces";
 import { SubscriptionGroupCard } from "../../components/entity-cards/subscription-group-card/subscription-group-card.component";
 import { PageHeader } from "../../components/page-header/page-header.component";
 import { SubscriptionGroupAlertsAccordian } from "../../components/subscription-group-alerts-accordian/subscription-group-alerts-accordian.component";
@@ -14,8 +12,10 @@ import {
     NotificationTypeV1,
     PageContentsGridV1,
     PageV1,
+    useDialogProviderV1,
     useNotificationProviderV1,
 } from "../../platform/components";
+import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { getAllAlerts } from "../../rest/alerts/alerts.rest";
 import { Alert } from "../../rest/dto/alert.interfaces";
 import {
@@ -39,7 +39,7 @@ export const SubscriptionGroupsViewPage: FunctionComponent = () => {
     const [uiSubscriptionGroup, setUiSubscriptionGroup] =
         useState<UiSubscriptionGroup | null>(null);
     const [alerts, setAlerts] = useState<Alert[]>([]);
-    const { showDialog } = useDialog();
+    const { showDialog } = useDialogProviderV1();
     const params = useParams<SubscriptionGroupsViewPageParams>();
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -128,10 +128,11 @@ export const SubscriptionGroupsViewPage: FunctionComponent = () => {
     ): void => {
         showDialog({
             type: DialogType.ALERT,
-            text: t("message.delete-confirmation", {
+            contents: t("message.delete-confirmation", {
                 name: uiSubscriptionGroup.name,
             }),
-            okButtonLabel: t("label.delete"),
+            cancelButtonText: t("label.cancel"),
+            okButtonText: t("label.delete"),
             onOk: () => handleSubscriptionGroupDeleteOk(uiSubscriptionGroup),
         });
     };

--- a/thirdeye-ui/src/app/platform/components/dialog-provider-v1/dialog-provider-v1.component.tsx
+++ b/thirdeye-ui/src/app/platform/components/dialog-provider-v1/dialog-provider-v1.component.tsx
@@ -5,6 +5,7 @@ import {
     Dialog,
     DialogActions,
     DialogContent,
+    DialogContentText,
     DialogTitle,
 } from "@material-ui/core";
 import classNames from "classnames";
@@ -15,6 +16,7 @@ import {
     DialogDataV1,
     DialogProviderV1ContextProps,
     DialogProviderV1Props,
+    DialogType,
 } from "./dialog-provider-v1.interfaces";
 
 export const DialogProviderV1: FunctionComponent<DialogProviderV1Props> = ({
@@ -105,13 +107,19 @@ export const DialogProviderV1: FunctionComponent<DialogProviderV1Props> = ({
                         <>
                             {/* Custom contents */}
                             {dialogData.customContents && (
-                                <>{dialogData.contents}</>
+                                <>{dialogData.customContents}</>
                             )}
 
                             {/* Default contents */}
                             {!dialogData.customContents && (
-                                <DialogContent className="dialog-provider-v1-contents">
-                                    {dialogData.contents}
+                                <DialogContent>
+                                    {dialogData.type === DialogType.ALERT ? (
+                                        <DialogContentText>
+                                            {dialogData.contents}
+                                        </DialogContentText>
+                                    ) : (
+                                        dialogData.contents
+                                    )}
                                 </DialogContent>
                             )}
                         </>

--- a/thirdeye-ui/src/app/platform/components/dialog-provider-v1/dialog-provider-v1.interfaces.ts
+++ b/thirdeye-ui/src/app/platform/components/dialog-provider-v1/dialog-provider-v1.interfaces.ts
@@ -2,6 +2,11 @@
 // All rights reserved. Confidential and proprietary information of StarTree Inc.
 import { ReactNode } from "react";
 
+export enum DialogType {
+    ALERT = "ALERT",
+    CUSTOM = "CUSTOM",
+}
+
 export interface DialogProviderV1Props {
     className?: string;
     children?: ReactNode;
@@ -16,6 +21,7 @@ export interface DialogProviderV1ContextProps {
 export interface DialogDataV1 {
     width?: "xs" | "sm" | "md" | "lg" | "xl";
     headerText?: string;
+    type: DialogType;
     contents?: ReactNode;
     customContents?: boolean;
     hideOkButton?: boolean;


### PR DESCRIPTION
### Changes

1. Replace `DialogProvider` with `DialogProviderV1` to eliminate redundant code from the repo
2. Fix typo at `DailogProviderV1` for `customContents`
3. Introduce `DailogType` for `DialogProviderV1`

There will be no UI changes as it's just component changes

Alert dialog:

<img width="552" alt="Screenshot 2022-04-20 at 8 17 10 PM" src="https://user-images.githubusercontent.com/12962843/164257895-397245e8-0b6c-4f43-9b6d-af5a855f16fc.png">

Custom dialog

<img width="528" alt="Screenshot 2022-04-20 at 8 17 23 PM" src="https://user-images.githubusercontent.com/12962843/164257936-ce1e280c-9263-4bc3-8292-f6cc7faa1abd.png">

