### PR TITLE
fix(ui): derive metric for anomaly from alert template properties

### DIFF
--- a/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
@@ -24,6 +24,7 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = (
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
     const { uiAnomaly } = props;
+    let metricName;
 
     useEffect(() => {
         if (uiAnomaly && uiAnomaly.alertId) {
@@ -46,20 +47,29 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = (
         }
     }, [status, errorMessages]);
 
+    if (alert && alert.templateProperties) {
+        if (
+            alert.templateProperties.aggregationColumn &&
+            alert.templateProperties.aggregationFunction
+        ) {
+            metricName = `${alert.templateProperties.aggregationFunction}(${alert.templateProperties.aggregationColumn})`;
+        } else if (props.uiAnomaly && props.uiAnomaly.metricName) {
+            metricName = props.uiAnomaly.metricName;
+        }
+    }
+
     return (
         <Card className={props.className} variant="outlined">
             <CardContent>
                 {uiAnomaly && (
                     <Grid container spacing={4}>
-                        {/* Alert */}
+                        {/* Metric */}
                         <Grid item lg={3} sm={6} xs={12}>
                             <div className={anomalySummaryCardStyles.valueText}>
                                 {status === ActionStatus.Working && (
                                     <span>Loading ...</span>
                                 )}
-                                {status === ActionStatus.Done &&
-                                    alert &&
-                                    alert.templateProperties.metric}
+                                {status === ActionStatus.Done && metricName}
                             </div>
                             <div className={anomalySummaryCardStyles.label}>
                                 {t("label.metric")}{" "}


### PR DESCRIPTION
sometimes the metric name value is blank so we'll derive it from the alert payload otherwise default it to the one from anomaly