### PR TITLE
chore(ui): revert validation function call for alert creation

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.component.tsx
@@ -19,9 +19,8 @@ import {
     TextField,
     Typography,
 } from "@material-ui/core";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CreateAlertConfigurationSection } from "../../../pages/alerts-create-page/alerts-create-page.interfaces";
 import { PageContentsCardV1 } from "../../../platform/components";
 import { useAlertWizardV2Styles } from "../alert-wizard-v2.styles";
 import { AlertDetailsProps } from "./alert-details.interfaces";
@@ -30,21 +29,12 @@ import { AlertFrequency } from "./alert-frequency/alert-frequency.component";
 function AlertDetails({
     alert,
     onAlertPropertyChange,
-    onValidationChange,
 }: AlertDetailsProps): JSX.Element {
     const [name, setName] = useState(alert.name);
     const [description, setDescription] = useState(alert.description);
     const [nameHasError, setNameHasError] = useState(false);
     const { t } = useTranslation();
     const classes = useAlertWizardV2Styles();
-
-    // Ensure the parent always has an entry for name
-    useEffect(() => {
-        onValidationChange(
-            CreateAlertConfigurationSection.NAME,
-            name.length > 0
-        );
-    }, [name]);
 
     const handleNameChange = (
         e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
@@ -136,7 +126,6 @@ function AlertDetails({
                 <AlertFrequency
                     alert={alert}
                     onAlertPropertyChange={onAlertPropertyChange}
-                    onValidationChange={onValidationChange}
                 />
             </Grid>
         </PageContentsCardV1>

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.interfaces.ts
@@ -11,14 +11,9 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { CreateAlertConfigurationSection } from "../../../pages/alerts-create-page/alerts-create-page.interfaces";
 import { EditableAlert } from "../../../rest/dto/alert.interfaces";
 
 export interface AlertDetailsProps {
     alert: EditableAlert;
     onAlertPropertyChange: (contents: Partial<EditableAlert>) => void;
-    onValidationChange: (
-        key: CreateAlertConfigurationSection,
-        isValid: boolean
-    ) => void;
 }

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.test.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.test.tsx
@@ -13,7 +13,6 @@
  */
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { CreateAlertConfigurationSection } from "../../../pages/alerts-create-page/alerts-create-page.interfaces";
 import { EditableAlert } from "../../../rest/dto/alert.interfaces";
 import { AlertDetails } from "./alert-details.component";
 
@@ -25,34 +24,25 @@ jest.mock("react-i18next", () => ({
 
 describe("AlertDetails", () => {
     it("should render name and description from passed alert", async () => {
-        const mockValidationCallback = jest.fn();
-
         render(
             <AlertDetails
                 alert={MOCK_ALERT}
                 onAlertPropertyChange={() => {
                     return;
                 }}
-                onValidationChange={mockValidationCallback}
             />
         );
 
         expect(screen.getByDisplayValue("hello-world")).toBeInTheDocument();
         expect(screen.getByDisplayValue("foo bar")).toBeInTheDocument();
-        expect(mockValidationCallback).toHaveBeenCalledWith(
-            CreateAlertConfigurationSection.NAME,
-            true
-        );
     });
 
     it("should render error state if name is empty and should not have called callback", async () => {
         const mockCallback = jest.fn();
-        const mockValidationCallback = jest.fn();
         render(
             <AlertDetails
                 alert={MOCK_ALERT}
                 onAlertPropertyChange={mockCallback}
-                onValidationChange={mockValidationCallback}
             />
         );
 
@@ -71,20 +61,14 @@ describe("AlertDetails", () => {
             screen.getByText("message.please-enter-valid-name")
         ).toBeInTheDocument();
         expect(mockCallback).toHaveBeenCalledTimes(0);
-        expect(mockValidationCallback).toHaveBeenLastCalledWith(
-            CreateAlertConfigurationSection.NAME,
-            false
-        );
     });
 
     it("should have called callback if valid input for name and description", async () => {
         const mockCallback = jest.fn();
-        const mockValidationCallback = jest.fn();
         render(
             <AlertDetails
                 alert={MOCK_ALERT}
                 onAlertPropertyChange={mockCallback}
-                onValidationChange={mockValidationCallback}
             />
         );
 
@@ -105,10 +89,6 @@ describe("AlertDetails", () => {
         expect(mockCallback).toHaveBeenCalledWith({
             description: "new-value-123",
         });
-        expect(mockValidationCallback).toHaveBeenLastCalledWith(
-            CreateAlertConfigurationSection.NAME,
-            true
-        );
     });
 });
 

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.component.tsx
@@ -15,35 +15,23 @@ import { FormHelperText, Grid, InputLabel, TextField } from "@material-ui/core";
 import CronValidator from "cron-expression-validator";
 import cronstrue from "cronstrue";
 import { uniq } from "lodash";
-import React, { FunctionComponent, useEffect, useState } from "react";
+import React, { FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CreateAlertConfigurationSection } from "../../../../../pages/alerts-create-page/alerts-create-page.interfaces";
 import { ensureArrayOfStrings } from "../../../alert-template/alert-template.utils";
 import { useAlertWizardV2Styles } from "../../../alert-wizard-v2.styles";
 import { AlertDateTimeCronAdvanceProps } from "./alert-date-time-cron-advance.interfaces";
 
 export const AlertDateTimeCronAdvance: FunctionComponent<
     AlertDateTimeCronAdvanceProps
-> = ({ cron, onCronChange, onValidationChange }): JSX.Element => {
+> = ({ cron, onCronChange }): JSX.Element => {
     const [currentCron, setCurrentCron] = useState<string>(cron);
     const { t } = useTranslation();
     const classes = useAlertWizardV2Styles();
     const isCronValid = CronValidator.isValidCronExpression(currentCron);
 
-    // Ensure the parent always has an entry for cron
-    useEffect(() => {
-        onValidationChange(CreateAlertConfigurationSection.CRON, isCronValid);
-    }, [currentCron]);
-
     const handleCronInputChange = (newCron: string): void => {
         setCurrentCron(newCron);
-
-        // no guarantee the new cron has been put in state
-        const isNewCronValid = CronValidator.isValidCronExpression(newCron);
-
-        if (isNewCronValid) {
-            onCronChange(newCron);
-        }
+        onCronChange(newCron);
     };
 
     return (

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.interfaces.ts
@@ -11,13 +11,8 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { CreateAlertConfigurationSection } from "../../../../../pages/alerts-create-page/alerts-create-page.interfaces";
 
 export interface AlertDateTimeCronAdvanceProps {
     cron: string;
     onCronChange: (newCron: string) => void;
-    onValidationChange: (
-        key: CreateAlertConfigurationSection,
-        isValid: boolean
-    ) => void;
 }

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.test.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.test.tsx
@@ -13,7 +13,6 @@
  */
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { CreateAlertConfigurationSection } from "../../../../../pages/alerts-create-page/alerts-create-page.interfaces";
 import { AlertDateTimeCronAdvance } from "./alert-date-time-cron-advance.component";
 
 jest.mock("react-i18next", () => ({
@@ -24,15 +23,12 @@ jest.mock("react-i18next", () => ({
 
 describe("AlertDateTimeCronAdvance", () => {
     it("should render error message if given invalid cron and colored error", async () => {
-        const mockValidationCallback = jest.fn();
-
         render(
             <AlertDateTimeCronAdvance
                 cron={INVALID_CRON}
                 onCronChange={() => {
                     return;
                 }}
-                onValidationChange={mockValidationCallback}
             />
         );
 
@@ -41,20 +37,14 @@ describe("AlertDateTimeCronAdvance", () => {
         ).toBeInTheDocument();
 
         expect(screen.getByTestId("cron-input-label")).toHaveClass("Mui-error");
-        expect(mockValidationCallback).toHaveBeenCalledWith(
-            CreateAlertConfigurationSection.CRON,
-            false
-        );
     });
 
     it("should remove error message if input valid cron and callback function called", async () => {
         const mockCallback = jest.fn();
-        const mockValidationCallback = jest.fn();
         render(
             <AlertDateTimeCronAdvance
                 cron={INVALID_CRON}
                 onCronChange={mockCallback}
-                onValidationChange={mockValidationCallback}
             />
         );
 
@@ -79,20 +69,14 @@ describe("AlertDateTimeCronAdvance", () => {
             )
         ).toBeInTheDocument();
         expect(mockCallback).toHaveBeenCalledWith(VALID_CRON);
-        expect(mockValidationCallback).toHaveBeenCalledWith(
-            CreateAlertConfigurationSection.CRON,
-            true
-        );
     });
 
-    it("should render error message if input invalid cron and callback function is not called", async () => {
+    it("should render error message if input invalid cron and callback function is called", async () => {
         const mockCallback = jest.fn();
-        const mockValidationCallback = jest.fn();
         render(
             <AlertDateTimeCronAdvance
                 cron={VALID_CRON}
                 onCronChange={mockCallback}
-                onValidationChange={mockValidationCallback}
             />
         );
 
@@ -116,11 +100,7 @@ describe("AlertDateTimeCronAdvance", () => {
         expect(
             screen.getByText("Unexpected end of expression")
         ).toBeInTheDocument();
-        expect(mockCallback).toHaveBeenCalledTimes(0);
-        expect(mockValidationCallback).toHaveBeenCalledWith(
-            CreateAlertConfigurationSection.CRON,
-            false
-        );
+        expect(mockCallback).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-frequency.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-frequency.component.tsx
@@ -21,7 +21,6 @@ import { AlertFrequencyProps } from "./alert-frequency.interfaces";
 function AlertFrequency<NewOrExistingAlert extends EditableAlert | Alert>({
     alert,
     onAlertPropertyChange,
-    onValidationChange,
 }: AlertFrequencyProps<NewOrExistingAlert>): JSX.Element {
     const [currentCron, setCurrentCron] = useState<string>(alert.cron);
 
@@ -50,7 +49,6 @@ function AlertFrequency<NewOrExistingAlert extends EditableAlert | Alert>({
             <AlertDateTimeCronAdvance
                 cron={currentCron}
                 onCronChange={handleCronChange}
-                onValidationChange={onValidationChange}
             />
         </>
     );

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-frequency.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-frequency.interfaces.ts
@@ -11,14 +11,9 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { CreateAlertConfigurationSection } from "../../../../pages/alerts-create-page/alerts-create-page.interfaces";
 import { EditableAlert } from "../../../../rest/dto/alert.interfaces";
 
 export interface AlertFrequencyProps<NewOrExistingAlert> {
     alert: NewOrExistingAlert;
     onAlertPropertyChange: (contents: Partial<EditableAlert>) => void;
-    onValidationChange: (
-        key: CreateAlertConfigurationSection,
-        isValid: boolean
-    ) => void;
 }


### PR DESCRIPTION
Decided to remove `onValidationChange` call in the child and have parent validate instead