### PR TITLE
fix(ui): sorting for date type in Anomaly screen

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.component.tsx
@@ -73,6 +73,18 @@ export const AnomalyListV1: FunctionComponent<AnomalyListV1Props> = (
         []
     );
 
+    const startTimeRenderer = useCallback(
+        // use formatted value to display
+        (_, data: UiAnomaly) => data.startTime,
+        []
+    );
+
+    const endTimeRenderer = useCallback(
+        // use formatted value to display
+        (_, data: UiAnomaly) => data.endTime,
+        []
+    );
+
     const isActionButtonDisable = !(
         selectedAnomaly && selectedAnomaly.rowKeyValues.length === 1
     );
@@ -116,17 +128,19 @@ export const AnomalyListV1: FunctionComponent<AnomalyListV1Props> = (
             },
             {
                 key: "startTime",
-                dataKey: "startTime",
+                dataKey: "startTimeVal",
                 header: t("label.start"),
                 sortable: true,
                 minWidth: 200,
+                customCellRenderer: startTimeRenderer,
             },
             {
                 key: "endTime",
-                dataKey: "endTime",
+                dataKey: "endTimeVal",
                 header: t("label.end"),
                 sortable: true,
                 minWidth: 200,
+                customCellRenderer: endTimeRenderer,
             },
             {
                 key: "current",
@@ -160,6 +174,8 @@ export const AnomalyListV1: FunctionComponent<AnomalyListV1Props> = (
             currentRenderer,
             predicatedRenderer,
             durationRenderer,
+            startTimeRenderer,
+            endTimeRenderer,
         ]
     );
 

--- a/thirdeye-ui/src/app/rest/dto/ui-anomaly.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/ui-anomaly.interfaces.ts
@@ -13,5 +13,7 @@ export interface UiAnomaly {
     duration: string;
     durationVal: number;
     startTime: string;
+    startTimeVal: number;
     endTime: string;
+    endTimeVal: number;
 }

--- a/thirdeye-ui/src/app/utils/anomalies/anomalies.util.test.ts
+++ b/thirdeye-ui/src/app/utils/anomalies/anomalies.util.test.ts
@@ -217,6 +217,8 @@ const mockEmptyUiAnomaly = {
     durationVal: 0,
     startTime: "label.no-data-marker",
     endTime: "label.no-data-marker",
+    startTimeVal: -1,
+    endTimeVal: -1,
 };
 
 const mockAnomaly1 = {
@@ -282,6 +284,8 @@ const mockUiAnomaly1 = {
     durationVal: 1,
     startTime: "2",
     endTime: "3",
+    startTimeVal: 2,
+    endTimeVal: 3,
 };
 
 const mockUiAnomaly2 = {
@@ -300,6 +304,8 @@ const mockUiAnomaly2 = {
     durationVal: 1,
     startTime: "8",
     endTime: "9",
+    startTimeVal: 8,
+    endTimeVal: 9,
 };
 
 const mockUiAnomaly3 = {
@@ -318,6 +324,8 @@ const mockUiAnomaly3 = {
     durationVal: 5,
     startTime: "3",
     endTime: "8",
+    startTimeVal: 3,
+    endTimeVal: 8,
 };
 
 const mockUiAnomaly4 = {
@@ -336,6 +344,8 @@ const mockUiAnomaly4 = {
     durationVal: 0,
     startTime: "label.no-data-marker",
     endTime: "label.no-data-marker",
+    startTimeVal: -1,
+    endTimeVal: -1,
 };
 
 const mockUiAnomaly5 = {
@@ -354,6 +364,8 @@ const mockUiAnomaly5 = {
     durationVal: 10,
     startTime: "100",
     endTime: "110",
+    startTimeVal: 100,
+    endTimeVal: 110,
 };
 
 const mockUiAnomalies = [

--- a/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
+++ b/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
@@ -43,6 +43,8 @@ export const createEmptyUiAnomaly = (): UiAnomaly => {
         durationVal: 0,
         startTime: noDataMarker,
         endTime: noDataMarker,
+        endTimeVal: -1,
+        startTimeVal: -1,
     };
 };
 
@@ -102,9 +104,11 @@ export const getUiAnomaly = (anomaly: Anomaly): UiAnomaly => {
     // Start and end time
     if (anomaly.startTime) {
         uiAnomaly.startTime = formatDateAndTimeV1(anomaly.startTime);
+        uiAnomaly.startTimeVal = anomaly.startTime;
     }
     if (anomaly.endTime) {
         uiAnomaly.endTime = formatDateAndTimeV1(anomaly.endTime);
+        uiAnomaly.endTimeVal = anomaly.endTime;
     }
 
     // Duration


### PR DESCRIPTION
### Issue
> Date sorting was not working properly at the Anomaly screen

### Fix
> Store actual date value and perform sorting based on that values instead on string values


<img width="1680" alt="Screenshot 2022-04-26 at 11 56 01 PM" src="https://user-images.githubusercontent.com/12962843/165367306-b4755180-8f16-4813-9bcb-a1e016d352ef.png">
