### PR TITLE
[core] make node params compatible with structured properties

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertTemplateRenderer.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertTemplateRenderer.java
@@ -21,6 +21,7 @@ import static ai.startree.thirdeye.util.ResourceUtils.ensureExists;
 import ai.startree.thirdeye.mapper.ApiBeanMapper;
 import ai.startree.thirdeye.spi.api.AlertApi;
 import ai.startree.thirdeye.spi.api.AlertTemplateApi;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
 import ai.startree.thirdeye.spi.datalayer.bao.AlertTemplateManager;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
@@ -136,7 +137,7 @@ public class AlertTemplateRenderer {
           // TODO spyne remove magic string. This was done to remove dependency of AnomalyDetector.TYPE on the renderer
           .filter(node -> node.getType().equals("AnomalyDetector"))
           .forEach(node -> node.getParams()
-              .put("anomaly.source", String.format("%s/%s", alertName, node.getName())));
+              .put("anomaly.source", Templatable.withValue(String.format("%s/%s", alertName, node.getName()))));
     }
 
     return StringTemplateUtils.applyContext(template, properties);

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/components/EventDataFetcher.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/components/EventDataFetcher.java
@@ -51,7 +51,7 @@ public class EventDataFetcher implements DataFetcher<EventFetcherSpec> {
     startTimeLookback = isoPeriod(spec.getStartTimeLookback(), DEFAULT_START_TIME_LOOKBACK);
     endTimeLookback = isoPeriod(spec.getEndTimeLookback(), DEFAULT_END_TIME_LOOKBACK);
     lookaround = isoPeriod(spec.getLookaround(), DEFAULT_LOOKAROUND);
-    eventTypes = Objects.requireNonNull(spec.getEventTypes().value());
+    eventTypes = Objects.requireNonNull(spec.getEventTypes());
     freeTextSqlFilter = spec.getSqlFilter();
 
     eventDao = spec.getEventManager();

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/AnomalyDetectorOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/AnomalyDetectorOperator.java
@@ -27,6 +27,7 @@ import ai.startree.thirdeye.spi.dataframe.BooleanSeries;
 import ai.startree.thirdeye.spi.dataframe.DataFrame;
 import ai.startree.thirdeye.spi.dataframe.DoubleSeries;
 import ai.startree.thirdeye.spi.dataframe.LongSeries;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.MergedAnomalyResultDTO;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.AnomalyDetector;
@@ -70,7 +71,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
   }
 
   private AnomalyDetector<? extends AbstractSpec> createDetector(
-      final Map<String, Object> params,
+      final Map<String, Templatable<Object>> params,
       final DetectionRegistry detectionRegistry) {
     final String type = ensureExists(MapUtils.getString(params, PROP_TYPE),
         ERR_MISSING_CONFIGURATION_FIELD,
@@ -107,6 +108,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
   private void addMetadata(DetectionPipelineResult detectionPipelineResult) {
     // Annotate each anomaly with a metric name
     optional(planNode.getParams().get("anomaly.metric"))
+        .map(Templatable::value)
         .map(Object::toString)
         .ifPresent(anomalyMetric -> detectionPipelineResult.getDetectionResults().stream()
             .map(DetectionResult::getAnomalies)
@@ -114,6 +116,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
             .forEach(anomaly -> anomaly.setMetric(anomalyMetric)));
 
     optional(planNode.getParams().get("anomaly.dataset"))
+        .map(Templatable::value)
         .map(Object::toString)
         .ifPresent(anomalyDataset -> detectionPipelineResult.getDetectionResults().stream()
             .map(DetectionResult::getAnomalies)
@@ -122,6 +125,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
 
     // Annotate each anomaly with source info
     optional(planNode.getParams().get("anomaly.source"))
+        .map(Templatable::value)
         .map(Object::toString)
         .ifPresent(anomalySource -> detectionPipelineResult.getDetectionResults().stream()
             .map(DetectionResult::getAnomalies)

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/CombinerOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/CombinerOperator.java
@@ -18,6 +18,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator.ForkJoinResult;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.model.DetectionResult;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
@@ -29,7 +30,7 @@ public class CombinerOperator extends DetectionPipelineOperator {
 
   public static final String DEFAULT_INPUT_KEY = "input_Combiner";
   public static final String DEFAULT_OUTPUT_KEY = "output_Combiner";
-  private Map<String, Object> params;
+  private Map<String, Templatable<Object>> params;
 
   public CombinerOperator() {
     super();

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperator.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.detectionpipeline.operator;
 
 import static ai.startree.thirdeye.spi.Constants.EVALUATION_FILTERS_KEY;
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -22,6 +23,7 @@ import ai.startree.thirdeye.datasource.calcite.QueryPredicate;
 import ai.startree.thirdeye.detectionpipeline.components.GenericDataFetcher;
 import ai.startree.thirdeye.detectionpipeline.spec.DataFetcherSpec;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DataFetcher;
@@ -52,7 +54,8 @@ public class DataFetcherOperator extends DetectionPipelineOperator {
     dataFetcher = createDataFetcher(planNode.getParams(), dataSourceCache);
   }
 
-  protected DataFetcher<DataFetcherSpec> createDataFetcher(final Map<String, Object> params,
+  protected DataFetcher<DataFetcherSpec> createDataFetcher(
+      final Map<String, Templatable<Object>> params,
       final DataSourceCache dataSourceCache) {
     final Map<String, Object> componentSpec = getComponentSpec(params);
     final DataFetcherSpec spec = requireNonNull(
@@ -60,7 +63,8 @@ public class DataFetcherOperator extends DetectionPipelineOperator {
         "Unable to construct DataFetcherSpec");
     spec.setDataSourceCache(dataSourceCache);
     @SuppressWarnings("unchecked") final List<QueryPredicate> timeseriesFilters =
-        (List<QueryPredicate>) params.getOrDefault(EVALUATION_FILTERS_KEY, List.of());
+        (List<QueryPredicate>) optional(params.get(EVALUATION_FILTERS_KEY)).map(Templatable::value)
+            .orElse(List.of());
     spec.setTimeseriesFilters(timeseriesFilters);
 
     final GenericDataFetcher genericDataFetcher = new GenericDataFetcher();

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DetectionPipelineOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DetectionPipelineOperator.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.detectionpipeline.operator;
 
 import ai.startree.thirdeye.detectionpipeline.utils.EpochTimeConverter;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
 import ai.startree.thirdeye.spi.detection.TimeConverter;
@@ -46,7 +47,8 @@ public abstract class DetectionPipelineOperator implements Operator {
   protected DetectionPipelineOperator() {
   }
 
-  protected static Map<String, Object> getComponentSpec(final Map<String, Object> params) {
+  // pre-condition: templatable objects have properties applied
+  protected static Map<String, Object> getComponentSpec(final Map<String, Templatable<Object>> params) {
     final Map<String, Object> componentSpec = new HashMap<>();
     if (params == null || params.isEmpty()) {
       return componentSpec;
@@ -54,7 +56,7 @@ public abstract class DetectionPipelineOperator implements Operator {
     final String prefix = "component.";
     params.forEach((key, value) -> {
       if (key.startsWith(prefix)) {
-        componentSpec.put(key.substring(prefix.length()), value);
+        componentSpec.put(key.substring(prefix.length()), value.value());
       }
     });
     return componentSpec;
@@ -96,11 +98,6 @@ public abstract class DetectionPipelineOperator implements Operator {
       key = outputKeyMap.get(key);
     }
     resultMap.put(key, output);
-  }
-
-  @Override
-  public void setProperty(final String key, final Object value) {
-    planNode.getParams().put(key, value);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EchoOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EchoOperator.java
@@ -17,6 +17,7 @@ import ai.startree.thirdeye.spi.detection.model.DetectionResult;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import java.util.List;
+import java.util.Objects;
 
 public class EchoOperator extends DetectionPipelineOperator {
 
@@ -34,7 +35,9 @@ public class EchoOperator extends DetectionPipelineOperator {
 
   @Override
   public void execute() throws Exception {
-    final String echoText = getPlanNode().getParams().get(DEFAULT_INPUT_KEY).toString();
+    final String echoText = Objects.requireNonNull(getPlanNode().getParams()
+        .get(DEFAULT_INPUT_KEY)
+        .value()).toString();
     setOutput(DEFAULT_OUTPUT_KEY, new EchoResult(echoText));
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EnumeratorOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EnumeratorOperator.java
@@ -13,11 +13,13 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.model.DetectionResult;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class EnumeratorOperator extends DetectionPipelineOperator {
 
@@ -36,9 +38,9 @@ public class EnumeratorOperator extends DetectionPipelineOperator {
   @SuppressWarnings("unchecked")
   @Override
   public void execute() throws Exception {
-    final Map<String, Object> params = getPlanNode().getParams();
+    final Map<String, Templatable<Object>> params = getPlanNode().getParams();
     final List<Map<String, Object>> enumerationList =
-        (List<Map<String, Object>>) params.get("enumerationList");
+        (List<Map<String, Object>>) Objects.requireNonNull(params.get("enumerationList")).value();
     setOutput(DEFAULT_OUTPUT_KEY, new EnumeratorResult(enumerationList));
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperator.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import ai.startree.thirdeye.detectionpipeline.components.EventDataFetcher;
 import ai.startree.thirdeye.detectionpipeline.spec.EventFetcherSpec;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DataFetcher;
@@ -57,7 +58,7 @@ public class EventFetcherOperator extends DetectionPipelineOperator {
   }
 
   private DataFetcher<EventFetcherSpec> createEventFetcher(
-      final Map<String, Object> params, final EventManager eventDao) {
+      final Map<String, Templatable<Object>> params, final EventManager eventDao) {
     final Map<String, Object> componentSpec = getComponentSpec(params);
     final EventFetcherSpec spec = requireNonNull(
         AbstractSpec.fromProperties(componentSpec, EventFetcherSpec.class),

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventTriggerOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventTriggerOperator.java
@@ -13,10 +13,12 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DetectionUtils;
 import ai.startree.thirdeye.spi.detection.EventTrigger;
@@ -24,7 +26,6 @@ import ai.startree.thirdeye.spi.detection.EventTriggerFactoryContext;
 import ai.startree.thirdeye.spi.detection.v2.DataTable;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import java.util.Map;
-import org.apache.commons.collections4.MapUtils;
 
 public class EventTriggerOperator extends DetectionPipelineOperator {
 
@@ -64,10 +65,11 @@ public class EventTriggerOperator extends DetectionPipelineOperator {
   }
 
   protected EventTrigger<? extends AbstractSpec> createEventTrigger(
-      final Map<String, Object> params,
+      final Map<String, Templatable<Object>> params,
       final DetectionRegistry detectionRegistry) {
-    final String type = requireNonNull(MapUtils.getString(params, PROP_TYPE),
-        "Must have 'type' in trigger config");
+    final String type = optional(params.get(PROP_TYPE)).map(Templatable::value)
+        .map(Object::toString)
+        .orElseThrow(() -> new NullPointerException("Must have 'type' in trigger config"));
     final Map<String, Object> componentSpec = getComponentSpec(params);
     return detectionRegistry.buildTrigger(type, new EventTriggerFactoryContext()
         .setProperties(componentSpec));

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/ForkJoinOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/ForkJoinOperator.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye.detectionpipeline.operator;
 import ai.startree.thirdeye.detectionpipeline.PlanNodeFactory;
 import ai.startree.thirdeye.detectionpipeline.operator.EnumeratorOperator.EnumeratorResult;
 import ai.startree.thirdeye.mapper.PlanNodeMapper;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.detection.model.DetectionResult;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
@@ -175,13 +176,13 @@ public class ForkJoinOperator extends DetectionPipelineOperator {
 
   private PlanNodeBean clonePlanNodeBean(final Map<String, Object> templateProperties,
       final PlanNodeBean n) {
-    final Map<String, Object> params = applyTemplatePropertiesOnParams(n.getParams(),
+    final Map<String, Templatable<Object>> params = applyTemplatePropertiesOnParams(n.getParams(),
         templateProperties);
     return PlanNodeMapper.INSTANCE.clone(n).setParams(params);
   }
 
-  private Map<String, Object> applyTemplatePropertiesOnParams(
-      final Map<String, Object> params, final Map<String, Object> templateProperties) {
+  private Map<String, Templatable<Object>> applyTemplatePropertiesOnParams(
+      final Map<String, Templatable<Object>> params, final Map<String, Object> templateProperties) {
     if (params == null) {
       return null;
     }

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperator.java
@@ -13,7 +13,10 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+
 import ai.startree.thirdeye.detectionpipeline.operator.sql.DataTableToSqlAdapterFactory;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
 import ai.startree.thirdeye.spi.detection.v2.DataTable;
 import ai.startree.thirdeye.spi.detection.v2.DataTableToSqlAdapter;
@@ -55,17 +58,19 @@ public class SqlExecutionOperator extends DetectionPipelineOperator {
       outputKeyMap.put(outputBean.getOutputKey(), outputBean.getOutputName());
     }
     if (planNode.getParams().containsKey(SQL_QUERIES)) {
-      queries.addAll((List<String>) planNode.getParams().get(SQL_QUERIES));
+      queries.addAll((List<String>) planNode.getParams().get(SQL_QUERIES).value());
     } else {
       throw new IllegalArgumentException(
           "Missing property '" + SQL_QUERIES + "' in SqlExecutionOperator");
     }
 
-    dataTableToSqlAdapter = DataTableToSqlAdapterFactory.create(planNode.getParams()
-        .getOrDefault(SQL_ENGINE, DEFAULT_SQL_ENGINE).toString());
+    dataTableToSqlAdapter = DataTableToSqlAdapterFactory.create(
+        optional(planNode.getParams().get(SQL_ENGINE)).map(Templatable::value)
+            .orElse(DEFAULT_SQL_ENGINE)
+            .toString());
     if (planNode.getParams().containsKey(JDBC_CONNECTION_PARAMS)) {
       dataTableToSqlAdapter.jdbcProperties()
-          .putAll((Map<String, String>) planNode.getParams().get(JDBC_CONNECTION_PARAMS));
+          .putAll((Map<String, String>) planNode.getParams().get(JDBC_CONNECTION_PARAMS).value());
     }
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperator.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.components.TimeIndexFiller;
 import ai.startree.thirdeye.detectionpipeline.spec.TimeIndexFillerSpec;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DetectionUtils;
 import ai.startree.thirdeye.spi.detection.IndexFiller;
@@ -61,7 +62,7 @@ public class TimeIndexFillerOperator extends DetectionPipelineOperator {
   }
 
   private IndexFiller<? extends AbstractSpec> createTimeIndexFiller(
-      final Map<String, Object> params) {
+      final Map<String, Templatable<Object>> params) {
     final Map<String, Object> componentSpec = getComponentSpec(params);
     final TimeIndexFillerSpec spec = requireNonNull(
         AbstractSpec.fromProperties(componentSpec, TimeIndexFillerSpec.class),

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/AnomalyDetectorPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/AnomalyDetectorPlanNode.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
 import ai.startree.thirdeye.detectionpipeline.operator.AnomalyDetectorOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -47,7 +48,7 @@ public class AnomalyDetectorPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/CombinerPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/CombinerPlanNode.java
@@ -17,6 +17,7 @@ import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Collections.emptyMap;
 
 import ai.startree.thirdeye.detectionpipeline.operator.CombinerOperator;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -25,7 +26,7 @@ import java.util.Map;
 public class CombinerPlanNode extends DetectionPipelinePlanNode {
 
   public static final String TYPE = "Combiner";
-  private Map<String, Object> params;
+  private Map<String, Templatable<Object>> params;
 
   public CombinerPlanNode() {
     super();
@@ -43,7 +44,7 @@ public class CombinerPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return params;
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DataFetcherPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DataFetcherPlanNode.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye.detectionpipeline.plan;
 import ai.startree.thirdeye.datasource.cache.DataSourceCache;
 import ai.startree.thirdeye.detectionpipeline.operator.DataFetcherOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -43,7 +44,7 @@ public class DataFetcherPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DetectionPipelinePlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DetectionPipelinePlanNode.java
@@ -15,6 +15,7 @@ package ai.startree.thirdeye.detectionpipeline.plan;
 
 import static java.util.Objects.requireNonNull;
 
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
@@ -71,7 +72,7 @@ public abstract class DetectionPipelinePlanNode implements PlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EchoPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EchoPlanNode.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.detectionpipeline.plan;
 
 import ai.startree.thirdeye.detectionpipeline.operator.EchoOperator;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -38,7 +39,7 @@ public class EchoPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EnumeratorPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EnumeratorPlanNode.java
@@ -17,6 +17,7 @@ import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Collections.emptyMap;
 
 import ai.startree.thirdeye.detectionpipeline.operator.EnumeratorOperator;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -25,7 +26,7 @@ import java.util.Map;
 public class EnumeratorPlanNode extends DetectionPipelinePlanNode {
 
   public static final String TYPE = "Enumerator";
-  private Map<String, Object> params;
+  private Map<String, Templatable<Object>> params;
 
   public EnumeratorPlanNode() {
     super();
@@ -43,7 +44,7 @@ public class EnumeratorPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return params;
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventFetcherPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventFetcherPlanNode.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import ai.startree.thirdeye.detectionpipeline.operator.EventFetcherOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
@@ -44,7 +45,7 @@ public class EventFetcherPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventTriggerPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventTriggerPlanNode.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
 import ai.startree.thirdeye.detectionpipeline.operator.EventTriggerOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -46,7 +47,7 @@ public class EventTriggerPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/ForkJoinPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/ForkJoinPlanNode.java
@@ -19,6 +19,7 @@ import static ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator.K
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNode;
@@ -49,7 +50,7 @@ public class ForkJoinPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/ForkJoinPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/ForkJoinPlanNode.java
@@ -75,7 +75,7 @@ public class ForkJoinPlanNode extends DetectionPipelinePlanNode {
   }
 
   private PlanNode getPlanNode(final String key) {
-    final String nodeName = String.valueOf(requireNonNull(getParams().get(key),
+    final String nodeName = String.valueOf(requireNonNull(getParams().get(key).value(),
         "param missing: " + key));
     return requireNonNull(pipelinePlanNodes.get(nodeName), "node not found: " + nodeName);
   }

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/SqlExecutionPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/SqlExecutionPlanNode.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.detectionpipeline.plan;
 
 import ai.startree.thirdeye.detectionpipeline.operator.SqlExecutionOperator;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -36,7 +37,7 @@ public class SqlExecutionPlanNode extends DetectionPipelinePlanNode {
   }
 
   @Override
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return planNodeBean.getParams();
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/spec/EventFetcherSpec.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/spec/EventFetcherSpec.java
@@ -13,7 +13,6 @@
  */
 package ai.startree.thirdeye.detectionpipeline.spec;
 
-import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -48,7 +47,7 @@ public class EventFetcherSpec extends AbstractSpec {
    * These filters are applied on an index.
    * Useful optimization if there is a lot of different type of events.
    */
-  private Templatable<List<String>> eventTypes = new Templatable<List<String>>().setValue(List.of());
+  private List<String> eventTypes = List.of();
 
   /**
    * Dimension filters. As a sql filter string. If empty or null, no filter is applied.
@@ -97,12 +96,12 @@ public class EventFetcherSpec extends AbstractSpec {
     return this;
   }
 
-  public Templatable<List<String>> getEventTypes() {
+  public List<String> getEventTypes() {
     return eventTypes;
   }
 
   public EventFetcherSpec setEventTypes(
-      final Templatable<List<String>> eventTypes) {
+      final List<String> eventTypes) {
     this.eventTypes = eventTypes;
     return this;
   }

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/PlanExecutorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/PlanExecutorTest.java
@@ -29,6 +29,7 @@ import ai.startree.thirdeye.detectionpipeline.plan.CombinerPlanNode;
 import ai.startree.thirdeye.detectionpipeline.plan.EchoPlanNode;
 import ai.startree.thirdeye.detectionpipeline.plan.EnumeratorPlanNode;
 import ai.startree.thirdeye.detectionpipeline.plan.ForkJoinPlanNode;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
@@ -69,7 +70,7 @@ public class PlanExecutorTest {
         .setDetectionInterval(new Interval(0L, 0L, DateTimeZone.UTC))
         .setPlanNodeBean(new PlanNodeBean()
             .setInputs(Collections.emptyList())
-            .setParams(ImmutableMap.of(EchoOperator.DEFAULT_INPUT_KEY, echoInput))
+            .setParams(ImmutableMap.of(EchoOperator.DEFAULT_INPUT_KEY, Templatable.withValue(echoInput)))
         )
     );
     final HashMap<ContextKey, DetectionPipelineResult> context = new HashMap<>();
@@ -95,17 +96,17 @@ public class PlanExecutorTest {
         .setName("echo")
         .setType(EchoPlanNode.TYPE)
         .setParams(ImmutableMap.of(
-            EchoOperator.DEFAULT_INPUT_KEY, "${key}"
+            EchoOperator.DEFAULT_INPUT_KEY, Templatable.withValue("${key}")
         ));
 
     final PlanNodeBean enumeratorNode = new PlanNodeBean()
         .setName("enumerator")
         .setType(EnumeratorPlanNode.TYPE)
-        .setParams(Map.of("enumerationList", List.of(
+        .setParams(Map.of("enumerationList", Templatable.withValue(List.of(
             Map.of("key", 1),
             Map.of("key", 2),
             Map.of("key", 3)
-        )))
+        ))))
         ;
 
     final PlanNodeBean combinerNode = new PlanNodeBean()
@@ -116,9 +117,9 @@ public class PlanExecutorTest {
         .setName("root")
         .setType(ForkJoinPlanNode.TYPE)
         .setParams(ImmutableMap.of(
-            K_ENUMERATOR, enumeratorNode.getName(),
-            K_ROOT, echoNode.getName(),
-            K_COMBINER, combinerNode.getName()
+            K_ENUMERATOR, Templatable.withValue(enumeratorNode.getName()),
+            K_ROOT, Templatable.withValue(echoNode.getName()),
+            K_COMBINER, Templatable.withValue(combinerNode.getName())
         ));
 
     final List<PlanNodeBean> planNodeBeans = Arrays.asList(

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperatorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import ai.startree.thirdeye.datasource.cache.DataSourceCache;
 import ai.startree.thirdeye.detectionpipeline.components.GenericDataFetcher;
 import ai.startree.thirdeye.detectionpipeline.spec.DataFetcherSpec;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSource;
 import ai.startree.thirdeye.spi.detection.BaseComponent;
@@ -54,7 +55,7 @@ public class DataFetcherOperatorTest {
   public void testNewInstance() {
     final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
     final PlanNodeBean planNodeBean = new PlanNodeBean()
-        .setParams(ImmutableMap.of("component.dataSource", dataSourceName))
+        .setParams(ImmutableMap.of("component.dataSource", Templatable.withValue(dataSourceName)))
         .setOutputs(ImmutableList.of());
     final Map<String, Object> properties = ImmutableMap.of(DATA_SOURCE_CACHE_REF_KEY,
         dataSourceCache);
@@ -71,11 +72,11 @@ public class DataFetcherOperatorTest {
 
   @Test
   public void testInitComponents() {
-    Map<String, Object> params = new HashMap<>();
+    Map<String, Templatable<Object>> params = new HashMap<>();
 
-    params.put("component.dataSource", dataSourceName);
-    params.put("component.query", "SELECT * FROM myTable");
-    params.put("component.tableName", "myTable");
+    params.put("component.dataSource", Templatable.withValue(dataSourceName));
+    params.put("component.query", Templatable.withValue("SELECT * FROM myTable"));
+    params.put("component.tableName", Templatable.withValue("myTable"));
 
     final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
     final long startTime = System.currentTimeMillis();

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperatorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import ai.startree.thirdeye.spi.Constants;
 import ai.startree.thirdeye.spi.dataframe.DataFrame;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.datalayer.dto.EventDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
@@ -75,7 +76,10 @@ public class EventFetcherOperatorTest {
   @BeforeMethod
   public void setUp() {
     eventDao = mock(EventManager.class);
-    when(eventDao.findEventsBetweenTimeRange(anyLong(), anyLong(), nullable(List.class), nullable(String.class))).thenReturn(List.of(
+    when(eventDao.findEventsBetweenTimeRange(anyLong(),
+        anyLong(),
+        nullable(List.class),
+        nullable(String.class))).thenReturn(List.of(
         CHRISTMAS_EVENT,
         FR_ONLY_EVENT,
         DEPLOY_EVENT));
@@ -87,15 +91,15 @@ public class EventFetcherOperatorTest {
         .setType("EventFetcher")
         // check that all parameters are parsed correctly - but don't test behavior, event manager is mocked
         .setParams(ImmutableMap.of("component.startTimeLookback",
-            "P2D",
+            Templatable.withValue("P2D"),
             "component.endTimeLookback",
-            "P1D",
+            Templatable.withValue("P1D"),
             "component.lookaround",
-            "P3D",
+            Templatable.withValue("P3D"),
             "component.eventTypes",
-            List.of("HOLIDAY"),
+            Templatable.withValue(List.of("HOLIDAY")),
             "component.sqlFilter",
-            "'US' member of dimensionMap['country']"))
+            Templatable.withValue("'US' member of dimensionMap['country']")))
         .setOutputs(List.of(new OutputBean().setOutputKey("events").setOutputName("events")));
 
     final OperatorContext context = new OperatorContext()

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperatorTest.java
@@ -15,6 +15,7 @@ package ai.startree.thirdeye.detectionpipeline.operator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
@@ -41,24 +42,24 @@ public class SqlExecutionOperatorTest {
   @Test
   public void testSqlExecutionHyperSQLAdapter() throws Exception {
     testSqlExecution(ImmutableMap.of(
-        "sql.engine", "HyperSql"
+        "sql.engine", Templatable.withValue("HyperSql")
     ));
   }
 
   @Test
   public void testSqlExecutionCalciteAdapter() throws Exception {
     testSqlExecution(ImmutableMap.of(
-        "sql.engine", "Calcite"
+        "sql.engine", Templatable.withValue("Calcite")
     ));
   }
 
-  private void testSqlExecution(Map<String, Object> customParams) throws Exception {
-    Map<String, Object> params = new HashMap<>();
-    params.put("sql.queries", ImmutableList.of(
+  private void testSqlExecution(Map<String, Templatable<Object>> customParams) throws Exception {
+    Map<String, Templatable<Object>> params = new HashMap<>();
+    params.put("sql.queries", Templatable.withValue(ImmutableList.of(
         "SELECT ts as timestamp_res, met as value_res FROM baseline_data",
         "SELECT ts as timestamp_res, met as value_res FROM current_data",
         "SELECT ts, met FROM baseline_data UNION ALL SELECT ts, met FROM current_data"
-    ));
+    )));
     // put custom params
     params.putAll(customParams);
 

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperatorTest.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye.detectionpipeline.operator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ai.startree.thirdeye.spi.dataframe.DataFrame;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
@@ -48,10 +49,10 @@ public class TimeIndexFillerOperatorTest {
         .setName("root")
         .setType("TimeIndexFiller")
         .setParams(ImmutableMap.of(
-                "component.monitoringGranularity", "P1D",
-                "component.timestamp", "ts",
-                "component.minTimeInference", "FROM_DATA",
-                "component.maxTimeInference", "FROM_DATA"
+                "component.monitoringGranularity", Templatable.withValue("P1D"),
+                "component.timestamp", Templatable.withValue("ts"),
+                "component.minTimeInference", Templatable.withValue("FROM_DATA"),
+                "component.maxTimeInference", Templatable.withValue("FROM_DATA")
             )
         )
         .setInputs(ImmutableList.of(
@@ -96,12 +97,12 @@ public class TimeIndexFillerOperatorTest {
         .setName("root")
         .setType("TimeIndexFiller")
         .setParams(ImmutableMap.of(
-                "component.monitoringGranularity", "P1D",
-                "component.timestamp", "ts",
+                "component.monitoringGranularity", Templatable.withValue("P1D"),
+                "component.timestamp", Templatable.withValue("ts"),
                 // use detection time to infer bounds
-                "component.minTimeInference", "FROM_DETECTION_TIME_WITH_LOOKBACK",
-                "component.maxTimeInference", "FROM_DETECTION_TIME",
-                "component.lookback", "P1D"
+                "component.minTimeInference", Templatable.withValue("FROM_DETECTION_TIME_WITH_LOOKBACK"),
+                "component.maxTimeInference", Templatable.withValue("FROM_DETECTION_TIME"),
+                "component.lookback", Templatable.withValue("P1D")
             )
         )
         .setInputs(ImmutableList.of(

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/core/AlertEvaluator.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/core/AlertEvaluator.java
@@ -33,6 +33,7 @@ import ai.startree.thirdeye.spi.api.AnomalyApi;
 import ai.startree.thirdeye.spi.api.DetectionDataApi;
 import ai.startree.thirdeye.spi.api.DetectionEvaluationApi;
 import ai.startree.thirdeye.spi.api.EvaluationContextApi;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertMetadataDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
@@ -217,7 +218,7 @@ public class AlertEvaluator {
       if (planNodeBean.getParams() == null) {
         planNodeBean.setParams(new HashMap<>());
       }
-      planNodeBean.getParams().put(Constants.EVALUATION_FILTERS_KEY, filters);
+      planNodeBean.getParams().put(Constants.EVALUATION_FILTERS_KEY, Templatable.withValue(filters));
     }
   }
 

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/core/AlertEvaluatorTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/core/AlertEvaluatorTest.java
@@ -65,12 +65,12 @@ public class AlertEvaluatorTest {
     assertThat(alertTemplateDTO.getNodes().get(2).getParams().get(EVALUATION_FILTERS_KEY)).isNull();
 
     // test that filters are injected in data fetcher nodes
-    assertThat(alertTemplateDTO.getNodes().get(3).getParams().get(EVALUATION_FILTERS_KEY)).isNotNull();
-    assertThat(alertTemplateDTO.getNodes().get(4).getParams().get(EVALUATION_FILTERS_KEY)).isNotNull();
+    assertThat(alertTemplateDTO.getNodes().get(3).getParams().get(EVALUATION_FILTERS_KEY).value()).isNotNull();
+    assertThat(alertTemplateDTO.getNodes().get(4).getParams().get(EVALUATION_FILTERS_KEY).value()).isNotNull();
 
     // check the filter value for one data fetcher
     List<QueryPredicate> injectedFilters = (List<QueryPredicate>) alertTemplateDTO
-        .getNodes().get(3).getParams().get(EVALUATION_FILTERS_KEY);
+        .getNodes().get(3).getParams().get(EVALUATION_FILTERS_KEY).value();
     assertThat(injectedFilters.size()).isEqualTo(1);
     assertThat(injectedFilters.get(0).getDataset()).isEqualTo(DATASET_NAME);
     assertThat(injectedFilters.get(0).getMetricType()).isEqualTo(DimensionType.STRING);

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
@@ -97,6 +97,7 @@ public interface Constants {
   long DETECTION_TASK_MAX_LOOKBACK_WINDOW = TimeUnit.DAYS.toMillis(7);
 
   /* Detection Pipeline Context keys */
+  // fixme check here
   String EVALUATION_FILTERS_KEY = "evaluation.filters";
   String DATA_SOURCE_CACHE_REF_KEY = "$DataSourceCache";
   String DETECTION_REGISTRY_REF_KEY = "$DetectionRegistry";

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/PlanNodeApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/PlanNodeApi.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.api;
 
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -38,7 +39,7 @@ public class PlanNodeApi {
   /**
    * Customized params to init the PlanNode.
    */
-  private Map<String, Object> params;
+  private Map<String, Templatable<Object>> params;
   /**
    * Defines the inputs of this PlanNode are set
    */
@@ -66,11 +67,11 @@ public class PlanNodeApi {
     return this;
   }
 
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return params;
   }
 
-  public PlanNodeApi setParams(final Map<String, Object> params) {
+  public PlanNodeApi setParams(final Map<String, Templatable<Object>> params) {
     this.params = params;
     return this;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/Templatable.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/Templatable.java
@@ -33,6 +33,14 @@ public class Templatable<T> {
    */
   public static final String VALUE_FIELD_STRING = "value";
 
+  public static <T> Templatable<T> withValue(final T value) {
+    return new Templatable<T>().setValue(value);
+  }
+
+  public static <T> Templatable<T> withTemplatedValue(final String templatedValue) {
+    return new Templatable<T>().setTemplatedValue(templatedValue);
+  }
+
   @JsonProperty("templatedValue")
   // getter is shortened for ease of use and readability
   public @Nullable String templatedValue() {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/PlanNodeBean.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/PlanNodeBean.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -38,7 +39,7 @@ public class PlanNodeBean {
   /**
    * Customized params to init the PlanNode.
    */
-  private Map<String, Object> params;
+  private Map<String, Templatable<Object>> params;
   /**
    * Defines the inputs of this PlanNode are set
    */
@@ -66,11 +67,11 @@ public class PlanNodeBean {
     return this;
   }
 
-  public Map<String, Object> getParams() {
+  public Map<String, Templatable<Object>> getParams() {
     return params;
   }
 
-  public PlanNodeBean setParams(final Map<String, Object> params) {
+  public PlanNodeBean setParams(final Map<String, Templatable<Object>> params) {
     this.params = params;
     return this;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/v2/Operator.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/v2/Operator.java
@@ -25,8 +25,6 @@ public interface Operator {
 
   String getOperatorName();
 
-  void setProperty(String key, Object value);
-
 
   /**
    * Set keyed input

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/v2/PlanNode.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/v2/PlanNode.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.detection.v2;
 
+import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,7 @@ public interface PlanNode {
   /**
    * @return all params
    */
-  Map<String, Object> getParams();
+  Map<String, Templatable<Object>> getParams();
 
   /**
    * Get the execution operator associated with the PlanNode.

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/json/ApiTemplatableDeserializer.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/json/ApiTemplatableDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.type.SimpleType;
 import java.io.IOException;
 
 /**
@@ -49,7 +50,13 @@ class ApiTemplatableDeserializer extends JsonDeserializer<Templatable<?>>
     checkArgument(property != null,
         "Cannot deserialize Templatable object without its generic type. Attempt to use Templatable as root object?");
     final JavaType wrapperType = property.getType();
-    final JavaType valueType = wrapperType.containedType(0);
+    final int numDistinctType = wrapperType.containedTypeCount();
+    final JavaType valueType;
+    if (numDistinctType == 1) {
+      valueType = wrapperType.containedType(0);
+    } else {
+      valueType = SimpleType.constructUnsafe(Object.class);
+    }
     final ApiTemplatableDeserializer deserializer = new ApiTemplatableDeserializer();
     deserializer.valueType = valueType;
     return deserializer;

--- a/thirdeye-spi/src/test/java/ai/startree/thirdeye/spi/api/PlanNodeApiTest.java
+++ b/thirdeye-spi/src/test/java/ai/startree/thirdeye/spi/api/PlanNodeApiTest.java
@@ -13,7 +13,7 @@
  */
 package ai.startree.thirdeye.spi.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import ai.startree.thirdeye.spi.json.ThirdEyeSerialization;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
@@ -26,7 +26,7 @@ public class PlanNodeApiTest {
   @Test
   public void testInputNode() throws IOException {
     URL resource = PlanNodeApiTest.class.getClassLoader().getResource("inputNode.json");
-    final PlanNodeApi inputNode = new ObjectMapper().readValue(
+    final PlanNodeApi inputNode = ThirdEyeSerialization.newObjectMapper().readValue(
         Resources.toString(resource, StandardCharsets.UTF_8),
         PlanNodeApi.class);
     Assert.assertEquals(inputNode.getName(), "baselineDataFetcher");
@@ -40,7 +40,7 @@ public class PlanNodeApiTest {
   @Test
   public void testDetectionNode() throws IOException {
     URL resource = PlanNodeApiTest.class.getClassLoader().getResource("detectionNode.json");
-    final PlanNodeApi inputNode = new ObjectMapper().readValue(Resources.toString(resource,
+    final PlanNodeApi inputNode = ThirdEyeSerialization.newObjectMapper().readValue(Resources.toString(resource,
         StandardCharsets.UTF_8),
         PlanNodeApi.class);
     Assert.assertEquals(inputNode.getName(), "percentageChangeDetector");


### PR DESCRIPTION
---> AbstracSpec don't have to implement Templatable in the templatable fields