### PR TITLE
[server] Added request log filter for /admin/prometheus

### DIFF
--- a/config/server.yaml
+++ b/config/server.yaml
@@ -20,6 +20,14 @@ server:
     - type: http
       port: 8090
 
+  requestLog:
+    appenders:
+    - type: console
+      filterFactories:
+      - type: uri
+        uris:
+          - "/admin/prometheus"
+
 logging:
   level: INFO
   loggers:

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/logging/UriFilterFactory.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/logging/UriFilterFactory.java
@@ -1,0 +1,42 @@
+package ai.startree.thirdeye.logging;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.filter.FilterFactory;
+import java.util.Collections;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+
+// TODO: shounak. Remove this class and META-INF/services/io.dropwizard.logging.filter.FilterFactory file once dropwizard is upgraded to v2.1.x
+
+@JsonTypeName("uri")
+public class UriFilterFactory implements FilterFactory<IAccessEvent> {
+  @NotNull
+  private Set<String> uris = Collections.emptySet();
+
+  @JsonProperty
+  public Set<String> getUris() {
+    return uris;
+  }
+
+  @JsonProperty
+  public void setUris(final Set<String> uris) {
+    this.uris = uris;
+  }
+
+  @Override
+  public Filter<IAccessEvent> build() {
+    return new Filter<IAccessEvent>() {
+      @Override
+      public FilterReply decide(final IAccessEvent event) {
+        if (uris.contains(event.getRequestURI())) {
+          return FilterReply.DENY;
+        }
+        return FilterReply.NEUTRAL;
+      }
+    };
+  }
+}

--- a/thirdeye-server/src/main/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
+++ b/thirdeye-server/src/main/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
@@ -1,0 +1,1 @@
+ai.startree.thirdeye.logging.UriFilterFactory


### PR DESCRIPTION
**Note**: This feature already exists in Dropwizard v2.1.x. The `UriFilterFactory` and  `META-INF/services/io.dropwizard.logging.filter.FilterFactory` should be removed once we upgrade the Dropwizard version. The server configs are fine as they are inline with the v2.1.x convention.

I have the helm related changes handy, will wait until this changes makes to a release as changes on helm will break the deployments if the docker image don't have this change.