### PR TITLE
fix(ui): force update version string replacement script

### DIFF
--- a/thirdeye-ui/.eslintignore
+++ b/thirdeye-ui/.eslintignore
@@ -27,3 +27,5 @@ src/test/e2e/downloads/
 # webpack (ESLint rules don't agree with how these configs are written)
 webpack.config.*.js
 webpack/
+
+scripts/verify-version-replacement.js

--- a/thirdeye-ui/.prettierignore
+++ b/thirdeye-ui/.prettierignore
@@ -48,3 +48,5 @@ webpack/
 .DS_Store
 
 pom.xml
+
+scripts/verify-version-replacement.js

--- a/thirdeye-ui/package.json
+++ b/thirdeye-ui/package.json
@@ -45,7 +45,7 @@
         "prettier-fix": "prettier . --write",
         "lint": "npm run eslint-fix && npm run stylelint-fix && npm run prettier-fix",
         "lint-check": "npm run eslint-check && npm run stylelint-check && npm run prettier-check",
-        "release": "semantic-release"
+        "release": "semantic-release && ./scripts/verify-version-replacement.js"
     },
     "dependencies": {
         "@date-io/luxon": "^1.3.13",

--- a/thirdeye-ui/scripts/verify-version-replacement.js
+++ b/thirdeye-ui/scripts/verify-version-replacement.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const childProcess = require("child_process");
+
+const FILE_CONTAINING_STRING_REPLACEMENT = "dist/thirdeye-ui.js";
+const VERSION_STRING_TEMPLATE = "0.0.0-development-thirdeye-ui";
+const FILE_CONTAINING_STRING_REPLACEMENT_PATH = path.resolve(
+    FILE_CONTAINING_STRING_REPLACEMENT
+);
+
+function checkIfTemplateVersionStringExists() {
+    const fileContents = fs.readFileSync(
+        FILE_CONTAINING_STRING_REPLACEMENT_PATH
+    );
+
+    return fileContents.includes(VERSION_STRING_TEMPLATE);
+}
+
+function replaceWithLatestTaggedVersion() {
+    const latestUIVersionTag = childProcess
+        .execSync("git describe --abbrev=0 --tags --match thirdeye-ui\\*")
+        .toString()
+        .replace("\n", "");
+
+    let fileContents = fs
+        .readFileSync(FILE_CONTAINING_STRING_REPLACEMENT_PATH)
+        .toString();
+
+    fileContents = fileContents.replace(
+        VERSION_STRING_TEMPLATE,
+        latestUIVersionTag
+    );
+
+    fs.writeFileSync(FILE_CONTAINING_STRING_REPLACEMENT_PATH, fileContents);
+}
+
+if (!fs.existsSync(FILE_CONTAINING_STRING_REPLACEMENT_PATH)) {
+    console.log(
+        "File ",
+        FILE_CONTAINING_STRING_REPLACEMENT,
+        " does not exist, skipping verification."
+    );
+
+    return;
+}
+
+if (checkIfTemplateVersionStringExists()) {
+    console.log("Replacing version template with latest tag");
+    replaceWithLatestTaggedVersion();
+} else {
+    console.log("Version already replaced");
+}


### PR DESCRIPTION
Ensure that the ui version template tag will always be replaced. When backend changes trigger a build and there are no UI changes since last build, the version template does not get replaced