### PR TITLE
fix(ui): anomaly feedback existing bug fix

### DIFF
--- a/thirdeye-ui/src/app/components/anomlay-feedback/anomaly-feedback.component.tsx
+++ b/thirdeye-ui/src/app/components/anomlay-feedback/anomaly-feedback.component.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Grid, MenuItem, TextField } from "@material-ui/core";
 import { AxiosError } from "axios";
 import { isEmpty } from "lodash";
-import React, { FunctionComponent, useRef, useState } from "react";
+import React, { FunctionComponent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
     NotificationTypeV1,
@@ -152,6 +152,11 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
                       );
             });
     };
+
+    useEffect(() => {
+        setCurrentlySelected(anomalyFeedback.type);
+        setModifiedFeedbackComment(anomalyFeedback.comment);
+    }, [anomalyFeedback]);
 
     if (isLoading) {
         return (


### PR DESCRIPTION
Fixing bug in a previous change that allowed the feedback component to render loading state before anomaly object is fetched