### PR TITLE
feat(ui): support slack and webhook when reviewing in wizard

### DIFF
--- a/thirdeye-ui/src/app/components/subscription-group-wizard/groups-editor/groups-editor.interfaces.ts
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/groups-editor/groups-editor.interfaces.ts
@@ -34,4 +34,6 @@ export interface SpecUIConfig {
      */
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     formComponent: FunctionComponent<any>;
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    reviewComponent: FunctionComponent<any>;
 }

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/groups-editor/groups-editor.utils.ts
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/groups-editor/groups-editor.utils.ts
@@ -12,6 +12,7 @@
  * the License.
  */
 import { SpecType } from "../../../rest/dto/subscription-group.interfaces";
+import { SendgridEmailReview } from "../subscription-group-renderer/sendgrid-email-review/sendgrid-email-review.component";
 import { SpecUIConfig } from "./groups-editor.interfaces";
 import { SendgridEmail } from "./sendgrid-email/sendgrid-email.component";
 import { Slack } from "./slack/slack.component";
@@ -23,18 +24,21 @@ export const availableSpecTypes: SpecUIConfig[] = [
         internationalizationString: "label.email",
         icon: "carbon:email",
         formComponent: SendgridEmail,
+        reviewComponent: SendgridEmailReview,
     },
     {
         id: SpecType.Slack,
         internationalizationString: "label.slack",
         icon: "logos:slack-icon",
         formComponent: Slack,
+        reviewComponent: (props) => props.configuration.params.webhookUrl,
     },
     {
         id: SpecType.Webhook,
         internationalizationString: "label.webhook",
         icon: "logos:webhooks",
         formComponent: Webhook,
+        reviewComponent: (props) => props.configuration.params.url,
     },
 ];
 

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-renderer/sendgrid-email-review/sendgrid-email-review.component.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-renderer/sendgrid-email-review/sendgrid-email-review.component.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React, { FunctionComponent } from "react";
+import { useTranslation } from "react-i18next";
+import { SendgridEmailReviewProps } from "./sendgrid-email-review.interfaces";
+
+export const SendgridEmailReview: FunctionComponent<
+    SendgridEmailReviewProps
+> = ({ configuration }) => {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <div>
+                <strong>{t("label.to")}: </strong>
+                {configuration.params.emailRecipients.to.join(", ")}
+            </div>
+            <div>
+                <strong>{t("label.from")}: </strong>
+                {configuration.params.emailRecipients.from}
+            </div>
+            <div>
+                <strong>{t("label.sendgrid-api-key")}: </strong>
+                {configuration.params.apiKey}
+            </div>
+        </div>
+    );
+};

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-renderer/sendgrid-email-review/sendgrid-email-review.interfaces.ts
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-renderer/sendgrid-email-review/sendgrid-email-review.interfaces.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { SendgridEmailSpec } from "../../../../rest/dto/subscription-group.interfaces";
+
+export interface SendgridEmailReviewProps {
+    configuration: SendgridEmailSpec;
+}

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-renderer/subscription-group-renderer.component.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-renderer/subscription-group-renderer.component.tsx
@@ -11,10 +11,11 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { Grid, Typography } from "@material-ui/core";
+import { Box, Divider, Grid, Typography } from "@material-ui/core";
 import { isEmpty } from "lodash";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
+import { specTypeToUIConfig } from "../groups-editor/groups-editor.utils";
 import { SubscriptionGroupRendererProps } from "./subscription-group-renderer.interfaces";
 
 export const SubscriptionGroupRenderer: FunctionComponent<
@@ -84,41 +85,72 @@ export const SubscriptionGroupRenderer: FunctionComponent<
                 )}
 
             {/* Subscribed emails */}
-            <Grid item sm={2}>
-                <Typography variant="subtitle1">
-                    <strong>{t("label.subscribed-emails")}</strong>
-                </Typography>
-            </Grid>
-
-            {/* No subscribed emails */}
-            {!props.subscriptionGroup ||
-                !props.subscriptionGroup.notificationSchemes.email ||
-                (isEmpty(
-                    props.subscriptionGroup.notificationSchemes.email.to
-                ) && (
-                    <Grid item sm={10}>
-                        <Typography variant="body2">
-                            {t("label.no-data-marker")}
-                        </Typography>
-                    </Grid>
-                ))}
-
-            {/* All subscribed emails */}
             {props.subscriptionGroup &&
                 props.subscriptionGroup.notificationSchemes.email &&
                 !isEmpty(
                     props.subscriptionGroup.notificationSchemes.email.to
                 ) && (
-                    <Grid item sm={10}>
-                        {props.subscriptionGroup.notificationSchemes.email.to.map(
-                            (email, index) => (
-                                <Typography key={index} variant="body2">
-                                    {email}
-                                </Typography>
-                            )
-                        )}
-                    </Grid>
+                    <>
+                        <Grid item sm={2}>
+                            <Typography variant="subtitle1">
+                                <strong>{t("label.subscribed-emails")}</strong>
+                            </Typography>
+                        </Grid>
+                        <Grid item sm={10}>
+                            {props.subscriptionGroup.notificationSchemes.email.to.map(
+                                (email, index) => (
+                                    <Typography key={index} variant="body2">
+                                        {email}
+                                    </Typography>
+                                )
+                            )}
+                        </Grid>
+                    </>
                 )}
+
+            {props.subscriptionGroup && (
+                <>
+                    <Grid item xs={12}>
+                        <Box marginBottom={1}>
+                            <Divider />
+                        </Box>
+                        <Typography variant="h5">
+                            {t("label.groups")}
+                        </Typography>
+                    </Grid>
+                    {props.subscriptionGroup.specs.map((spec) => {
+                        const uiConfig = specTypeToUIConfig[spec.type];
+
+                        return (
+                            <>
+                                <Grid item sm={2}>
+                                    <Typography variant="subtitle1">
+                                        <strong>
+                                            {t(
+                                                uiConfig.internationalizationString
+                                            )}
+                                        </strong>
+                                    </Typography>
+                                </Grid>
+                                <Grid item sm={10}>
+                                    {React.createElement(
+                                        uiConfig.reviewComponent,
+                                        {
+                                            configuration: spec,
+                                        }
+                                    )}
+                                </Grid>
+                            </>
+                        );
+                    })}
+
+                    {props.subscriptionGroup.specs.length === 0 && (
+                        <Grid item xs={12}>
+                            {t("message.no-notifications-groups")}
+                        </Grid>
+                    )}
+                </>
+            )}
         </Grid>
     );
 };

--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -313,6 +313,7 @@
         "datasource-is-healthy": "Datasource is healthy",
         "checking-datasource-health": "Checking datasource health. This will take a few seconds ...",
         "to-get-started-select-type": "Select a type to get started",
-        "enter-webhook-url": "Enter webhook URL"
+        "enter-webhook-url": "Enter webhook URL",
+        "no-notifications-groups": "No notifications groups have been configured"
     }
 }


### PR DESCRIPTION
Support showing slack and webhook as well as new sendgrid email while also supporting legacy:

![image](https://user-images.githubusercontent.com/2080348/181379293-d7efb24a-723f-4a8a-a402-d815a5636793.png)
