### PR TITLE
[server] activeMetricsCount. Expose metric for number of active metrics.

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/MetricConfigManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/MetricConfigManagerImpl.java
@@ -9,6 +9,8 @@ import ai.startree.thirdeye.datalayer.dao.GenericPojoDao;
 import ai.startree.thirdeye.spi.datalayer.Predicate;
 import ai.startree.thirdeye.spi.datalayer.bao.MetricConfigManager;
 import ai.startree.thirdeye.spi.datalayer.dto.MetricConfigDTO;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.HashMap;
@@ -27,8 +29,15 @@ public class MetricConfigManagerImpl extends AbstractManagerImpl<MetricConfigDTO
   private static final String FIND_BY_ALIAS_LIKE_PART = " AND alias LIKE :alias__%d";
 
   @Inject
-  public MetricConfigManagerImpl(GenericPojoDao genericPojoDao) {
+  public MetricConfigManagerImpl(final GenericPojoDao genericPojoDao,
+      final MetricRegistry metricRegistry) {
     super(MetricConfigDTO.class, genericPojoDao);
+    metricRegistry.register("activeMetricsCount", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return countActive();
+      }
+    });
   }
 
   @Override
@@ -88,5 +97,9 @@ public class MetricConfigManagerImpl extends AbstractManagerImpl<MetricConfigDTO
 
     return genericPojoDao
         .executeParameterizedSQL(query.toString(), parameterMap, MetricConfigDTO.class);
+  }
+
+  public Long countActive() {
+    return count(Predicate.EQ("active", true));
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/MetricResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/MetricResource.java
@@ -13,9 +13,12 @@ import static ai.startree.thirdeye.util.ResourceUtils.ensureExists;
 import ai.startree.thirdeye.mapper.ApiBeanMapper;
 import ai.startree.thirdeye.spi.ThirdEyePrincipal;
 import ai.startree.thirdeye.spi.api.MetricApi;
+import ai.startree.thirdeye.spi.datalayer.Predicate;
 import ai.startree.thirdeye.spi.datalayer.bao.DatasetConfigManager;
 import ai.startree.thirdeye.spi.datalayer.bao.MetricConfigManager;
 import ai.startree.thirdeye.spi.datalayer.dto.MetricConfigDTO;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
@@ -40,10 +43,17 @@ public class MetricResource extends CrudResource<MetricApi, MetricConfigDTO> {
 
   @Inject
   public MetricResource(final MetricConfigManager metricConfigManager,
-      final DatasetConfigManager datasetConfigManager) {
+      final DatasetConfigManager datasetConfigManager,
+      final MetricRegistry metricRegistry) {
     super(metricConfigManager, ImmutableMap.of());
     this.datasetConfigManager = datasetConfigManager;
     this.metricConfigManager = metricConfigManager;
+    metricRegistry.register("activeMetricsCount", new Gauge<Integer>() {
+      @Override
+      public Integer getValue() {
+        return metricConfigManager.findByPredicate(Predicate.EQ("active", true)).size();
+      }
+    });
   }
 
   @Override

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/MetricResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/MetricResource.java
@@ -13,12 +13,9 @@ import static ai.startree.thirdeye.util.ResourceUtils.ensureExists;
 import ai.startree.thirdeye.mapper.ApiBeanMapper;
 import ai.startree.thirdeye.spi.ThirdEyePrincipal;
 import ai.startree.thirdeye.spi.api.MetricApi;
-import ai.startree.thirdeye.spi.datalayer.Predicate;
 import ai.startree.thirdeye.spi.datalayer.bao.DatasetConfigManager;
 import ai.startree.thirdeye.spi.datalayer.bao.MetricConfigManager;
 import ai.startree.thirdeye.spi.datalayer.dto.MetricConfigDTO;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
@@ -43,17 +40,10 @@ public class MetricResource extends CrudResource<MetricApi, MetricConfigDTO> {
 
   @Inject
   public MetricResource(final MetricConfigManager metricConfigManager,
-      final DatasetConfigManager datasetConfigManager,
-      final MetricRegistry metricRegistry) {
+      final DatasetConfigManager datasetConfigManager) {
     super(metricConfigManager, ImmutableMap.of());
     this.datasetConfigManager = datasetConfigManager;
     this.metricConfigManager = metricConfigManager;
-    metricRegistry.register("activeMetricsCount", new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return metricConfigManager.findByPredicate(Predicate.EQ("active", true)).size();
-      }
-    });
   }
 
   @Override


### PR DESCRIPTION
Metric : `activeMetricsCount`
Type : `gauge`
Description : Gives the number of active metrics.