### PR TITLE
feat(ui): semantic versioning for release to artifactory

### DIFF
--- a/thirdeye-ui/.releaserc.yaml
+++ b/thirdeye-ui/.releaserc.yaml
@@ -1,0 +1,63 @@
+---
+# Release branches
+branches:
+    - name: master
+
+# Concourse is not recognized as a CI provider
+ci: false
+
+plugins:
+    - - "@semantic-release/commit-analyzer"
+      - preset: conventionalcommits
+        releaseRules:
+            # Pull request types and scopes that trigger a release for this project
+            - type: major
+              scope: ui
+              release: major
+            - type: feat
+              scope: ui
+              release: minor
+            - type: fix
+              scope: ui
+              release: patch
+
+            # Pull request types and scopes that do not trigger a release for this project
+            - type: major
+              scope:
+              release: false
+            - type: major
+              scope: repo
+              release: false
+
+            - type: fix
+              scope:
+              release: false
+            - type: fix
+              scope: repo
+              release: false
+
+            - type: feat
+              scope:
+              release: minor
+            - type: feat
+              scope: repo
+              release: minor
+
+            # Pull request types that do not trigger a release
+            - type: wip
+              release: false
+            - type: test
+              release: false
+            - type: refactor
+              release: false
+            - type: chore
+              release: false
+    - "@semantic-release/npm"
+    - - semantic-release-plugin-update-version-in-files
+      # Replace placeholder in released source with the version number being released
+      - files:
+            - "dist/thirdeye-ui.js"
+        placeholder: "0.0.0-development-thirdeye-ui"
+
+# GitHub tag for the release
+tagFormat: thirdeye-ui-${version}

--- a/thirdeye-ui/package-lock.json
+++ b/thirdeye-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@startree-ui/thirdeye-ui",
-    "version": "0.0.0-developement",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -8,7 +8,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
             "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-            "dev": true,
             "requires": {
                 "@babel/highlight": "^7.12.13"
             }
@@ -248,8 +247,7 @@
         "@babel/helper-validator-identifier": {
             "version": "7.12.11",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-            "dev": true
+            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
         },
         "@babel/helper-validator-option": {
             "version": "7.12.16",
@@ -284,7 +282,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
             "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
-            "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.12.11",
                 "chalk": "^2.0.0",
@@ -1998,7 +1995,6 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
             "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
-            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "2.0.4",
                 "run-parallel": "^1.1.9"
@@ -2007,17 +2003,140 @@
         "@nodelib/fs.stat": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-            "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
-            "dev": true
+            "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
         },
         "@nodelib/fs.walk": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
             "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
-            "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.4",
                 "fastq": "^1.6.0"
+            }
+        },
+        "@octokit/auth-token": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+            "requires": {
+                "@octokit/types": "^6.0.3"
+            }
+        },
+        "@octokit/core": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "requires": {
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.6.3",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/endpoint": {
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "requires": {
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+                    "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+                }
+            }
+        },
+        "@octokit/graphql": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "requires": {
+                "@octokit/request": "^5.6.0",
+                "@octokit/types": "^6.0.3",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/openapi-types": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+            "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+        },
+        "@octokit/plugin-paginate-rest": {
+            "version": "2.17.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+            "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+            "requires": {
+                "@octokit/types": "^6.34.0"
+            }
+        },
+        "@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+            "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+            "requires": {
+                "@octokit/types": "^6.34.0",
+                "deprecation": "^2.3.1"
+            }
+        },
+        "@octokit/request": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "requires": {
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.1.0",
+                "@octokit/types": "^6.16.1",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+                    "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+                }
+            }
+        },
+        "@octokit/request-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "requires": {
+                "@octokit/types": "^6.0.3",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "@octokit/rest": {
+            "version": "18.12.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+            "requires": {
+                "@octokit/core": "^3.5.1",
+                "@octokit/plugin-paginate-rest": "^2.16.8",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+            }
+        },
+        "@octokit/types": {
+            "version": "6.34.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+            "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+            "requires": {
+                "@octokit/openapi-types": "^11.2.0"
             }
         },
         "@polka/url": {
@@ -2048,6 +2167,187 @@
             "dev": true,
             "requires": {
                 "any-observable": "^0.3.0"
+            }
+        },
+        "@semantic-release/commit-analyzer": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
+            "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
+            "requires": {
+                "conventional-changelog-angular": "^5.0.0",
+                "conventional-commits-filter": "^2.0.0",
+                "conventional-commits-parser": "^3.2.3",
+                "debug": "^4.0.0",
+                "import-from": "^4.0.0",
+                "lodash": "^4.17.4",
+                "micromatch": "^4.0.2"
+            }
+        },
+        "@semantic-release/error": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+            "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
+        },
+        "@semantic-release/github": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+            "integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
+            "requires": {
+                "@octokit/rest": "^18.0.0",
+                "@semantic-release/error": "^2.2.0",
+                "aggregate-error": "^3.0.0",
+                "bottleneck": "^2.18.1",
+                "debug": "^4.0.0",
+                "dir-glob": "^3.0.0",
+                "fs-extra": "^10.0.0",
+                "globby": "^11.0.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "issue-parser": "^6.0.0",
+                "lodash": "^4.17.4",
+                "mime": "^3.0.0",
+                "p-filter": "^2.0.0",
+                "p-retry": "^4.0.0",
+                "url-join": "^4.0.0"
+            },
+            "dependencies": {
+                "@semantic-release/error": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+                    "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
+                },
+                "fs-extra": {
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+                    "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "mime": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+                    "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+                },
+                "p-retry": {
+                    "version": "4.6.1",
+                    "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+                    "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+                    "requires": {
+                        "@types/retry": "^0.12.0",
+                        "retry": "^0.13.1"
+                    }
+                },
+                "retry": {
+                    "version": "0.13.1",
+                    "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+                    "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+                }
+            }
+        },
+        "@semantic-release/npm": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
+            "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+            "requires": {
+                "@semantic-release/error": "^3.0.0",
+                "aggregate-error": "^3.0.0",
+                "execa": "^5.0.0",
+                "fs-extra": "^10.0.0",
+                "lodash": "^4.17.15",
+                "nerf-dart": "^1.0.0",
+                "normalize-url": "^6.0.0",
+                "npm": "^8.3.0",
+                "rc": "^1.2.8",
+                "read-pkg": "^5.0.0",
+                "registry-auth-token": "^4.0.0",
+                "semver": "^7.1.2",
+                "tempy": "^1.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+                    "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.0",
+                        "human-signals": "^2.1.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.1",
+                        "onetime": "^5.1.2",
+                        "signal-exit": "^3.0.3",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "fs-extra": {
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+                    "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+                },
+                "human-signals": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+                    "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+                },
+                "is-stream": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                    "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@semantic-release/release-notes-generator": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
+            "integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
+            "requires": {
+                "conventional-changelog-angular": "^5.0.0",
+                "conventional-changelog-writer": "^5.0.0",
+                "conventional-commits-filter": "^2.0.0",
+                "conventional-commits-parser": "^3.2.3",
+                "debug": "^4.0.0",
+                "get-stream": "^6.0.0",
+                "import-from": "^4.0.0",
+                "into-stream": "^6.0.0",
+                "lodash": "^4.17.4",
+                "read-pkg-up": "^7.0.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+                }
             }
         },
         "@sinonjs/commons": {
@@ -2357,6 +2657,11 @@
                 "tippy.js": "^6.3.1"
             }
         },
+        "@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+        },
         "@types/anymatch": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2625,6 +2930,14 @@
             "integrity": "sha512-enkMO4WJcbdkhK1eZrItF616buau02wtrSN+DDt9Qj9U23boSAXNJm0fMlgwpTDaRHq3S0D/SPIRbxy4YxBjiA==",
             "dev": true
         },
+        "@types/mdast": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
+            "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2634,8 +2947,7 @@
         "@types/minimist": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-            "dev": true
+            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
         },
         "@types/node": {
             "version": "14.14.27",
@@ -2646,14 +2958,12 @@
         "@types/normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-            "dev": true
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
         },
         "@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-            "dev": true
+            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "@types/prettier": {
             "version": "2.2.0",
@@ -2760,6 +3070,11 @@
                 }
             }
         },
+        "@types/retry": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+            "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+        },
         "@types/scheduler": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -2853,6 +3168,11 @@
                     "dev": true
                 }
             }
+        },
+        "@types/unist": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+            "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
         },
         "@types/uuid": {
             "version": "8.3.4",
@@ -3705,6 +4025,15 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "requires": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            }
+        },
         "abab": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -3749,11 +4078,18 @@
             "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
             "dev": true
         },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "requires": {
+                "debug": "4"
+            }
+        },
         "aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
             "requires": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -3815,17 +4151,20 @@
         "ansi-regex": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-            "dev": true
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
+        },
+        "ansicolors": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
         },
         "any-observable": {
             "version": "0.3.0",
@@ -3857,6 +4196,11 @@
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
+        },
+        "argv-formatter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+            "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk="
         },
         "aria-query": {
             "version": "4.2.2",
@@ -3897,6 +4241,11 @@
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
             "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
             "dev": true
+        },
+        "array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
         },
         "array-includes": {
             "version": "3.1.4",
@@ -3992,8 +4341,7 @@
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -4099,8 +4447,7 @@
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
         "asn1": {
             "version": "0.2.4",
@@ -4319,6 +4666,11 @@
                 "babel-preset-current-node-syntax": "^1.0.0"
             }
         },
+        "bail": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+        },
         "balanced-match": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -4393,6 +4745,11 @@
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
+        },
+        "before-after-hook": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+            "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
         },
         "big.js": {
             "version": "5.2.2",
@@ -4505,11 +4862,15 @@
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
+        "bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4518,8 +4879,7 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "dev": true
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                 }
             }
         },
@@ -4527,7 +4887,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -4655,8 +5014,7 @@
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         },
         "camel-case": {
             "version": "4.1.2",
@@ -4686,7 +5044,6 @@
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
             "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-            "dev": true,
             "requires": {
                 "camelcase": "^5.3.1",
                 "map-obj": "^4.0.0",
@@ -4696,8 +5053,7 @@
                 "camelcase": {
                     "version": "5.3.1",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                    "dev": true
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
                 }
             }
         },
@@ -4710,17 +5066,30 @@
                 "rsvp": "^4.8.4"
             }
         },
+        "cardinal": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+            "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+            "requires": {
+                "ansicolors": "~0.3.2",
+                "redeyed": "~2.1.0"
+            }
+        },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
+        "ccount": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+            "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="
+        },
         "chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -4732,6 +5101,21 @@
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "dev": true
+        },
+        "character-entities": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+        },
+        "character-entities-legacy": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+        },
+        "character-reference-invalid": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
         },
         "check-more-types": {
             "version": "2.24.0",
@@ -4841,8 +5225,7 @@
         "clean-stack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
         },
         "clean-webpack-plugin": {
             "version": "3.0.0",
@@ -5013,7 +5396,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -5021,8 +5403,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "colord": {
             "version": "2.9.2",
@@ -5040,7 +5421,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
             "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-            "dev": true,
             "optional": true
         },
         "combined-stream": {
@@ -5063,6 +5443,15 @@
             "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
             "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
             "dev": true
+        },
+        "compare-func": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+            "requires": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^5.1.0"
+            }
         },
         "compare-versions": {
             "version": "3.6.0",
@@ -5120,8 +5509,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "connect-history-api-fallback": {
             "version": "1.6.0",
@@ -5149,6 +5537,200 @@
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "dev": true
+        },
+        "conventional-changelog-angular": {
+            "version": "5.0.13",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+            "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+            "requires": {
+                "compare-func": "^2.0.0",
+                "q": "^1.5.1"
+            }
+        },
+        "conventional-changelog-conventionalcommits": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+            "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+            "requires": {
+                "compare-func": "^2.0.0",
+                "lodash": "^4.17.15",
+                "q": "^1.5.1"
+            }
+        },
+        "conventional-changelog-writer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+            "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+            "requires": {
+                "conventional-commits-filter": "^2.0.7",
+                "dateformat": "^3.0.0",
+                "handlebars": "^4.7.7",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "semver": "^6.0.0",
+                "split": "^1.0.0",
+                "through2": "^4.0.0"
+            },
+            "dependencies": {
+                "hosted-git-info": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+                    "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                },
+                "meow": {
+                    "version": "8.1.2",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+                    "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+                    "requires": {
+                        "@types/minimist": "^1.2.0",
+                        "camelcase-keys": "^6.2.2",
+                        "decamelize-keys": "^1.1.0",
+                        "hard-rejection": "^2.1.0",
+                        "minimist-options": "4.1.0",
+                        "normalize-package-data": "^3.0.0",
+                        "read-pkg-up": "^7.0.1",
+                        "redent": "^3.0.0",
+                        "trim-newlines": "^3.0.0",
+                        "type-fest": "^0.18.0",
+                        "yargs-parser": "^20.2.3"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+                    "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+                    "requires": {
+                        "hosted-git-info": "^4.0.1",
+                        "is-core-module": "^2.5.0",
+                        "semver": "^7.3.4",
+                        "validate-npm-package-license": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "7.3.7",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        }
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                },
+                "type-fest": {
+                    "version": "0.18.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+                    "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
+                },
+                "yargs-parser": {
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+                }
+            }
+        },
+        "conventional-commits-filter": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+            "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+            "requires": {
+                "lodash.ismatch": "^4.4.0",
+                "modify-values": "^1.0.0"
+            }
+        },
+        "conventional-commits-parser": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "requires": {
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.1",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "dependencies": {
+                "hosted-git-info": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+                    "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                },
+                "meow": {
+                    "version": "8.1.2",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+                    "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+                    "requires": {
+                        "@types/minimist": "^1.2.0",
+                        "camelcase-keys": "^6.2.2",
+                        "decamelize-keys": "^1.1.0",
+                        "hard-rejection": "^2.1.0",
+                        "minimist-options": "4.1.0",
+                        "normalize-package-data": "^3.0.0",
+                        "read-pkg-up": "^7.0.1",
+                        "redent": "^3.0.0",
+                        "trim-newlines": "^3.0.0",
+                        "type-fest": "^0.18.0",
+                        "yargs-parser": "^20.2.3"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+                    "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+                    "requires": {
+                        "hosted-git-info": "^4.0.1",
+                        "is-core-module": "^2.5.0",
+                        "semver": "^7.3.4",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.18.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+                    "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
+                },
+                "yargs-parser": {
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+                }
+            }
         },
         "convert-source-map": {
             "version": "1.7.0",
@@ -5220,14 +5802,12 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cosmiconfig": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
             "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-            "dev": true,
             "requires": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -5240,12 +5820,16 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
             }
+        },
+        "crypto-random-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
         },
         "css": {
             "version": "3.0.0",
@@ -5790,6 +6374,11 @@
             "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
             "dev": true
         },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+        },
         "dayjs": {
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
@@ -5805,7 +6394,6 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -5813,14 +6401,12 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decamelize-keys": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-            "dev": true,
             "requires": {
                 "decamelize": "^1.1.0",
                 "map-obj": "^1.0.0"
@@ -5829,8 +6415,7 @@
                 "map-obj": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                    "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-                    "dev": true
+                    "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
                 }
             }
         },
@@ -5865,6 +6450,11 @@
                 "object-keys": "^1.1.1",
                 "regexp.prototype.flags": "^1.2.0"
             }
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "deep-is": {
             "version": "0.1.3",
@@ -5997,6 +6587,11 @@
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
         },
+        "deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -6025,7 +6620,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
             "requires": {
                 "path-type": "^4.0.0"
             }
@@ -6173,11 +6767,58 @@
                 }
             }
         },
+        "dot-prop": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+            "requires": {
+                "is-obj": "^2.0.0"
+            },
+            "dependencies": {
+                "is-obj": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+                    "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+                }
+            }
+        },
         "duplexer": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "requires": {
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
         },
         "ecc-jsbn": {
             "version": "0.1.2",
@@ -6210,8 +6851,7 @@
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "emojis-list": {
             "version": "3.0.0",
@@ -6260,6 +6900,57 @@
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
             "dev": true
         },
+        "env-ci": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
+            "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
+            "requires": {
+                "execa": "^5.0.0",
+                "fromentries": "^1.3.2",
+                "java-properties": "^1.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+                    "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.0",
+                        "human-signals": "^2.1.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.1",
+                        "onetime": "^5.1.2",
+                        "signal-exit": "^3.0.3",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+                },
+                "human-signals": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+                    "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+                },
+                "is-stream": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                    "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                }
+            }
+        },
         "envinfo": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
@@ -6279,7 +6970,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -6326,8 +7016,7 @@
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-html": {
             "version": "1.0.3",
@@ -6338,8 +7027,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "escodegen": {
             "version": "1.14.3",
@@ -6867,8 +7555,7 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "esquery": {
             "version": "1.4.0",
@@ -7219,8 +7906,7 @@
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -7347,7 +8033,6 @@
             "version": "3.2.5",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
             "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
-            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -7379,7 +8064,6 @@
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
             "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
-            "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
             }
@@ -7415,7 +8099,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
             "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-            "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5"
             }
@@ -7450,7 +8133,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -7507,7 +8189,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
             "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
-            "dev": true,
             "requires": {
                 "semver-regex": "^3.1.2"
             }
@@ -7697,6 +8378,44 @@
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
             "dev": true
         },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "fromentries": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+            "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
+        },
         "fs-extra": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -7718,8 +8437,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "2.3.2",
@@ -7731,8 +8449,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -7749,8 +8466,7 @@
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-intrinsic": {
             "version": "1.1.1",
@@ -7832,11 +8548,64 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "git-log-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+            "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+            "requires": {
+                "argv-formatter": "~1.0.0",
+                "spawn-error-forwarder": "~1.0.0",
+                "split2": "~1.0.0",
+                "stream-combiner2": "~1.1.1",
+                "through2": "~2.0.0",
+                "traverse": "~0.6.6"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "split2": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+                    "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+                    "requires": {
+                        "through2": "~2.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
+            }
+        },
         "glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -7850,7 +8619,6 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
             "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-            "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
             }
@@ -7919,7 +8687,6 @@
             "version": "11.0.2",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
             "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
-            "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -7938,8 +8705,7 @@
         "graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-            "dev": true
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
         "growly": {
             "version": "1.3.0",
@@ -7963,6 +8729,25 @@
             "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
             "dev": true
         },
+        "handlebars": {
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "requires": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7982,8 +8767,7 @@
         "hard-rejection": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-            "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-            "dev": true
+            "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="
         },
         "harmony-reflect": {
             "version": "1.6.1",
@@ -7995,7 +8779,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -8026,8 +8809,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
             "version": "1.0.1",
@@ -8138,11 +8920,15 @@
                 }
             }
         },
+        "hook-std": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+            "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g=="
+        },
         "hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-            "dev": true
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
         },
         "hpack.js": {
             "version": "2.1.6",
@@ -8353,6 +9139,16 @@
                 "requires-port": "^1.0.0"
             }
         },
+        "http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "requires": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "http-proxy-middleware": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
@@ -8481,6 +9277,15 @@
                 "sshpk": "^1.7.0"
             }
         },
+        "https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "human-signals": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -8604,8 +9409,7 @@
         "ignore": {
             "version": "5.1.8",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-            "dev": true
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
         },
         "immer": {
             "version": "8.0.1",
@@ -8616,11 +9420,15 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
             }
+        },
+        "import-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+            "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ=="
         },
         "import-lazy": {
             "version": "4.0.0",
@@ -8695,8 +9503,7 @@
         "indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
         },
         "indexes-of": {
             "version": "1.0.1",
@@ -8708,7 +9515,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -8717,14 +9523,12 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "internal-ip": {
             "version": "4.3.0",
@@ -8757,6 +9561,15 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
             "dev": true
+        },
+        "into-stream": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+            "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+            "requires": {
+                "from2": "^2.3.0",
+                "p-is-promise": "^3.0.0"
+            }
         },
         "invariant": {
             "version": "2.2.4",
@@ -8810,6 +9623,20 @@
                 }
             }
         },
+        "is-alphabetical": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+        },
+        "is-alphanumerical": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+            "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+            "requires": {
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0"
+            }
+        },
         "is-arguments": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
@@ -8822,8 +9649,7 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-bigint": {
             "version": "1.0.4",
@@ -8878,7 +9704,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
             "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-            "dev": true,
             "requires": {
                 "has": "^1.0.3"
             }
@@ -8908,6 +9733,11 @@
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
             "dev": true
+        },
+        "is-decimal": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -8944,14 +9774,12 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "is-generator-fn": {
             "version": "2.1.0",
@@ -8963,10 +9791,14 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
+        },
+        "is-hexadecimal": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
         },
         "is-in-browser": {
             "version": "1.1.3",
@@ -9000,8 +9832,7 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "is-number-object": {
             "version": "1.0.6",
@@ -9030,8 +9861,7 @@
         "is-path-cwd": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-            "dev": true
+            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
         },
         "is-path-in-cwd": {
             "version": "2.1.0",
@@ -9054,8 +9884,7 @@
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-            "dev": true
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -9124,6 +9953,14 @@
                 "has-symbols": "^1.0.1"
             }
         },
+        "is-text-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+            "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+            "requires": {
+                "text-extensions": "^1.0.0"
+            }
+        },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -9155,11 +9992,15 @@
                 "is-docker": "^2.0.0"
             }
         },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
@@ -9172,6 +10013,18 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
+        },
+        "issue-parser": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
+            "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+            "requires": {
+                "lodash.capitalize": "^4.2.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.uniqby": "^4.7.0"
+            }
         },
         "istanbul-lib-coverage": {
             "version": "3.0.0",
@@ -9255,6 +10108,11 @@
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
             }
+        },
+        "java-properties": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+            "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ=="
         },
         "jest": {
             "version": "26.6.3",
@@ -11228,14 +12086,12 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "json-schema": {
             "version": "0.2.3",
@@ -11258,8 +12114,7 @@
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "dev": true
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "json3": {
             "version": "3.3.3",
@@ -11280,11 +12135,15 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
             }
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
         },
         "jsprim": {
             "version": "1.4.1",
@@ -11402,8 +12261,7 @@
         "kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "dev": true
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "kleur": {
             "version": "3.0.3",
@@ -11448,8 +12306,7 @@
         "lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-            "dev": true
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
         },
         "lint-staged": {
             "version": "10.5.4",
@@ -11957,7 +12814,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^4.0.0",
@@ -11969,7 +12825,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-                    "dev": true,
                     "requires": {
                         "error-ex": "^1.3.1",
                         "json-parse-better-errors": "^1.0.1"
@@ -11978,14 +12833,12 @@
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
                 },
                 "strip-bom": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-                    "dev": true
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
                 }
             }
         },
@@ -12025,6 +12878,31 @@
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
             "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
         },
+        "lodash.capitalize": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+            "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
+        },
+        "lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+        },
+        "lodash.ismatch": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+            "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -12048,6 +12926,11 @@
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true
+        },
+        "lodash.uniqby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+            "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
         },
         "log-symbols": {
             "version": "4.0.0",
@@ -12127,6 +13010,11 @@
             "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
             "dev": true
         },
+        "longest-streak": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+            "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
+        },
         "loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12156,7 +13044,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -12213,8 +13100,7 @@
         "map-obj": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-            "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-            "dev": true
+            "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
         },
         "map-visit": {
             "version": "1.0.0",
@@ -12223,6 +13109,83 @@
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "markdown-table": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+            "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+            "requires": {
+                "repeat-string": "^1.0.0"
+            }
+        },
+        "marked": {
+            "version": "4.0.14",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+            "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ=="
+        },
+        "marked-terminal": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.1.1.tgz",
+            "integrity": "sha512-+cKTOx9P4l7HwINYhzbrBSyzgxO2HaHKGZGuB1orZsMIgXYaJyfidT81VXRdpelW/PcHEWxywscePVgI/oUF6g==",
+            "requires": {
+                "ansi-escapes": "^5.0.0",
+                "cardinal": "^2.1.1",
+                "chalk": "^5.0.0",
+                "cli-table3": "^0.6.1",
+                "node-emoji": "^1.11.0",
+                "supports-hyperlinks": "^2.2.0"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+                    "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+                    "requires": {
+                        "type-fest": "^1.0.2"
+                    }
+                },
+                "chalk": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+                    "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+                },
+                "cli-table3": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+                    "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+                    "requires": {
+                        "colors": "1.4.0",
+                        "string-width": "^4.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "supports-hyperlinks": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+                    "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+                    "requires": {
+                        "has-flag": "^4.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+                    "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+                }
             }
         },
         "math-expression-evaluator": {
@@ -12235,6 +13198,100 @@
             "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
             "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
             "dev": true
+        },
+        "mdast-util-find-and-replace": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+            "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+            "requires": {
+                "escape-string-regexp": "^4.0.0",
+                "unist-util-is": "^4.0.0",
+                "unist-util-visit-parents": "^3.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+                }
+            }
+        },
+        "mdast-util-from-markdown": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+            "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "mdast-util-to-string": "^2.0.0",
+                "micromark": "~2.11.0",
+                "parse-entities": "^2.0.0",
+                "unist-util-stringify-position": "^2.0.0"
+            }
+        },
+        "mdast-util-gfm": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+            "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+            "requires": {
+                "mdast-util-gfm-autolink-literal": "^0.1.0",
+                "mdast-util-gfm-strikethrough": "^0.2.0",
+                "mdast-util-gfm-table": "^0.1.0",
+                "mdast-util-gfm-task-list-item": "^0.1.0",
+                "mdast-util-to-markdown": "^0.6.1"
+            }
+        },
+        "mdast-util-gfm-autolink-literal": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+            "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+            "requires": {
+                "ccount": "^1.0.0",
+                "mdast-util-find-and-replace": "^1.1.0",
+                "micromark": "^2.11.3"
+            }
+        },
+        "mdast-util-gfm-strikethrough": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+            "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+            "requires": {
+                "mdast-util-to-markdown": "^0.6.0"
+            }
+        },
+        "mdast-util-gfm-table": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+            "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+            "requires": {
+                "markdown-table": "^2.0.0",
+                "mdast-util-to-markdown": "~0.6.0"
+            }
+        },
+        "mdast-util-gfm-task-list-item": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+            "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+            "requires": {
+                "mdast-util-to-markdown": "~0.6.0"
+            }
+        },
+        "mdast-util-to-markdown": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+            "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "longest-streak": "^2.0.0",
+                "mdast-util-to-string": "^2.0.0",
+                "parse-entities": "^2.0.0",
+                "repeat-string": "^1.0.0",
+                "zwitch": "^1.0.0"
+            }
+        },
+        "mdast-util-to-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
         },
         "mdn-data": {
             "version": "2.0.4",
@@ -12386,14 +13443,12 @@
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
         },
         "methods": {
             "version": "1.1.2",
@@ -12401,11 +13456,69 @@
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
             "dev": true
         },
+        "micromark": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "requires": {
+                "debug": "^4.0.0",
+                "parse-entities": "^2.0.0"
+            }
+        },
+        "micromark-extension-gfm": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+            "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+            "requires": {
+                "micromark": "~2.11.0",
+                "micromark-extension-gfm-autolink-literal": "~0.5.0",
+                "micromark-extension-gfm-strikethrough": "~0.6.5",
+                "micromark-extension-gfm-table": "~0.4.0",
+                "micromark-extension-gfm-tagfilter": "~0.3.0",
+                "micromark-extension-gfm-task-list-item": "~0.3.0"
+            }
+        },
+        "micromark-extension-gfm-autolink-literal": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+            "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+            "requires": {
+                "micromark": "~2.11.3"
+            }
+        },
+        "micromark-extension-gfm-strikethrough": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+            "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+            "requires": {
+                "micromark": "~2.11.0"
+            }
+        },
+        "micromark-extension-gfm-table": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+            "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+            "requires": {
+                "micromark": "~2.11.0"
+            }
+        },
+        "micromark-extension-gfm-tagfilter": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+            "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q=="
+        },
+        "micromark-extension-gfm-task-list-item": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+            "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+            "requires": {
+                "micromark": "~2.11.0"
+            }
+        },
         "micromatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
             "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-            "dev": true,
             "requires": {
                 "braces": "^3.0.1",
                 "picomatch": "^2.0.5"
@@ -12435,14 +13548,12 @@
         "mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-            "dev": true
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
         },
         "minimalistic-assert": {
             "version": "1.0.1",
@@ -12454,7 +13565,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -12462,14 +13572,12 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minimist-options": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
             "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-            "dev": true,
             "requires": {
                 "arrify": "^1.0.1",
                 "is-plain-obj": "^1.1.0",
@@ -12511,11 +13619,15 @@
                 "minimist": "^1.2.5"
             }
         },
+        "modify-values": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+            "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multicast-dns": {
             "version": "6.2.3",
@@ -12585,8 +13697,12 @@
         "neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+        },
+        "nerf-dart": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+            "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo="
         },
         "nice-try": {
             "version": "1.0.5",
@@ -12609,6 +13725,43 @@
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
                     "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
                     "dev": true
+                }
+            }
+        },
+        "node-emoji": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+            "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+            "requires": {
+                "lodash": "^4.17.21"
+            }
+        },
+        "node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
                 }
             }
         },
@@ -12661,7 +13814,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -12680,6 +13832,1487 @@
             "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
             "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
             "dev": true
+        },
+        "normalize-url": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+        },
+        "npm": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
+            "integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
+            "requires": {
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/arborist": "^5.0.4",
+                "@npmcli/ci-detect": "^2.0.0",
+                "@npmcli/config": "^4.0.1",
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/map-workspaces": "^2.0.2",
+                "@npmcli/package-json": "^1.0.1",
+                "@npmcli/run-script": "^3.0.1",
+                "abbrev": "~1.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "archy": "~1.0.0",
+                "cacache": "^16.0.3",
+                "chalk": "^4.1.2",
+                "chownr": "^2.0.0",
+                "cli-columns": "^4.0.0",
+                "cli-table3": "^0.6.1",
+                "columnify": "^1.6.0",
+                "fastest-levenshtein": "^1.0.12",
+                "glob": "^7.2.0",
+                "graceful-fs": "^4.2.9",
+                "hosted-git-info": "^5.0.0",
+                "ini": "^2.0.0",
+                "init-package-json": "^3.0.2",
+                "is-cidr": "^4.0.2",
+                "json-parse-even-better-errors": "^2.3.1",
+                "libnpmaccess": "^6.0.2",
+                "libnpmdiff": "^4.0.2",
+                "libnpmexec": "^4.0.2",
+                "libnpmfund": "^3.0.1",
+                "libnpmhook": "^8.0.2",
+                "libnpmorg": "^4.0.2",
+                "libnpmpack": "^4.0.2",
+                "libnpmpublish": "^6.0.2",
+                "libnpmsearch": "^5.0.2",
+                "libnpmteam": "^4.0.2",
+                "libnpmversion": "^3.0.1",
+                "make-fetch-happen": "^10.1.1",
+                "minipass": "^3.1.6",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "mkdirp-infer-owner": "^2.0.0",
+                "ms": "^2.1.2",
+                "node-gyp": "^9.0.0",
+                "nopt": "^5.0.0",
+                "npm-audit-report": "^3.0.0",
+                "npm-install-checks": "^4.0.0",
+                "npm-package-arg": "^9.0.1",
+                "npm-pick-manifest": "^7.0.0",
+                "npm-profile": "^6.0.2",
+                "npm-registry-fetch": "^13.1.0",
+                "npm-user-validate": "^1.0.1",
+                "npmlog": "^6.0.1",
+                "opener": "^1.5.2",
+                "pacote": "^13.0.5",
+                "parse-conflict-json": "^2.0.2",
+                "proc-log": "^2.0.1",
+                "qrcode-terminal": "^0.12.0",
+                "read": "~1.0.7",
+                "read-package-json": "^5.0.0",
+                "read-package-json-fast": "^2.0.3",
+                "readdir-scoped-modules": "^1.1.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "ssri": "^8.0.1",
+                "tar": "^6.1.11",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
+                "treeverse": "^1.0.4",
+                "validate-npm-package-name": "^4.0.0",
+                "which": "^2.0.2",
+                "write-file-atomic": "^4.0.1"
+            },
+            "dependencies": {
+                "@gar/promisify": {
+                    "version": "1.1.3",
+                    "bundled": true
+                },
+                "@isaacs/string-locale-compare": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "@npmcli/arborist": {
+                    "version": "5.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "@isaacs/string-locale-compare": "^1.1.0",
+                        "@npmcli/installed-package-contents": "^1.0.7",
+                        "@npmcli/map-workspaces": "^2.0.0",
+                        "@npmcli/metavuln-calculator": "^3.0.1",
+                        "@npmcli/move-file": "^1.1.0",
+                        "@npmcli/name-from-folder": "^1.0.1",
+                        "@npmcli/node-gyp": "^1.0.3",
+                        "@npmcli/package-json": "^1.0.1",
+                        "@npmcli/run-script": "^3.0.0",
+                        "bin-links": "^3.0.0",
+                        "cacache": "^16.0.0",
+                        "common-ancestor-path": "^1.0.1",
+                        "json-parse-even-better-errors": "^2.3.1",
+                        "json-stringify-nice": "^1.1.4",
+                        "mkdirp": "^1.0.4",
+                        "mkdirp-infer-owner": "^2.0.0",
+                        "nopt": "^5.0.0",
+                        "npm-install-checks": "^4.0.0",
+                        "npm-package-arg": "^9.0.0",
+                        "npm-pick-manifest": "^7.0.0",
+                        "npm-registry-fetch": "^13.0.0",
+                        "npmlog": "^6.0.1",
+                        "pacote": "^13.0.5",
+                        "parse-conflict-json": "^2.0.1",
+                        "proc-log": "^2.0.0",
+                        "promise-all-reject-late": "^1.0.0",
+                        "promise-call-limit": "^1.0.1",
+                        "read-package-json-fast": "^2.0.2",
+                        "readdir-scoped-modules": "^1.1.0",
+                        "rimraf": "^3.0.2",
+                        "semver": "^7.3.5",
+                        "ssri": "^8.0.1",
+                        "treeverse": "^1.0.4",
+                        "walk-up-path": "^1.0.0"
+                    }
+                },
+                "@npmcli/ci-detect": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "@npmcli/config": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/map-workspaces": "^2.0.1",
+                        "ini": "^2.0.0",
+                        "mkdirp-infer-owner": "^2.0.0",
+                        "nopt": "^5.0.0",
+                        "proc-log": "^2.0.0",
+                        "read-package-json-fast": "^2.0.3",
+                        "semver": "^7.3.5",
+                        "walk-up-path": "^1.0.0"
+                    }
+                },
+                "@npmcli/disparity-colors": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-styles": "^4.3.0"
+                    }
+                },
+                "@npmcli/fs": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "@gar/promisify": "^1.1.3",
+                        "semver": "^7.3.5"
+                    }
+                },
+                "@npmcli/git": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/promise-spawn": "^1.3.2",
+                        "lru-cache": "^7.3.1",
+                        "mkdirp": "^1.0.4",
+                        "npm-pick-manifest": "^7.0.0",
+                        "proc-log": "^2.0.0",
+                        "promise-inflight": "^1.0.1",
+                        "promise-retry": "^2.0.1",
+                        "semver": "^7.3.5",
+                        "which": "^2.0.2"
+                    }
+                },
+                "@npmcli/installed-package-contents": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "requires": {
+                        "npm-bundled": "^1.1.1",
+                        "npm-normalize-package-bin": "^1.0.1"
+                    }
+                },
+                "@npmcli/map-workspaces": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/name-from-folder": "^1.0.1",
+                        "glob": "^7.2.0",
+                        "minimatch": "^5.0.1",
+                        "read-package-json-fast": "^2.0.3"
+                    },
+                    "dependencies": {
+                        "brace-expansion": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "balanced-match": "^1.0.0"
+                            }
+                        },
+                        "minimatch": {
+                            "version": "5.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "brace-expansion": "^2.0.1"
+                            }
+                        }
+                    }
+                },
+                "@npmcli/metavuln-calculator": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "cacache": "^16.0.0",
+                        "json-parse-even-better-errors": "^2.3.1",
+                        "pacote": "^13.0.3",
+                        "semver": "^7.3.5"
+                    }
+                },
+                "@npmcli/move-file": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "mkdirp": "^1.0.4",
+                        "rimraf": "^3.0.2"
+                    }
+                },
+                "@npmcli/name-from-folder": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "@npmcli/node-gyp": {
+                    "version": "1.0.3",
+                    "bundled": true
+                },
+                "@npmcli/package-json": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "json-parse-even-better-errors": "^2.3.1"
+                    }
+                },
+                "@npmcli/promise-spawn": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "infer-owner": "^1.0.4"
+                    }
+                },
+                "@npmcli/run-script": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/node-gyp": "^1.0.3",
+                        "@npmcli/promise-spawn": "^1.3.2",
+                        "node-gyp": "^9.0.0",
+                        "read-package-json-fast": "^2.0.3"
+                    }
+                },
+                "@tootallnate/once": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "agent-base": {
+                    "version": "6.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "4"
+                    }
+                },
+                "agentkeepalive": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "^4.1.0",
+                        "depd": "^1.1.2",
+                        "humanize-ms": "^1.2.1"
+                    }
+                },
+                "aggregate-error": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "clean-stack": "^2.0.0",
+                        "indent-string": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "ansicolors": {
+                    "version": "0.3.2",
+                    "bundled": true
+                },
+                "ansistyles": {
+                    "version": "0.1.3",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "are-we-there-yet": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^3.6.0"
+                    }
+                },
+                "asap": {
+                    "version": "2.0.6",
+                    "bundled": true
+                },
+                "balanced-match": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "bin-links": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "cmd-shim": "^4.0.1",
+                        "mkdirp-infer-owner": "^2.0.0",
+                        "npm-normalize-package-bin": "^1.0.0",
+                        "read-cmd-shim": "^2.0.0",
+                        "rimraf": "^3.0.0",
+                        "write-file-atomic": "^4.0.0"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "2.2.0",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "builtins": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "semver": "^7.0.0"
+                    }
+                },
+                "cacache": {
+                    "version": "16.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/fs": "^2.1.0",
+                        "@npmcli/move-file": "^1.1.2",
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.1.0",
+                        "glob": "^7.2.0",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^7.7.1",
+                        "minipass": "^3.1.6",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "mkdirp": "^1.0.4",
+                        "p-map": "^4.0.0",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^3.0.2",
+                        "ssri": "^8.0.1",
+                        "tar": "^6.1.11",
+                        "unique-filename": "^1.1.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "chownr": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "cidr-regex": {
+                    "version": "3.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "ip-regex": "^4.1.0"
+                    }
+                },
+                "clean-stack": {
+                    "version": "2.2.0",
+                    "bundled": true
+                },
+                "cli-columns": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^4.2.3",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "cli-table3": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "requires": {
+                        "colors": "1.4.0",
+                        "string-width": "^4.2.0"
+                    }
+                },
+                "clone": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "cmd-shim": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "mkdirp-infer-owner": "^2.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "bundled": true
+                },
+                "color-support": {
+                    "version": "1.1.3",
+                    "bundled": true
+                },
+                "colors": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "columnify": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "requires": {
+                        "strip-ansi": "^6.0.1",
+                        "wcwidth": "^1.0.0"
+                    }
+                },
+                "common-ancestor-path": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "debug": {
+                    "version": "4.3.4",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.1.2",
+                            "bundled": true
+                        }
+                    }
+                },
+                "debuglog": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "defaults": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "clone": "^1.0.2"
+                    }
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "depd": {
+                    "version": "1.1.2",
+                    "bundled": true
+                },
+                "dezalgo": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "asap": "^2.0.0",
+                        "wrappy": "1"
+                    }
+                },
+                "diff": {
+                    "version": "5.0.0",
+                    "bundled": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "bundled": true
+                },
+                "encoding": {
+                    "version": "0.1.13",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "iconv-lite": "^0.6.2"
+                    }
+                },
+                "env-paths": {
+                    "version": "2.2.1",
+                    "bundled": true
+                },
+                "err-code": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "fastest-levenshtein": {
+                    "version": "1.0.12",
+                    "bundled": true
+                },
+                "fs-minipass": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^3.0.0"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "gauge": {
+                    "version": "4.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^1.0.3 || ^2.0.0",
+                        "color-support": "^1.1.3",
+                        "console-control-strings": "^1.1.0",
+                        "has-unicode": "^2.0.1",
+                        "signal-exit": "^3.0.7",
+                        "string-width": "^4.2.3",
+                        "strip-ansi": "^6.0.1",
+                        "wide-align": "^1.1.5"
+                    }
+                },
+                "glob": {
+                    "version": "7.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.9",
+                    "bundled": true
+                },
+                "has": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "bundled": true
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "hosted-git-info": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "lru-cache": "^7.5.1"
+                    }
+                },
+                "http-cache-semantics": {
+                    "version": "4.1.0",
+                    "bundled": true
+                },
+                "http-proxy-agent": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "@tootallnate/once": "2",
+                        "agent-base": "6",
+                        "debug": "4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "agent-base": "6",
+                        "debug": "4"
+                    }
+                },
+                "humanize-ms": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "^2.0.0"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.6.3",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true
+                },
+                "indent-string": {
+                    "version": "4.0.0",
+                    "bundled": true
+                },
+                "infer-owner": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.4",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "init-package-json": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "npm-package-arg": "^9.0.1",
+                        "promzard": "^0.3.0",
+                        "read": "^1.0.7",
+                        "read-package-json": "^5.0.0",
+                        "semver": "^7.3.5",
+                        "validate-npm-package-license": "^3.0.4",
+                        "validate-npm-package-name": "^4.0.0"
+                    }
+                },
+                "ip": {
+                    "version": "1.1.5",
+                    "bundled": true
+                },
+                "ip-regex": {
+                    "version": "4.3.0",
+                    "bundled": true
+                },
+                "is-cidr": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "cidr-regex": "^3.1.1"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.8.1",
+                    "bundled": true,
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "is-lambda": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "json-parse-even-better-errors": {
+                    "version": "2.3.1",
+                    "bundled": true
+                },
+                "json-stringify-nice": {
+                    "version": "1.1.4",
+                    "bundled": true
+                },
+                "jsonparse": {
+                    "version": "1.3.1",
+                    "bundled": true
+                },
+                "just-diff": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "just-diff-apply": {
+                    "version": "5.2.0",
+                    "bundled": true
+                },
+                "libnpmaccess": {
+                    "version": "6.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "minipass": "^3.1.1",
+                        "npm-package-arg": "^9.0.1",
+                        "npm-registry-fetch": "^13.0.0"
+                    }
+                },
+                "libnpmdiff": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/disparity-colors": "^1.0.1",
+                        "@npmcli/installed-package-contents": "^1.0.7",
+                        "binary-extensions": "^2.2.0",
+                        "diff": "^5.0.0",
+                        "minimatch": "^3.0.4",
+                        "npm-package-arg": "^9.0.1",
+                        "pacote": "^13.0.5",
+                        "tar": "^6.1.0"
+                    }
+                },
+                "libnpmexec": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/arborist": "^5.0.0",
+                        "@npmcli/ci-detect": "^2.0.0",
+                        "@npmcli/run-script": "^3.0.0",
+                        "chalk": "^4.1.0",
+                        "mkdirp-infer-owner": "^2.0.0",
+                        "npm-package-arg": "^9.0.1",
+                        "npmlog": "^6.0.1",
+                        "pacote": "^13.0.5",
+                        "proc-log": "^2.0.0",
+                        "read": "^1.0.7",
+                        "read-package-json-fast": "^2.0.2",
+                        "walk-up-path": "^1.0.0"
+                    }
+                },
+                "libnpmfund": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/arborist": "^5.0.0"
+                    }
+                },
+                "libnpmhook": {
+                    "version": "8.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "npm-registry-fetch": "^13.0.0"
+                    }
+                },
+                "libnpmorg": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "npm-registry-fetch": "^13.0.0"
+                    }
+                },
+                "libnpmpack": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/run-script": "^3.0.0",
+                        "npm-package-arg": "^9.0.1",
+                        "pacote": "^13.0.5"
+                    }
+                },
+                "libnpmpublish": {
+                    "version": "6.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "normalize-package-data": "^4.0.0",
+                        "npm-package-arg": "^9.0.1",
+                        "npm-registry-fetch": "^13.0.0",
+                        "semver": "^7.1.3",
+                        "ssri": "^8.0.1"
+                    }
+                },
+                "libnpmsearch": {
+                    "version": "5.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "npm-registry-fetch": "^13.0.0"
+                    }
+                },
+                "libnpmteam": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "npm-registry-fetch": "^13.0.0"
+                    }
+                },
+                "libnpmversion": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/git": "^3.0.0",
+                        "@npmcli/run-script": "^3.0.0",
+                        "json-parse-even-better-errors": "^2.3.1",
+                        "proc-log": "^2.0.0",
+                        "semver": "^7.3.5",
+                        "stringify-package": "^1.0.1"
+                    }
+                },
+                "lru-cache": {
+                    "version": "7.7.1",
+                    "bundled": true
+                },
+                "make-fetch-happen": {
+                    "version": "10.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "agentkeepalive": "^4.2.1",
+                        "cacache": "^16.0.2",
+                        "http-cache-semantics": "^4.1.0",
+                        "http-proxy-agent": "^5.0.0",
+                        "https-proxy-agent": "^5.0.0",
+                        "is-lambda": "^1.0.1",
+                        "lru-cache": "^7.7.1",
+                        "minipass": "^3.1.6",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-fetch": "^2.0.3",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "negotiator": "^0.6.3",
+                        "promise-retry": "^2.0.1",
+                        "socks-proxy-agent": "^6.1.1",
+                        "ssri": "^8.0.1"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minipass": {
+                    "version": "3.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "minipass-collect": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^3.0.0"
+                    }
+                },
+                "minipass-fetch": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "encoding": "^0.1.13",
+                        "minipass": "^3.1.6",
+                        "minipass-sized": "^1.0.3",
+                        "minizlib": "^2.1.2"
+                    }
+                },
+                "minipass-flush": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^3.0.0"
+                    }
+                },
+                "minipass-json-stream": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "jsonparse": "^1.3.1",
+                        "minipass": "^3.0.0"
+                    }
+                },
+                "minipass-pipeline": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^3.0.0"
+                    }
+                },
+                "minipass-sized": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^3.0.0",
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "mkdirp-infer-owner": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "chownr": "^2.0.0",
+                        "infer-owner": "^1.0.4",
+                        "mkdirp": "^1.0.3"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.3",
+                    "bundled": true
+                },
+                "mute-stream": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "negotiator": {
+                    "version": "0.6.3",
+                    "bundled": true
+                },
+                "node-gyp": {
+                    "version": "9.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "env-paths": "^2.2.0",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.2.6",
+                        "make-fetch-happen": "^10.0.3",
+                        "nopt": "^5.0.0",
+                        "npmlog": "^6.0.0",
+                        "rimraf": "^3.0.2",
+                        "semver": "^7.3.5",
+                        "tar": "^6.1.2",
+                        "which": "^2.0.2"
+                    }
+                },
+                "nopt": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "abbrev": "1"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "hosted-git-info": "^5.0.0",
+                        "is-core-module": "^2.8.1",
+                        "semver": "^7.3.5",
+                        "validate-npm-package-license": "^3.0.4"
+                    }
+                },
+                "npm-audit-report": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "npm-normalize-package-bin": "^1.0.1"
+                    }
+                },
+                "npm-install-checks": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "semver": "^7.1.1"
+                    }
+                },
+                "npm-normalize-package-bin": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "npm-package-arg": {
+                    "version": "9.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "hosted-git-info": "^5.0.0",
+                        "semver": "^7.3.5",
+                        "validate-npm-package-name": "^4.0.0"
+                    }
+                },
+                "npm-packlist": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "^7.2.0",
+                        "ignore-walk": "^4.0.1",
+                        "npm-bundled": "^1.1.2",
+                        "npm-normalize-package-bin": "^1.0.1"
+                    }
+                },
+                "npm-pick-manifest": {
+                    "version": "7.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "npm-install-checks": "^4.0.0",
+                        "npm-normalize-package-bin": "^1.0.1",
+                        "npm-package-arg": "^9.0.0",
+                        "semver": "^7.3.5"
+                    }
+                },
+                "npm-profile": {
+                    "version": "6.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "npm-registry-fetch": "^13.0.0",
+                        "proc-log": "^2.0.0"
+                    }
+                },
+                "npm-registry-fetch": {
+                    "version": "13.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "make-fetch-happen": "^10.0.6",
+                        "minipass": "^3.1.6",
+                        "minipass-fetch": "^2.0.3",
+                        "minipass-json-stream": "^1.0.1",
+                        "minizlib": "^2.1.2",
+                        "npm-package-arg": "^9.0.1",
+                        "proc-log": "^2.0.0"
+                    }
+                },
+                "npm-user-validate": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "npmlog": {
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "are-we-there-yet": "^3.0.0",
+                        "console-control-strings": "^1.1.0",
+                        "gauge": "^4.0.0",
+                        "set-blocking": "^2.0.0"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "opener": {
+                    "version": "1.5.2",
+                    "bundled": true
+                },
+                "p-map": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "aggregate-error": "^3.0.0"
+                    }
+                },
+                "pacote": {
+                    "version": "13.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "@npmcli/git": "^3.0.0",
+                        "@npmcli/installed-package-contents": "^1.0.7",
+                        "@npmcli/promise-spawn": "^1.2.0",
+                        "@npmcli/run-script": "^3.0.1",
+                        "cacache": "^16.0.0",
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.1.0",
+                        "infer-owner": "^1.0.4",
+                        "minipass": "^3.1.6",
+                        "mkdirp": "^1.0.4",
+                        "npm-package-arg": "^9.0.0",
+                        "npm-packlist": "^4.0.0",
+                        "npm-pick-manifest": "^7.0.0",
+                        "npm-registry-fetch": "^13.0.1",
+                        "proc-log": "^2.0.0",
+                        "promise-retry": "^2.0.1",
+                        "read-package-json": "^5.0.0",
+                        "read-package-json-fast": "^2.0.3",
+                        "rimraf": "^3.0.2",
+                        "ssri": "^8.0.1",
+                        "tar": "^6.1.11"
+                    }
+                },
+                "parse-conflict-json": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "json-parse-even-better-errors": "^2.3.1",
+                        "just-diff": "^5.0.1",
+                        "just-diff-apply": "^5.2.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "proc-log": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "promise-all-reject-late": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "promise-call-limit": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "promise-inflight": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "promise-retry": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "err-code": "^2.0.2",
+                        "retry": "^0.12.0"
+                    }
+                },
+                "promzard": {
+                    "version": "0.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "read": "1"
+                    }
+                },
+                "qrcode-terminal": {
+                    "version": "0.12.0",
+                    "bundled": true
+                },
+                "read": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "requires": {
+                        "mute-stream": "~0.0.4"
+                    }
+                },
+                "read-cmd-shim": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "read-package-json": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "^7.2.0",
+                        "json-parse-even-better-errors": "^2.3.1",
+                        "normalize-package-data": "^4.0.0",
+                        "npm-normalize-package-bin": "^1.0.1"
+                    }
+                },
+                "read-package-json-fast": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "json-parse-even-better-errors": "^2.3.0",
+                        "npm-normalize-package-bin": "^1.0.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "bundled": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "readdir-scoped-modules": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
+                    }
+                },
+                "retry": {
+                    "version": "0.12.0",
+                    "bundled": true
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "bundled": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "7.3.5",
+                    "bundled": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        }
+                    }
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "signal-exit": {
+                    "version": "3.0.7",
+                    "bundled": true
+                },
+                "smart-buffer": {
+                    "version": "4.2.0",
+                    "bundled": true
+                },
+                "socks": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "requires": {
+                        "ip": "^1.1.5",
+                        "smart-buffer": "^4.2.0"
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "6.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "agent-base": "^6.0.2",
+                        "debug": "^4.3.1",
+                        "socks": "^2.6.1"
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.3.0",
+                    "bundled": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.11",
+                    "bundled": true
+                },
+                "ssri": {
+                    "version": "8.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^3.1.1"
+                    }
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "bundled": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                },
+                "stringify-package": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "6.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.0.0",
+                        "minipass": "^3.0.0",
+                        "minizlib": "^2.1.1",
+                        "mkdirp": "^1.0.3",
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "text-table": {
+                    "version": "0.2.0",
+                    "bundled": true
+                },
+                "tiny-relative-date": {
+                    "version": "1.3.0",
+                    "bundled": true
+                },
+                "treeverse": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "unique-filename": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "unique-slug": "^2.0.0"
+                    }
+                },
+                "unique-slug": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
+                    }
+                },
+                "validate-npm-package-name": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "builtins": "^5.0.0"
+                    }
+                },
+                "walk-up-path": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "wcwidth": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "defaults": "^1.0.3"
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^1.0.2 || 2 || 3 || 4"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "write-file-atomic": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.7"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "bundled": true
+                }
+            }
         },
         "npm-run-path": {
             "version": "2.0.2",
@@ -13135,7 +15768,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -13144,7 +15776,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
             }
@@ -13210,14 +15841,26 @@
         "p-each-series": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-            "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
-            "dev": true
+            "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA=="
+        },
+        "p-filter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+            "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+            "requires": {
+                "p-map": "^2.0.0"
+            }
         },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
             "dev": true
+        },
+        "p-is-promise": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+            "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
         },
         "p-limit": {
             "version": "3.1.0",
@@ -13240,8 +15883,12 @@
         "p-map": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-            "dev": true
+            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+        },
+        "p-reduce": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+            "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="
         },
         "p-retry": {
             "version": "3.0.1",
@@ -13255,8 +15902,7 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "param-case": {
             "version": "3.0.4",
@@ -13280,16 +15926,27 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
+            }
+        },
+        "parse-entities": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+            "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+            "requires": {
+                "character-entities": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "character-reference-invalid": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
             }
         },
         "parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -13342,14 +15999,12 @@
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -13360,20 +16015,17 @@
         "path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "path-parse": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "pend": {
             "version": "1.2.0",
@@ -13396,8 +16048,7 @@
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-            "dev": true
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
         },
         "pify": {
             "version": "4.0.1",
@@ -13427,6 +16078,60 @@
             "dev": true,
             "requires": {
                 "node-modules-regexp": "^1.0.0"
+            }
+        },
+        "pkg-conf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+            "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+            "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                }
             }
         },
         "pkg-dir": {
@@ -13663,8 +16368,7 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "progress": {
             "version": "2.0.3",
@@ -13745,8 +16449,7 @@
         "q": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-            "dev": true
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "qs": {
             "version": "6.5.2",
@@ -13769,14 +16472,12 @@
         "queue-microtask": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
-            "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
-            "dev": true
+            "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
         },
         "quick-lru": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-            "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-            "dev": true
+            "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
         },
         "ramda": {
             "version": "0.27.1",
@@ -13816,6 +16517,24 @@
                     "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
                     "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
                     "dev": true
+                }
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
                 }
             }
         },
@@ -13994,7 +16713,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
             "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-            "dev": true,
             "requires": {
                 "@types/normalize-package-data": "^2.4.0",
                 "normalize-package-data": "^2.5.0",
@@ -14005,8 +16723,7 @@
                 "type-fest": {
                     "version": "0.6.0",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-                    "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-                    "dev": true
+                    "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
                 }
             }
         },
@@ -14014,7 +16731,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
             "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-            "dev": true,
             "requires": {
                 "find-up": "^4.1.0",
                 "read-pkg": "^5.2.0",
@@ -14025,7 +16741,6 @@
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "dev": true,
                     "requires": {
                         "locate-path": "^5.0.0",
                         "path-exists": "^4.0.0"
@@ -14035,7 +16750,6 @@
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                    "dev": true,
                     "requires": {
                         "p-locate": "^4.1.0"
                     }
@@ -14044,7 +16758,6 @@
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
                     "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-                    "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
                     }
@@ -14053,7 +16766,6 @@
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                    "dev": true,
                     "requires": {
                         "p-limit": "^2.2.0"
                     }
@@ -14064,7 +16776,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -14102,10 +16813,17 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
             "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-            "dev": true,
             "requires": {
                 "indent-string": "^4.0.0",
                 "strip-indent": "^3.0.0"
+            }
+        },
+        "redeyed": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+            "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+            "requires": {
+                "esprima": "~4.0.0"
             }
         },
         "reduce-css-calc": {
@@ -14208,6 +16926,14 @@
                 "unicode-match-property-value-ecmascript": "^1.2.0"
             }
         },
+        "registry-auth-token": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+            "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+            "requires": {
+                "rc": "^1.2.8"
+            }
+        },
         "regjsgen": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
@@ -14236,6 +16962,31 @@
             "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
             "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
             "dev": true
+        },
+        "remark-gfm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+            "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+            "requires": {
+                "mdast-util-gfm": "^0.1.0",
+                "micromark-extension-gfm": "^0.3.0"
+            }
+        },
+        "remark-parse": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+            "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+            "requires": {
+                "mdast-util-from-markdown": "^0.8.0"
+            }
+        },
+        "remark-stringify": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
+            "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
+            "requires": {
+                "mdast-util-to-markdown": "^0.6.0"
+            }
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
@@ -14282,8 +17033,7 @@
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "request": {
             "version": "2.88.2",
@@ -14375,8 +17125,7 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-from-string": {
             "version": "2.0.2",
@@ -14400,7 +17149,6 @@
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
             "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-            "dev": true,
             "requires": {
                 "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
@@ -14426,8 +17174,7 @@
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
         "resolve-url": {
             "version": "0.2.1",
@@ -14460,8 +17207,7 @@
         "reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
         },
         "rifm": {
             "version": "0.7.0",
@@ -14490,7 +17236,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
             }
@@ -14515,8 +17260,7 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safe-regex": {
             "version": "1.1.0",
@@ -14757,11 +17501,199 @@
                 "node-forge": "^0.10.0"
             }
         },
+        "semantic-release": {
+            "version": "19.0.2",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
+            "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
+            "requires": {
+                "@semantic-release/commit-analyzer": "^9.0.2",
+                "@semantic-release/error": "^3.0.0",
+                "@semantic-release/github": "^8.0.0",
+                "@semantic-release/npm": "^9.0.0",
+                "@semantic-release/release-notes-generator": "^10.0.0",
+                "aggregate-error": "^3.0.0",
+                "cosmiconfig": "^7.0.0",
+                "debug": "^4.0.0",
+                "env-ci": "^5.0.0",
+                "execa": "^5.0.0",
+                "figures": "^3.0.0",
+                "find-versions": "^4.0.0",
+                "get-stream": "^6.0.0",
+                "git-log-parser": "^1.2.0",
+                "hook-std": "^2.0.0",
+                "hosted-git-info": "^4.0.0",
+                "lodash": "^4.17.21",
+                "marked": "^4.0.10",
+                "marked-terminal": "^5.0.0",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^2.1.0",
+                "p-reduce": "^2.0.0",
+                "read-pkg-up": "^7.0.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.3.2",
+                "semver-diff": "^3.1.1",
+                "signale": "^1.2.1",
+                "yargs": "^16.2.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "cliui": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^7.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                },
+                "execa": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+                    "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.0",
+                        "human-signals": "^2.1.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.1",
+                        "onetime": "^5.1.2",
+                        "signal-exit": "^3.0.3",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+                },
+                "hosted-git-info": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "human-signals": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+                    "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+                },
+                "is-stream": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                    "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+                },
+                "semver": {
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "5.0.8",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+                },
+                "yargs": {
+                    "version": "16.2.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.0",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^20.2.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+                }
+            }
+        },
+        "semantic-release-plugin-update-version-in-files": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semantic-release-plugin-update-version-in-files/-/semantic-release-plugin-update-version-in-files-1.1.0.tgz",
+            "integrity": "sha512-OWBrved3Rr0w3YP4iID81MhG9qhGrG+XtxdO9VMhKJ9qte3yBdMz5cSxDiPE/uhnGJQF00fqQetY3yhHFGabWw==",
+            "requires": {
+                "debug": "^4.1.1",
+                "glob": "^7.1.3"
+            }
+        },
+        "semantic-release-slack-bot": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/semantic-release-slack-bot/-/semantic-release-slack-bot-3.5.2.tgz",
+            "integrity": "sha512-xCig9RxUW9EJ6w5Hvoo4U0u9OAClBxkJCWBPwQSROlzMx1SzhjU8wfQkYBOIJACRqOGQS2qfETZTRdK/7CpGeA==",
+            "requires": {
+                "@semantic-release/error": "^2.2.0",
+                "micromatch": "4.0.2",
+                "node-fetch": "^2.3.0",
+                "slackify-markdown": "^4.3.0"
+            },
+            "dependencies": {
+                "@semantic-release/error": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+                    "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
+                }
+            }
+        },
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -14769,11 +17701,25 @@
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
             "dev": true
         },
+        "semver-diff": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+            "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+            "requires": {
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
         "semver-regex": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-            "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
-            "dev": true
+            "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA=="
         },
         "send": {
             "version": "0.17.1",
@@ -14951,7 +17897,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^3.0.0"
             }
@@ -14959,8 +17904,7 @@
         "shebang-regex": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "shellwords": {
             "version": "0.1.1",
@@ -14983,8 +17927,27 @@
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "dev": true
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+        },
+        "signale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+            "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+            "requires": {
+                "chalk": "^2.3.2",
+                "figures": "^2.0.0",
+                "pkg-conf": "^2.1.0"
+            },
+            "dependencies": {
+                "figures": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                }
+            }
         },
         "sirv": {
             "version": "1.0.11",
@@ -15011,11 +17974,24 @@
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "dev": true
         },
+        "slackify-markdown": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/slackify-markdown/-/slackify-markdown-4.3.1.tgz",
+            "integrity": "sha512-6Uktkq4rEB6JZlRguI/dpPDF6Rak6QXZm3Gv2IM0VMeYQRSufp+TLFfOylxwINnOeMRc9ciYRhsbt1hUFD+uuQ==",
+            "requires": {
+                "mdast-util-to-markdown": "^0.6.2",
+                "remark-gfm": "^1.0.0",
+                "remark-parse": "^9.0.0",
+                "remark-stringify": "^9.0.1",
+                "unified": "^9.0.0",
+                "unist-util-remove": "^2.0.1",
+                "unist-util-visit": "^2.0.3"
+            }
+        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
         "slice-ansi": {
             "version": "4.0.0",
@@ -15285,11 +18261,15 @@
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
             "dev": true
         },
+        "spawn-error-forwarder": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+            "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk="
+        },
         "spdx-correct": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
             "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -15298,14 +18278,12 @@
         "spdx-exceptions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
         },
         "spdx-expression-parse": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
             "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -15314,8 +18292,7 @@
         "spdx-license-ids": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
-            "dev": true
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
         },
         "spdy": {
             "version": "4.0.2",
@@ -15350,6 +18327,14 @@
             "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
             "dev": true
         },
+        "split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "requires": {
+                "through": "2"
+            }
+        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15357,6 +18342,14 @@
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
+            }
+        },
+        "split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "requires": {
+                "readable-stream": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -15455,6 +18448,39 @@
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
             "dev": true
         },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "requires": {
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
         "string-argv": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -15475,7 +18501,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
             "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-            "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -15600,7 +18625,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.2.0"
             },
@@ -15608,8 +18632,7 @@
                 "safe-buffer": {
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                    "dev": true
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
             }
         },
@@ -15628,7 +18651,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
             "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^5.0.0"
             }
@@ -15648,14 +18670,12 @@
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
         },
         "strip-indent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
             "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-            "dev": true,
             "requires": {
                 "min-indent": "^1.0.0"
             }
@@ -15995,7 +19015,6 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }
@@ -16137,6 +19156,71 @@
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
             "dev": true
         },
+        "temp-dir": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="
+        },
+        "tempy": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+            "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+            "requires": {
+                "del": "^6.0.0",
+                "is-stream": "^2.0.0",
+                "temp-dir": "^2.0.0",
+                "type-fest": "^0.16.0",
+                "unique-string": "^2.0.0"
+            },
+            "dependencies": {
+                "del": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+                    "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+                    "requires": {
+                        "globby": "^11.0.1",
+                        "graceful-fs": "^4.2.4",
+                        "is-glob": "^4.0.1",
+                        "is-path-cwd": "^2.2.0",
+                        "is-path-inside": "^3.0.2",
+                        "p-map": "^4.0.0",
+                        "rimraf": "^3.0.2",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "is-path-inside": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+                    "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
+                },
+                "is-stream": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                    "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+                },
+                "p-map": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+                    "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+                    "requires": {
+                        "aggregate-error": "^3.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.16.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+                    "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="
+                }
+            }
+        },
         "terminal-link": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -16230,6 +19314,11 @@
                 "minimatch": "^3.0.4"
             }
         },
+        "text-extensions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+            "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
+        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16251,8 +19340,15 @@
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "through2": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+            "requires": {
+                "readable-stream": "3"
+            }
         },
         "thunky": {
             "version": "1.1.0",
@@ -16341,7 +19437,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -16383,11 +19478,20 @@
                 "punycode": "^2.1.1"
             }
         },
+        "traverse": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+        },
         "trim-newlines": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-            "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-            "dev": true
+            "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+        },
+        "trough": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
         },
         "ts-jest": {
             "version": "26.5.1",
@@ -16560,8 +19664,7 @@
         "type-fest": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-            "dev": true
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
         },
         "type-is": {
             "version": "1.6.18",
@@ -16587,6 +19690,12 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
             "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
             "dev": true
+        },
+        "uglify-js": {
+            "version": "3.15.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+            "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+            "optional": true
         },
         "unbox-primitive": {
             "version": "1.0.1",
@@ -16636,6 +19745,31 @@
             "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
             "dev": true
         },
+        "unified": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+            "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+            "requires": {
+                "bail": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-buffer": "^2.0.0",
+                "is-plain-obj": "^2.0.0",
+                "trough": "^1.0.0",
+                "vfile": "^4.0.0"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+                },
+                "is-plain-obj": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+                    "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+                }
+            }
+        },
         "union-value": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -16654,11 +19788,63 @@
             "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
             "dev": true
         },
+        "unique-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+            "requires": {
+                "crypto-random-string": "^2.0.0"
+            }
+        },
+        "unist-util-is": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
+        },
+        "unist-util-remove": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-2.1.0.tgz",
+            "integrity": "sha512-J8NYPyBm4baYLdCbjmf1bhPu45Cr1MWTm77qd9istEkzWpnN6O9tMsEbB2JhNnBCqGENRqEWomQ+He6au0B27Q==",
+            "requires": {
+                "unist-util-is": "^4.0.0"
+            }
+        },
+        "unist-util-stringify-position": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+            "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+            "requires": {
+                "@types/unist": "^2.0.2"
+            }
+        },
+        "unist-util-visit": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+            "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^4.0.0",
+                "unist-util-visit-parents": "^3.0.0"
+            }
+        },
+        "unist-util-visit-parents": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+            "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^4.0.0"
+            }
+        },
+        "universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        },
         "universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         },
         "unpipe": {
             "version": "1.0.0",
@@ -16763,6 +19949,11 @@
                 }
             }
         },
+        "url-join": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+        },
         "url-loader": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
@@ -16793,8 +19984,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util.promisify": {
             "version": "1.0.1",
@@ -16875,7 +20065,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -16896,6 +20085,33 @@
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
+            }
+        },
+        "vfile": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+            "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "is-buffer": "^2.0.0",
+                "unist-util-stringify-position": "^2.0.0",
+                "vfile-message": "^2.0.0"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+                }
+            }
+        },
+        "vfile-message": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+            "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-stringify-position": "^2.0.0"
             }
         },
         "void-elements": {
@@ -17940,7 +21156,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -17982,6 +21197,11 @@
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
         },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+        },
         "wrap-ansi": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -18022,8 +21242,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
             "version": "3.0.3",
@@ -18055,6 +21274,11 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
         },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
         "y18n": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
@@ -18064,14 +21288,12 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yaml": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-            "dev": true
+            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
         },
         "yargs": {
             "version": "15.4.1",
@@ -18183,6 +21405,11 @@
             "version": "3.5.10",
             "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.10.tgz",
             "integrity": "sha512-upluvSRWrlCiExu2UbkuMIPJ9AigyjRFoO7O9eUossIj7rPPq7pcJ0NKk6t2P7KF80tg/UdPX6/pNKOSbs9DEg=="
+        },
+        "zwitch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+            "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
         }
     }
 }

--- a/thirdeye-ui/package.json
+++ b/thirdeye-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@startree-ui/thirdeye-ui",
-    "version": "0.0.0-developement",
+    "version": "0.0.0-development",
     "description": "UI project for StarTree ThirdEye",
     "keywords": [
         "startree",
@@ -18,7 +18,7 @@
         "url": "https://www.startree.ai"
     },
     "license": "UNLICENSED",
-    "private": true,
+    "private": false,
     "repository": {
         "type": "git",
         "url": "https://github.com/startreedata/thirdeye.git",
@@ -44,7 +44,8 @@
         "prettier-check": "prettier . --check",
         "prettier-fix": "prettier . --write",
         "lint": "npm run eslint-fix && npm run stylelint-fix && npm run prettier-fix",
-        "lint-check": "npm run eslint-check && npm run stylelint-check && npm run prettier-check"
+        "lint-check": "npm run eslint-check && npm run stylelint-check && npm run prettier-check",
+        "release": "semantic-release"
     },
     "dependencies": {
         "@date-io/luxon": "^1.3.13",
@@ -106,6 +107,7 @@
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^7.0.0",
         "css-loader": "^5.0.1",
+        "conventional-changelog-conventionalcommits": "^4.6.3",
         "cypress": "^7.4.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
@@ -128,6 +130,9 @@
         "react-test-renderer": "^16.14.0",
         "sass": "^1.32.0",
         "sass-loader": "^10.1.0",
+        "semantic-release": "^19.0.2",
+        "semantic-release-plugin-update-version-in-files": "^1.1.0",
+        "semantic-release-slack-bot": "^3.5.2",
         "style-loader": "^2.0.0",
         "stylelint": "^14.3.0",
         "stylelint-config-prettier": "^9.0.3",

--- a/thirdeye-ui/src/app/utils/version/version.util.ts
+++ b/thirdeye-ui/src/app/utils/version/version.util.ts
@@ -1,0 +1,7 @@
+// Returns version number of current release
+// Version number placeholder is replaced by the precise release version number at the time of
+// release
+// Relevant configuration located in semantic-release configuration file
+export const getThirdEyeUiVersion = (): string => {
+    return "0.0.0-development-thirdeye-ui"; // Version number placeholder
+};


### PR DESCRIPTION
Setting up thirdeye UI in conjunction with concourse pipeline to release to NPM and replacing template string with the version tagged.

Successful run tested in https://ci.startreedata.io/teams/thirdeye/pipelines/publish-thirdeye-steven/jobs/build-thirdeye-ui/builds/28