### PR TITLE
chore(ui): instead NAN deviation show no data marker

### DIFF
--- a/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
+++ b/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
@@ -96,7 +96,9 @@ export const getUiAnomaly = (anomaly: Anomaly): UiAnomaly => {
         const deviation =
             (anomaly.avgCurrentVal - anomaly.avgBaselineVal) /
             anomaly.avgBaselineVal;
-        uiAnomaly.deviation = formatPercentageV1(deviation);
+        uiAnomaly.deviation = isNaN(deviation)
+            ? i18n.t("label.no-data-marker")
+            : formatPercentageV1(deviation);
         uiAnomaly.deviationVal = deviation;
         uiAnomaly.negativeDeviation = deviation < 0;
     }


### PR DESCRIPTION
### Issue:

> We are showing deviation as "NAN%" at the Anomaly list screen which is not a good UI / UX

### Fix:

> Replace "NAN%" with "-"

Before:

<img width="1680" alt="Screenshot 2022-04-28 at 9 44 13 AM" src="https://user-images.githubusercontent.com/12962843/165675333-a0310e44-e081-4716-9ff5-35d793ebd065.png">

After:

<img width="1680" alt="Screenshot 2022-04-28 at 9 41 30 AM" src="https://user-images.githubusercontent.com/12962843/165675047-f03e32da-4117-4d8a-8b5b-58f22b325f18.png">

