### PR TITLE
chore(ui): fix verify script after license header addition

### DIFF
--- a/thirdeye-ui/scripts/verify-version-replacement.js
+++ b/thirdeye-ui/scripts/verify-version-replacement.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
  * Copyright 2022 StarTree Inc
  *
@@ -11,7 +12,6 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-#!/usr/bin/env node
 
 const fs = require("fs");
 const path = require("path");


### PR DESCRIPTION
Moving `#!/usr/bin/env node` to the top