### PR TITLE
feat(ui): tooltip support areaclosed and take on color override

### DIFF
--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/chart-core/chart-core.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/chart-core/chart-core.component.tsx
@@ -134,7 +134,7 @@ export const ChartCore: FunctionComponent<ChartCoreProps> = ({
                                 data={seriesData.data}
                                 key={seriesData.name || `${idx}`}
                                 stroke={color}
-                                strokeWidth={1}
+                                strokeWidth={seriesData.strokeWidth}
                                 x={(d) =>
                                     xScaleToUse(seriesData.xAccessor(d)) || 0
                                 }

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/legend/legend.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/legend/legend.component.tsx
@@ -1,10 +1,9 @@
+import { Grid } from "@material-ui/core";
 import { LegendItem, LegendLabel, LegendOrdinal } from "@visx/legend";
 import React, { FunctionComponent } from "react";
 import { LegendProps } from "./legend.interfaces";
 
 const LEGEND_CONTAINER_STYLE = {
-    justifyContent: "space-evenly",
-    display: "flex",
     cursor: "pointer",
 };
 const RECT_HEIGHT_WIDTH = 15;
@@ -21,40 +20,54 @@ export const Legend: FunctionComponent<LegendProps> = ({
     return (
         <LegendOrdinal scale={colorScale}>
             {(labels) => (
-                <div style={LEGEND_CONTAINER_STYLE}>
+                <Grid container justifyContent="center">
                     {labels.map((label, idx) => {
                         let color = label.value;
 
-                        if (series[idx].color !== undefined) {
+                        /**
+                         * colorScale is updated before the processed series
+                         * in the parent so check for existence of series for index
+                         *
+                         * colorScale cannot be stored in state since its a complicated
+                         * object with functions
+                         */
+                        if (series[idx] && series[idx].color !== undefined) {
                             color = series[idx].color;
                         }
 
-                        if (!series[idx].enabled) {
+                        /**
+                         * colorScale is updated before the processed series
+                         * in the parent so check for existence of series for index
+                         */
+                        if (series[idx] && !series[idx].enabled) {
                             color = "#EEE";
                         }
 
                         return (
-                            <LegendItem
+                            <Grid
+                                item
                                 key={`legend-item-${idx}`}
-                                onClick={() => handleOnClick(idx)}
+                                style={LEGEND_CONTAINER_STYLE}
                             >
-                                <svg
-                                    height={RECT_HEIGHT_WIDTH}
-                                    width={RECT_HEIGHT_WIDTH}
-                                >
-                                    <rect
-                                        fill={color}
+                                <LegendItem onClick={() => handleOnClick(idx)}>
+                                    <svg
                                         height={RECT_HEIGHT_WIDTH}
                                         width={RECT_HEIGHT_WIDTH}
-                                    />
-                                </svg>
-                                <LegendLabel align="left" margin="0 0 0 5px">
-                                    {label.text}
-                                </LegendLabel>
-                            </LegendItem>
+                                    >
+                                        <rect
+                                            fill={color}
+                                            height={RECT_HEIGHT_WIDTH}
+                                            width={RECT_HEIGHT_WIDTH}
+                                        />
+                                    </svg>
+                                    <LegendLabel align="left" margin="0 5px">
+                                        {label.text}
+                                    </LegendLabel>
+                                </LegendItem>
+                            </Grid>
                         );
                     })}
-                </div>
+                </Grid>
             )}
         </LegendOrdinal>
     );

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -17,7 +17,7 @@ import {
 import { TooltipMarkers } from "./tooltip/tooltip-markers.component";
 import { TooltipPopover } from "./tooltip/tooltip-popover.component";
 
-const TOP_CHART_HEIGHT_RATIO = 0.8;
+const TOP_CHART_HEIGHT_RATIO = 0.85;
 const CHART_SEPARATION = 50;
 const CHART_MARGINS = {
     top: 20,
@@ -130,7 +130,7 @@ export const TimeSeriesChartInternal: FunctionComponent<
 
     if (brush) {
         topChartBottomMargin = isXAxisEnabled
-            ? CHART_SEPARATION / 2
+            ? CHART_SEPARATION
             : CHART_SEPARATION + 10;
         topChartHeight =
             TOP_CHART_HEIGHT_RATIO * innerHeight - topChartBottomMargin;

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.interfaces.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.interfaces.ts
@@ -13,9 +13,15 @@ export interface Series {
     type?: SeriesType;
     color?: string;
     enabled?: boolean;
+    strokeWidth?: number;
     xAccessor?: (d: DataPoint | ThresholdDataPoint) => Date;
     yAccessor?: (d: DataPoint | ThresholdDataPoint) => number;
     y1Accessor?: (d: ThresholdDataPoint) => number;
+    tooltipValueFormatter?: (
+        value: number,
+        d: DataPoint | ThresholdDataPoint,
+        series: NormalizedSeries
+    ) => string;
 }
 
 export interface NormalizedSeries {
@@ -24,9 +30,15 @@ export interface NormalizedSeries {
     type: SeriesType;
     color?: string;
     enabled: boolean;
+    strokeWidth: number;
     xAccessor: (d: DataPoint | ThresholdDataPoint) => Date;
     yAccessor: (d: DataPoint | ThresholdDataPoint) => number;
     y1Accessor: (d: ThresholdDataPoint) => number;
+    tooltipValueFormatter: (
+        value: number,
+        d: DataPoint | ThresholdDataPoint,
+        series: NormalizedSeries
+    ) => string;
 }
 
 export interface PlotBand {

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.test.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.test.ts
@@ -1,5 +1,6 @@
 import { SeriesType } from "./time-series-chart.interfaces";
 import {
+    defaultTooltipValueFormatter,
     defaultXAccessor,
     defaultY1Accessor,
     defaultYAccessor,
@@ -85,6 +86,8 @@ describe("Time Series Chart Utils", () => {
             xAccessor: defaultXAccessor,
             yAccessor: defaultYAccessor,
             y1Accessor: defaultY1Accessor,
+            strokeWidth: 1,
+            tooltipValueFormatter: defaultTooltipValueFormatter,
         });
         expect(result[1]).toEqual({
             data: [],
@@ -94,6 +97,8 @@ describe("Time Series Chart Utils", () => {
             xAccessor: defaultXAccessor,
             yAccessor: defaultYAccessor,
             y1Accessor: defaultY1Accessor,
+            strokeWidth: 1,
+            tooltipValueFormatter: defaultTooltipValueFormatter,
         });
     });
 });

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.ts
@@ -45,6 +45,7 @@ export function normalizeSeries(series: Series[]): NormalizedSeries[] {
             name: item.name || `Series ${idx}`,
             enabled: item.enabled === undefined ? true : item.enabled,
             type: item.type === undefined ? DEFAULT_CHART_TYPE : item.type,
+            strokeWidth: item.strokeWidth === undefined ? 1 : item.strokeWidth,
             xAccessor:
                 item.xAccessor === undefined
                     ? defaultXAccessor
@@ -57,6 +58,10 @@ export function normalizeSeries(series: Series[]): NormalizedSeries[] {
                 item.y1Accessor === undefined
                     ? defaultY1Accessor
                     : item.y1Accessor,
+            tooltipValueFormatter:
+                item.tooltipValueFormatter === undefined
+                    ? defaultTooltipValueFormatter
+                    : item.tooltipValueFormatter,
         };
     });
 }
@@ -75,4 +80,8 @@ export const defaultYAccessor = (d: DataPoint | ThresholdDataPoint): number => {
 
 export const defaultY1Accessor = (d: ThresholdDataPoint): number => {
     return d.y1;
+};
+
+export const defaultTooltipValueFormatter = (value: number): string => {
+    return value.toString();
 };

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-markers.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-markers.component.tsx
@@ -1,6 +1,11 @@
 import { Line } from "@visx/shape";
 import React, { FunctionComponent } from "react";
-import { DataPoint, Series } from "../time-series-chart.interfaces";
+import {
+    DataPoint,
+    NormalizedSeries,
+    SeriesType,
+    ThresholdDataPoint,
+} from "../time-series-chart.interfaces";
 import { TooltipMarkersProps } from "./tooltip.interfaces";
 import { getDataPointsInSeriesForXValue } from "./tooltip.utils";
 
@@ -14,7 +19,7 @@ export const TooltipMarkers: FunctionComponent<TooltipMarkersProps> = ({
     xValue,
     colorScale,
 }) => {
-    const dataPointForXValue: [DataPoint, Series][] =
+    const dataPointForXValue: [DataPoint, NormalizedSeries][] =
         getDataPointsInSeriesForXValue(series, xValue);
 
     return (
@@ -33,6 +38,11 @@ export const TooltipMarkers: FunctionComponent<TooltipMarkersProps> = ({
             />
 
             {dataPointForXValue.map(([dataPoint, seriesData]) => {
+                const color =
+                    seriesData.color === undefined
+                        ? colorScale(seriesData.name as string)
+                        : seriesData.color;
+
                 return (
                     <>
                         <circle
@@ -49,12 +59,42 @@ export const TooltipMarkers: FunctionComponent<TooltipMarkersProps> = ({
                         <circle
                             cx={xScale(xValue)}
                             cy={yScale(dataPoint.y)}
-                            fill={colorScale(seriesData.name as string)}
+                            fill={color}
                             pointerEvents="none"
                             r={4}
                             stroke="white"
                             strokeWidth={2}
                         />
+                        {seriesData.type === SeriesType.AREA_CLOSED && (
+                            <>
+                                <circle
+                                    cx={xScale(xValue)}
+                                    cy={
+                                        (yScale(
+                                            (dataPoint as ThresholdDataPoint).y1
+                                        ) as number) + 1
+                                    }
+                                    fill="black"
+                                    fillOpacity={0.1}
+                                    pointerEvents="none"
+                                    r={4}
+                                    stroke="black"
+                                    strokeOpacity={0.1}
+                                    strokeWidth={2}
+                                />
+                                <circle
+                                    cx={xScale(xValue)}
+                                    cy={yScale(
+                                        (dataPoint as ThresholdDataPoint).y1
+                                    )}
+                                    fill={color}
+                                    pointerEvents="none"
+                                    r={4}
+                                    stroke="white"
+                                    strokeWidth={2}
+                                />
+                            </>
+                        )}
                     </>
                 );
             })}

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-popover.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-popover.component.tsx
@@ -2,7 +2,12 @@ import { Grid, Typography } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
 import { formatDateAndTimeV1 } from "../../../../platform/utils";
 import { useAlertEvaluationTimeSeriesTooltipStyles } from "../../alert-evaluation-time-series/alert-evaluation-time-series-tooltip/alert-evaluation-time-series-tooltip.styles";
-import { DataPoint, Series } from "../time-series-chart.interfaces";
+import {
+    DataPoint,
+    NormalizedSeries,
+    SeriesType,
+    ThresholdDataPoint,
+} from "../time-series-chart.interfaces";
 import { TooltipPopoverProps } from "./tooltip.interfaces";
 import { useTooltipStyles } from "./tooltip.styles";
 import { getDataPointsInSeriesForXValue } from "./tooltip.utils";
@@ -15,7 +20,7 @@ export const TooltipPopover: FunctionComponent<TooltipPopoverProps> = ({
     const alertEvaluationTimeSeriesTooltipClasses =
         useAlertEvaluationTimeSeriesTooltipStyles();
     const timeSeriesChartTooltipClasses = useTooltipStyles();
-    const dataPointForXValue: [DataPoint, Series][] =
+    const dataPointForXValue: [DataPoint, NormalizedSeries][] =
         getDataPointsInSeriesForXValue(series, xValue);
 
     return (
@@ -44,13 +49,34 @@ export const TooltipPopover: FunctionComponent<TooltipPopoverProps> = ({
                 <table className={timeSeriesChartTooltipClasses.table}>
                     <tbody>
                         {dataPointForXValue.map(([dataPoint, series]) => {
+                            const color =
+                                series.color === undefined
+                                    ? colorScale(series.name as string)
+                                    : series.color;
+
+                            let displayValue = series.tooltipValueFormatter(
+                                dataPoint.y,
+                                dataPoint,
+                                series
+                            );
+
+                            if (series.type === SeriesType.AREA_CLOSED) {
+                                displayValue = `${series.tooltipValueFormatter(
+                                    dataPoint.y,
+                                    dataPoint,
+                                    series
+                                )} - ${series.tooltipValueFormatter(
+                                    (dataPoint as ThresholdDataPoint).y1,
+                                    dataPoint,
+                                    series
+                                )}`;
+                            }
+
                             return (
                                 <tr key={series.name}>
                                     <td
                                         style={{
-                                            color: colorScale(
-                                                series.name as string
-                                            ),
+                                            color,
                                         }}
                                     >
                                         {series.name}
@@ -60,7 +86,7 @@ export const TooltipPopover: FunctionComponent<TooltipPopoverProps> = ({
                                             timeSeriesChartTooltipClasses.valueCell
                                         }
                                     >
-                                        {dataPoint.y}
+                                        {displayValue}
                                     </td>
                                 </tr>
                             );

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip.interfaces.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip.interfaces.ts
@@ -1,16 +1,16 @@
 import { AxisScale } from "@visx/axis";
-import { Series } from "../time-series-chart.interfaces";
+import { NormalizedSeries } from "../time-series-chart.interfaces";
 
 export interface TooltipMarkersProps {
     chartHeight: number;
     xScale: AxisScale<number>;
     yScale: AxisScale<number>;
-    series: Series[];
+    series: NormalizedSeries[];
     xValue: number;
     colorScale: (name: string) => string;
 }
 export interface TooltipPopoverProps {
     xValue: number;
-    series: Series[];
+    series: NormalizedSeries[];
     colorScale: (name: string) => string;
 }

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip.utils.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip.utils.ts
@@ -2,7 +2,7 @@ import { localPoint } from "@visx/event";
 import { bisector } from "d3-array";
 import { ScaleTime } from "d3-scale";
 import { MouseEvent } from "react";
-import { DataPoint, Series } from "../time-series-chart.interfaces";
+import { DataPoint, NormalizedSeries } from "../time-series-chart.interfaces";
 
 /**
  * Find the closest valid x value from the data points of all the series to the
@@ -10,7 +10,7 @@ import { DataPoint, Series } from "../time-series-chart.interfaces";
  */
 export const determineXPointForHover = (
     event: MouseEvent<SVGRectElement>,
-    series: Series[],
+    series: NormalizedSeries[],
     dateScale: ScaleTime<number, number, never>,
     marginLeft: number
 ): [number, { x: number; y: number }] | [null, null] => {
@@ -89,10 +89,10 @@ export const determineXPointForHover = (
  * @param xValue - Find the datapoint that whose `x` value matches this
  */
 export const getDataPointsInSeriesForXValue = (
-    series: Series[],
+    series: NormalizedSeries[],
     xValue: number
-): [DataPoint, Series][] => {
-    const dataPointsWithSeries: [DataPoint, Series][] = [];
+): [DataPoint, NormalizedSeries][] => {
+    const dataPointsWithSeries: [DataPoint, NormalizedSeries][] = [];
 
     series.forEach((seriesData) => {
         if (seriesData.enabled) {


### PR DESCRIPTION
Adding generic support for areacloased to display values for `y` and `y1` in the tooltip

![image](https://user-images.githubusercontent.com/2080348/165358889-b9bfba5e-bd3b-4865-a8c1-f63ead000d6e.png)
