### PR TITLE
fix(ui): remove filter for timeseries when filter has value (NO_FILTER)

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-dimension-analysis/anomaly-dimension-analysis.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-dimension-analysis/anomaly-dimension-analysis.component.tsx
@@ -1,6 +1,6 @@
 import { CardContent } from "@material-ui/core";
 import { isEmpty } from "lodash";
-import React, { FunctionComponent, useEffect } from "react";
+import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
     NotificationTypeV1,
@@ -8,7 +8,9 @@ import {
     useNotificationProviderV1,
 } from "../../platform/components";
 import { ActionStatus } from "../../rest/actions.interfaces";
+import { AnomalyDimensionAnalysisData } from "../../rest/dto/rca.interfaces";
 import { useGetAnomalyDimensionAnalysis } from "../../rest/rca/rca.actions";
+import { getFilterDimensionAnalysisData } from "../../utils/anomaly-dimension-analysis/anomaly-dimension-analysis";
 import { AnomalyDimensionAnalysisTable } from "./algorithm-table/algorithm-table.component";
 import { AnomalyDimensionAnalysisProps } from "./anomaly-dimension-analysis.interfaces";
 
@@ -24,14 +26,23 @@ export const AnomalyDimensionAnalysis: FunctionComponent<
     const { notify } = useNotificationProviderV1();
     const { t } = useTranslation();
     const {
-        anomalyDimensionAnalysisData,
         getDimensionAnalysisData,
         status: anomalyDimensionAnalysisReqStatus,
         errorMessages,
     } = useGetAnomalyDimensionAnalysis();
+
+    const [anomalyDimensionAnalysisData, setAnomalyDimensionAnalysisData] =
+        useState<AnomalyDimensionAnalysisData | null>();
+
     useEffect(() => {
         getDimensionAnalysisData(anomalyId, {
             baselineOffset: comparisonOffset,
+        }).then((data: AnomalyDimensionAnalysisData | undefined) => {
+            if (data) {
+                setAnomalyDimensionAnalysisData(
+                    getFilterDimensionAnalysisData(data)
+                );
+            }
         });
     }, [anomalyId, comparisonOffset]);
 

--- a/thirdeye-ui/src/app/utils/anomaly-dimension-analysis/anomaly-dimension-analysis.ts
+++ b/thirdeye-ui/src/app/utils/anomaly-dimension-analysis/anomaly-dimension-analysis.ts
@@ -1,0 +1,22 @@
+import {
+    AnomalyDimensionAnalysisData,
+    AnomalyDimensionAnalysisMetricRow,
+} from "../../rest/dto/rca.interfaces";
+
+export const RCA_NO_FILTER_MARKER = "(NO_FILTER)";
+
+export const getFilterDimensionAnalysisData = (
+    data: AnomalyDimensionAnalysisData
+): AnomalyDimensionAnalysisData => {
+    return {
+        ...data,
+        responseRows: data.responseRows.map(
+            (responseRow: AnomalyDimensionAnalysisMetricRow) => ({
+                ...responseRow,
+                names: responseRow.names.filter(
+                    (name) => name !== RCA_NO_FILTER_MARKER
+                ),
+            })
+        ),
+    };
+};


### PR DESCRIPTION
#### Issue

- empty string for filter value represents no filter instead a filter value

#### Changes

- BE now sends `(NO_FILTER)` instead of empty value
- UI will remove all filters with the value `(NO_FILTER)` while making a request to time-series data
- Hide `(NO_FILTER)` label from UI in the Top Contributors tab

<img width="1680" alt="Screenshot 2022-06-06 at 5 31 54 PM" src="https://user-images.githubusercontent.com/12962843/172156815-f5ce2763-0918-47cb-9e47-aef55ffad1fc.png">

<img width="1680" alt="Screenshot 2022-06-06 at 5 32 20 PM" src="https://user-images.githubusercontent.com/12962843/172156865-4c6b531f-3922-4e1b-8c47-eb94261811a2.png">

