### PR TITLE
fix(ui): fix large number formatting

### DIFF
--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/chart-core/chart-core.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/chart-core/chart-core.component.tsx
@@ -3,6 +3,7 @@ import { Group } from "@visx/group";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { AreaClosed, Bar, LinePath } from "@visx/shape";
 import React, { FunctionComponent, MouseEvent, useMemo } from "react";
+import { formatLargeNumberForVisualization } from "../../../../utils/visualization/visualization.util";
 import { PlotBand } from "../plot-band/plot-band.component";
 import {
     DataPoint,
@@ -207,6 +208,7 @@ export const ChartCore: FunctionComponent<ChartCoreProps> = ({
                 <AxisLeft
                     numTicks={5}
                     scale={yScaleToUse}
+                    tickFormat={formatLargeNumberForVisualization}
                     tickLabelProps={() => axisLeftTickLabelProps}
                 />
             )}


### PR DESCRIPTION
Formatting large numbers in the Y axis for time series chart 

![image](https://user-images.githubusercontent.com/2080348/170389372-e661f98c-e513-48b3-8bf2-d402de7e1aec.png)

