### PR TITLE
[core] make node params templatable

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertTemplateRenderer.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertTemplateRenderer.java
@@ -136,7 +136,7 @@ public class AlertTemplateRenderer {
           // TODO spyne remove magic string. This was done to remove dependency of AnomalyDetector.TYPE on the renderer
           .filter(node -> node.getType().equals("AnomalyDetector"))
           .forEach(node -> node.getParams()
-              .put("anomaly.source", String.format("%s/%s", alertName, node.getName())));
+              .putValue("anomaly.source", String.format("%s/%s", alertName, node.getName())));
     }
 
     return StringTemplateUtils.applyContext(template, properties);

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -37,7 +37,6 @@ public class StringTemplateUtils {
     GROOVY_TEMPLATE_ENGINE.setEscapeBackslash(true);
   }
 
-  // todo cyril make this protected for test only - move alertResourceTest
   public static String renderTemplate(final String template, final Map<String, Object> newContext)
       throws IOException, ClassNotFoundException {
     final Map<String, Object> contextMap = getDefaultContextMap();

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -37,6 +37,7 @@ public class StringTemplateUtils {
     GROOVY_TEMPLATE_ENGINE.setEscapeBackslash(true);
   }
 
+  // todo cyril make this protected for test only - move alertResourceTest
   public static String renderTemplate(final String template, final Map<String, Object> newContext)
       throws IOException, ClassNotFoundException {
     final Map<String, Object> contextMap = getDefaultContextMap();

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/AnomalyDetectorOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/AnomalyDetectorOperator.java
@@ -27,6 +27,8 @@ import ai.startree.thirdeye.spi.dataframe.BooleanSeries;
 import ai.startree.thirdeye.spi.dataframe.DataFrame;
 import ai.startree.thirdeye.spi.dataframe.DoubleSeries;
 import ai.startree.thirdeye.spi.dataframe.LongSeries;
+import ai.startree.thirdeye.spi.datalayer.Templatable;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.MergedAnomalyResultDTO;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.AnomalyDetector;
@@ -66,7 +68,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
     final DetectionRegistry detectionRegistry = (DetectionRegistry) context.getProperties()
         .get(Constants.DETECTION_REGISTRY_REF_KEY);
     requireNonNull(detectionRegistry, "DetectionRegistry is not set");
-    detector = createDetector(planNode.getParams(), detectionRegistry);
+    detector = createDetector(optional(planNode.getParams()).map(TemplatableMap::valueMap).orElse(null), detectionRegistry);
   }
 
   private AnomalyDetector<? extends AbstractSpec> createDetector(
@@ -107,6 +109,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
   private void addMetadata(DetectionPipelineResult detectionPipelineResult) {
     // Annotate each anomaly with a metric name
     optional(planNode.getParams().get("anomaly.metric"))
+        .map(Templatable::value)
         .map(Object::toString)
         .ifPresent(anomalyMetric -> detectionPipelineResult.getDetectionResults().stream()
             .map(DetectionResult::getAnomalies)
@@ -114,6 +117,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
             .forEach(anomaly -> anomaly.setMetric(anomalyMetric)));
 
     optional(planNode.getParams().get("anomaly.dataset"))
+        .map(Templatable::value)
         .map(Object::toString)
         .ifPresent(anomalyDataset -> detectionPipelineResult.getDetectionResults().stream()
             .map(DetectionResult::getAnomalies)
@@ -122,6 +126,7 @@ public class AnomalyDetectorOperator extends DetectionPipelineOperator {
 
     // Annotate each anomaly with source info
     optional(planNode.getParams().get("anomaly.source"))
+        .map(Templatable::value)
         .map(Object::toString)
         .ifPresent(anomalySource -> detectionPipelineResult.getDetectionResults().stream()
             .map(DetectionResult::getAnomalies)

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/CombinerOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/CombinerOperator.java
@@ -18,6 +18,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator.ForkJoinResult;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.model.DetectionResult;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
@@ -39,7 +40,7 @@ public class CombinerOperator extends DetectionPipelineOperator {
   @Override
   public void init(final OperatorContext context) {
     super.init(context);
-    params = optional(getPlanNode().getParams()).orElse(emptyMap());
+    params = optional(getPlanNode().getParams()).map(TemplatableMap::valueMap).orElse(emptyMap());
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperator.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.detectionpipeline.operator;
 
 import static ai.startree.thirdeye.spi.Constants.EVALUATION_FILTERS_KEY;
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -22,6 +23,7 @@ import ai.startree.thirdeye.datasource.calcite.QueryPredicate;
 import ai.startree.thirdeye.detectionpipeline.components.GenericDataFetcher;
 import ai.startree.thirdeye.detectionpipeline.spec.DataFetcherSpec;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DataFetcher;
@@ -49,7 +51,7 @@ public class DataFetcherOperator extends DetectionPipelineOperator {
 
     final DataSourceCache dataSourceCache = (DataSourceCache) context.getProperties()
         .get(Constants.DATA_SOURCE_CACHE_REF_KEY);
-    dataFetcher = createDataFetcher(planNode.getParams(), dataSourceCache);
+    dataFetcher = createDataFetcher(optional(planNode.getParams()).map(TemplatableMap::valueMap).orElse(null), dataSourceCache);
   }
 
   protected DataFetcher<DataFetcherSpec> createDataFetcher(final Map<String, Object> params,

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DetectionPipelineOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/DetectionPipelineOperator.java
@@ -100,7 +100,7 @@ public abstract class DetectionPipelineOperator implements Operator {
 
   @Override
   public void setProperty(final String key, final Object value) {
-    planNode.getParams().put(key, value);
+    planNode.getParams().putValue(key, value);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EchoOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EchoOperator.java
@@ -34,7 +34,7 @@ public class EchoOperator extends DetectionPipelineOperator {
 
   @Override
   public void execute() throws Exception {
-    final String echoText = getPlanNode().getParams().get(DEFAULT_INPUT_KEY).toString();
+    final String echoText = getPlanNode().getParams().getValue(DEFAULT_INPUT_KEY).toString();
     setOutput(DEFAULT_OUTPUT_KEY, new EchoResult(echoText));
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EnumeratorOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EnumeratorOperator.java
@@ -13,6 +13,8 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import ai.startree.thirdeye.spi.detection.model.DetectionResult;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
@@ -36,7 +38,8 @@ public class EnumeratorOperator extends DetectionPipelineOperator {
   @SuppressWarnings("unchecked")
   @Override
   public void execute() throws Exception {
-    final Map<String, Object> params = getPlanNode().getParams();
+    checkArgument(getPlanNode().getParams() != null, "Missing configuration parameters in EnumeratorOperator.");
+    final Map<String, Object> params = getPlanNode().getParams().valueMap();
     final List<Map<String, Object>> enumerationList =
         (List<Map<String, Object>>) params.get("enumerationList");
     setOutput(DEFAULT_OUTPUT_KEY, new EnumeratorResult(enumerationList));

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperator.java
@@ -13,12 +13,14 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.components.EventDataFetcher;
 import ai.startree.thirdeye.detectionpipeline.spec.EventFetcherSpec;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DataFetcher;
@@ -37,7 +39,8 @@ public class EventFetcherOperator extends DetectionPipelineOperator {
     super.init(context);
     final EventManager eventDao = (EventManager) context.getProperties()
         .get(Constants.EVENT_MANAGER_REF_KEY);
-    this.eventFetcher = createEventFetcher(planNode.getParams(), eventDao);
+    this.eventFetcher = createEventFetcher(optional(planNode.getParams()).map(TemplatableMap::valueMap)
+        .orElse(null), eventDao);
 
     checkArgument(inputMap == null || inputMap.size() == 0,
         OPERATOR_NAME + " must have exactly 0 input node.");

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventTriggerOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/EventTriggerOperator.java
@@ -13,10 +13,12 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DetectionUtils;
 import ai.startree.thirdeye.spi.detection.EventTrigger;
@@ -41,7 +43,7 @@ public class EventTriggerOperator extends DetectionPipelineOperator {
         .get(Constants.DETECTION_REGISTRY_REF_KEY);
     requireNonNull(detectionRegistry, "DetectionRegistry is not set");
 
-    eventTrigger = createEventTrigger(planNode.getParams(), detectionRegistry);
+    eventTrigger = createEventTrigger(optional(planNode.getParams()).map(TemplatableMap::valueMap).orElse(null), detectionRegistry);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/ForkJoinOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/ForkJoinOperator.java
@@ -20,6 +20,7 @@ import ai.startree.thirdeye.detectionpipeline.PlanExecutor;
 import ai.startree.thirdeye.detectionpipeline.PlanNodeFactory;
 import ai.startree.thirdeye.detectionpipeline.operator.EnumeratorOperator.EnumeratorResult;
 import ai.startree.thirdeye.mapper.PlanNodeMapper;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.detection.model.DetectionResult;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
@@ -28,7 +29,6 @@ import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNode;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
 import ai.startree.thirdeye.util.StringTemplateUtils;
-import com.google.common.collect.ImmutableBiMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -184,21 +184,18 @@ public class ForkJoinOperator extends DetectionPipelineOperator {
 
   private PlanNodeBean clonePlanNodeBean(final Map<String, Object> templateProperties,
       final PlanNodeBean n) {
-    final Map<String, Object> params = applyTemplatePropertiesOnParams(n.getParams(),
+    final TemplatableMap<String, Object> params = applyTemplatePropertiesOnParams(n.getParams(),
         templateProperties);
     return PlanNodeMapper.INSTANCE.clone(n).setParams(params);
   }
 
-  private Map<String, Object> applyTemplatePropertiesOnParams(
-      final Map<String, Object> params, final Map<String, Object> templateProperties) {
+  private TemplatableMap<String, Object> applyTemplatePropertiesOnParams(
+      final TemplatableMap<String, Object> params, final Map<String, Object> templateProperties) {
     if (params == null) {
       return null;
     }
     try {
-      return ImmutableBiMap.copyOf(StringTemplateUtils.applyContext(
-          new HashMap<>(params),
-          templateProperties
-      ));
+      return new TemplatableMap<>(StringTemplateUtils.applyContext(params, templateProperties));
     } catch (final IOException | ClassNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperator.java
@@ -13,6 +13,8 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import ai.startree.thirdeye.detectionpipeline.operator.sql.DataTableToSqlAdapterFactory;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
 import ai.startree.thirdeye.spi.detection.v2.DataTable;
@@ -54,18 +56,19 @@ public class SqlExecutionOperator extends DetectionPipelineOperator {
     for (final OutputBean outputBean : context.getPlanNode().getOutputs()) {
       outputKeyMap.put(outputBean.getOutputKey(), outputBean.getOutputName());
     }
+    checkArgument(planNode.getParams() != null);
     if (planNode.getParams().containsKey(SQL_QUERIES)) {
-      queries.addAll((List<String>) planNode.getParams().get(SQL_QUERIES));
+      queries.addAll((List<String>) planNode.getParams().getValue(SQL_QUERIES));
     } else {
       throw new IllegalArgumentException(
           "Missing property '" + SQL_QUERIES + "' in SqlExecutionOperator");
     }
 
-    dataTableToSqlAdapter = DataTableToSqlAdapterFactory.create(planNode.getParams()
+    dataTableToSqlAdapter = DataTableToSqlAdapterFactory.create(planNode.getParams().valueMap()
         .getOrDefault(SQL_ENGINE, DEFAULT_SQL_ENGINE).toString());
     if (planNode.getParams().containsKey(JDBC_CONNECTION_PARAMS)) {
       dataTableToSqlAdapter.jdbcProperties()
-          .putAll((Map<String, String>) planNode.getParams().get(JDBC_CONNECTION_PARAMS));
+          .putAll((Map<String, String>) planNode.getParams().getValue(JDBC_CONNECTION_PARAMS));
     }
   }
 

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperator.java
@@ -13,11 +13,13 @@
  */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.components.TimeIndexFiller;
 import ai.startree.thirdeye.detectionpipeline.spec.TimeIndexFillerSpec;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.AbstractSpec;
 import ai.startree.thirdeye.spi.detection.DetectionUtils;
 import ai.startree.thirdeye.spi.detection.IndexFiller;
@@ -37,7 +39,8 @@ public class TimeIndexFillerOperator extends DetectionPipelineOperator {
   @Override
   public void init(final OperatorContext context) {
     super.init(context);
-    this.timeIndexFiller = createTimeIndexFiller(planNode.getParams());
+    this.timeIndexFiller = createTimeIndexFiller(optional(planNode.getParams()).map(TemplatableMap::valueMap)
+        .orElse(null));
 
     checkArgument(inputMap.size() == 1,
         OPERATOR_NAME + " must have exactly 1 input node.");

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/AnomalyDetectorPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/AnomalyDetectorPlanNode.java
@@ -13,11 +13,13 @@
  */
 package ai.startree.thirdeye.detectionpipeline.plan;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
 import ai.startree.thirdeye.detectionpipeline.operator.AnomalyDetectorOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -48,7 +50,7 @@ public class AnomalyDetectorPlanNode extends DetectionPipelinePlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/CombinerPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/CombinerPlanNode.java
@@ -17,6 +17,7 @@ import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Collections.emptyMap;
 
 import ai.startree.thirdeye.detectionpipeline.operator.CombinerOperator;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -34,7 +35,7 @@ public class CombinerPlanNode extends DetectionPipelinePlanNode {
   @Override
   public void init(final PlanNodeContext planNodeContext) {
     super.init(planNodeContext);
-    params = optional(planNodeBean.getParams()).orElse(emptyMap());
+    params = optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(emptyMap());
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DataFetcherPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DataFetcherPlanNode.java
@@ -13,9 +13,12 @@
  */
 package ai.startree.thirdeye.detectionpipeline.plan;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+
 import ai.startree.thirdeye.datasource.cache.DataSourceCache;
 import ai.startree.thirdeye.detectionpipeline.operator.DataFetcherOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -44,7 +47,7 @@ public class DataFetcherPlanNode extends DetectionPipelinePlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DetectionPipelinePlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/DetectionPipelinePlanNode.java
@@ -13,8 +13,10 @@
  */
 package ai.startree.thirdeye.detectionpipeline.plan;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Objects.requireNonNull;
 
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
@@ -72,7 +74,7 @@ public abstract class DetectionPipelinePlanNode implements PlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EchoPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EchoPlanNode.java
@@ -13,7 +13,10 @@
  */
 package ai.startree.thirdeye.detectionpipeline.plan;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+
 import ai.startree.thirdeye.detectionpipeline.operator.EchoOperator;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -39,7 +42,7 @@ public class EchoPlanNode extends DetectionPipelinePlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EnumeratorPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EnumeratorPlanNode.java
@@ -17,6 +17,7 @@ import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Collections.emptyMap;
 
 import ai.startree.thirdeye.detectionpipeline.operator.EnumeratorOperator;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -34,7 +35,7 @@ public class EnumeratorPlanNode extends DetectionPipelinePlanNode {
   @Override
   public void init(final PlanNodeContext planNodeContext) {
     super.init(planNodeContext);
-    params = optional(planNodeBean.getParams()).orElse(emptyMap());
+    params = optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(emptyMap());
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventFetcherPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventFetcherPlanNode.java
@@ -13,10 +13,12 @@
  */
 package ai.startree.thirdeye.detectionpipeline.plan;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import ai.startree.thirdeye.detectionpipeline.operator.EventFetcherOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
@@ -45,7 +47,7 @@ public class EventFetcherPlanNode extends DetectionPipelinePlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventTriggerPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/EventTriggerPlanNode.java
@@ -13,11 +13,13 @@
  */
 package ai.startree.thirdeye.detectionpipeline.plan;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
 import ai.startree.thirdeye.detectionpipeline.operator.EventTriggerOperator;
 import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -47,7 +49,7 @@ public class EventTriggerPlanNode extends DetectionPipelinePlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/ForkJoinPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/ForkJoinPlanNode.java
@@ -16,9 +16,11 @@ package ai.startree.thirdeye.detectionpipeline.plan;
 import static ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator.K_COMBINER;
 import static ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator.K_ENUMERATOR;
 import static ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator.K_ROOT;
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.detectionpipeline.operator.ForkJoinOperator;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNode;
@@ -50,7 +52,7 @@ public class ForkJoinPlanNode extends DetectionPipelinePlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/SqlExecutionPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/SqlExecutionPlanNode.java
@@ -13,7 +13,10 @@
  */
 package ai.startree.thirdeye.detectionpipeline.plan;
 
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+
 import ai.startree.thirdeye.detectionpipeline.operator.SqlExecutionOperator;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.detection.v2.Operator;
 import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
 import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
@@ -37,7 +40,7 @@ public class SqlExecutionPlanNode extends DetectionPipelinePlanNode {
 
   @Override
   public Map<String, Object> getParams() {
-    return planNodeBean.getParams();
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
   }
 
   @Override

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/PlanExecutorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/PlanExecutorTest.java
@@ -29,6 +29,7 @@ import ai.startree.thirdeye.detectionpipeline.plan.CombinerPlanNode;
 import ai.startree.thirdeye.detectionpipeline.plan.EchoPlanNode;
 import ai.startree.thirdeye.detectionpipeline.plan.EnumeratorPlanNode;
 import ai.startree.thirdeye.detectionpipeline.plan.ForkJoinPlanNode;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.detection.v2.DetectionPipelineResult;
@@ -69,7 +70,7 @@ public class PlanExecutorTest {
         .setDetectionInterval(new Interval(0L, 0L, DateTimeZone.UTC))
         .setPlanNodeBean(new PlanNodeBean()
             .setInputs(Collections.emptyList())
-            .setParams(ImmutableMap.of(EchoOperator.DEFAULT_INPUT_KEY, echoInput))
+            .setParams(TemplatableMap.ofValue(EchoOperator.DEFAULT_INPUT_KEY, echoInput))
         )
     );
     final HashMap<ContextKey, DetectionPipelineResult> context = new HashMap<>();
@@ -94,14 +95,14 @@ public class PlanExecutorTest {
     final PlanNodeBean echoNode = new PlanNodeBean()
         .setName("echo")
         .setType(EchoPlanNode.TYPE)
-        .setParams(ImmutableMap.of(
+        .setParams(TemplatableMap.ofValue(
             EchoOperator.DEFAULT_INPUT_KEY, "${key}"
         ));
 
     final PlanNodeBean enumeratorNode = new PlanNodeBean()
         .setName("enumerator")
         .setType(EnumeratorPlanNode.TYPE)
-        .setParams(Map.of("enumerationList", List.of(
+        .setParams(TemplatableMap.ofValue("enumerationList", List.of(
             Map.of("key", 1),
             Map.of("key", 2),
             Map.of("key", 3)
@@ -115,11 +116,11 @@ public class PlanExecutorTest {
     final PlanNodeBean forkJoinNode = new PlanNodeBean()
         .setName("root")
         .setType(ForkJoinPlanNode.TYPE)
-        .setParams(ImmutableMap.of(
+        .setParams(TemplatableMap.fromValueMap(ImmutableMap.of(
             K_ENUMERATOR, enumeratorNode.getName(),
             K_ROOT, echoNode.getName(),
             K_COMBINER, combinerNode.getName()
-        ));
+        )));
 
     final List<PlanNodeBean> planNodeBeans = Arrays.asList(
         echoNode,

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/DataFetcherOperatorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import ai.startree.thirdeye.datasource.cache.DataSourceCache;
 import ai.startree.thirdeye.detectionpipeline.components.GenericDataFetcher;
 import ai.startree.thirdeye.detectionpipeline.spec.DataFetcherSpec;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSource;
 import ai.startree.thirdeye.spi.detection.BaseComponent;
@@ -54,7 +55,7 @@ public class DataFetcherOperatorTest {
   public void testNewInstance() {
     final DataFetcherOperator dataFetcherOperator = new DataFetcherOperator();
     final PlanNodeBean planNodeBean = new PlanNodeBean()
-        .setParams(ImmutableMap.of("component.dataSource", dataSourceName))
+        .setParams(TemplatableMap.fromValueMap(ImmutableMap.of("component.dataSource", dataSourceName)))
         .setOutputs(ImmutableList.of());
     final Map<String, Object> properties = ImmutableMap.of(DATA_SOURCE_CACHE_REF_KEY,
         dataSourceCache);
@@ -83,7 +84,7 @@ public class DataFetcherOperatorTest {
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setOutputs(ImmutableList.of())
         .setInputs(ImmutableList.of())
-        .setParams(params);
+        .setParams(TemplatableMap.fromValueMap(params));
 
     final Map<String, Object> properties = ImmutableMap.of(DATA_SOURCE_CACHE_REF_KEY,
         dataSourceCache);

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/EventFetcherOperatorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import ai.startree.thirdeye.spi.Constants;
 import ai.startree.thirdeye.spi.dataframe.DataFrame;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.bao.EventManager;
 import ai.startree.thirdeye.spi.datalayer.dto.EventDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
@@ -75,7 +76,10 @@ public class EventFetcherOperatorTest {
   @BeforeMethod
   public void setUp() {
     eventDao = mock(EventManager.class);
-    when(eventDao.findEventsBetweenTimeRange(anyLong(), anyLong(), nullable(List.class), nullable(String.class))).thenReturn(List.of(
+    when(eventDao.findEventsBetweenTimeRange(anyLong(),
+        anyLong(),
+        nullable(List.class),
+        nullable(String.class))).thenReturn(List.of(
         CHRISTMAS_EVENT,
         FR_ONLY_EVENT,
         DEPLOY_EVENT));
@@ -86,7 +90,7 @@ public class EventFetcherOperatorTest {
     final PlanNodeBean planNodeBean = new PlanNodeBean().setName("root")
         .setType("EventFetcher")
         // check that all parameters are parsed correctly - but don't test behavior, event manager is mocked
-        .setParams(ImmutableMap.of("component.startTimeLookback",
+        .setParams(TemplatableMap.fromValueMap(ImmutableMap.of("component.startTimeLookback",
             "P2D",
             "component.endTimeLookback",
             "P1D",
@@ -95,7 +99,7 @@ public class EventFetcherOperatorTest {
             "component.eventTypes",
             List.of("HOLIDAY"),
             "component.sqlFilter",
-            "'US' member of dimensionMap['country']"))
+            "'US' member of dimensionMap['country']")))
         .setOutputs(List.of(new OutputBean().setOutputKey("events").setOutputName("events")));
 
     final OperatorContext context = new OperatorContext()

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/SqlExecutionOperatorTest.java
@@ -15,6 +15,7 @@ package ai.startree.thirdeye.detectionpipeline.operator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
@@ -66,7 +67,7 @@ public class SqlExecutionOperatorTest {
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setName("root")
         .setType("SqlExecution")
-        .setParams(params)
+        .setParams(TemplatableMap.fromValueMap(params))
         .setInputs(ImmutableList.of(
             new InputBean().setTargetProperty("baseline_data")
                 .setSourceProperty("baselineOutput")

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/TimeIndexFillerOperatorTest.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye.detectionpipeline.operator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ai.startree.thirdeye.spi.dataframe.DataFrame;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.OutputBean;
@@ -47,13 +48,13 @@ public class TimeIndexFillerOperatorTest {
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setName("root")
         .setType("TimeIndexFiller")
-        .setParams(ImmutableMap.of(
+        .setParams(TemplatableMap.fromValueMap(ImmutableMap.of(
                 "component.monitoringGranularity", "P1D",
                 "component.timestamp", "ts",
                 "component.minTimeInference", "FROM_DATA",
                 "component.maxTimeInference", "FROM_DATA"
             )
-        )
+        ))
         .setInputs(ImmutableList.of(
             new InputBean().setTargetProperty("baseline")
                 .setSourceProperty("currentDataFetcher")
@@ -95,7 +96,7 @@ public class TimeIndexFillerOperatorTest {
     final PlanNodeBean planNodeBean = new PlanNodeBean()
         .setName("root")
         .setType("TimeIndexFiller")
-        .setParams(ImmutableMap.of(
+        .setParams(TemplatableMap.fromValueMap(ImmutableMap.of(
                 "component.monitoringGranularity", "P1D",
                 "component.timestamp", "ts",
                 // use detection time to infer bounds
@@ -103,7 +104,7 @@ public class TimeIndexFillerOperatorTest {
                 "component.maxTimeInference", "FROM_DETECTION_TIME",
                 "component.lookback", "P1D"
             )
-        )
+        ))
         .setInputs(ImmutableList.of(
             new InputBean().setTargetProperty("baseline")
                 .setSourceProperty("currentDataFetcher")

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/core/AlertEvaluator.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/core/AlertEvaluator.java
@@ -33,6 +33,7 @@ import ai.startree.thirdeye.spi.api.AnomalyApi;
 import ai.startree.thirdeye.spi.api.DetectionDataApi;
 import ai.startree.thirdeye.spi.api.DetectionEvaluationApi;
 import ai.startree.thirdeye.spi.api.EvaluationContextApi;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertMetadataDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
@@ -215,9 +216,9 @@ public class AlertEvaluator {
   private void addFilters(PlanNodeBean planNodeBean, List<QueryPredicate> filters) {
     if (planNodeBean.getType().equals(new DataFetcherPlanNode().getType())) {
       if (planNodeBean.getParams() == null) {
-        planNodeBean.setParams(new HashMap<>());
+        planNodeBean.setParams(new TemplatableMap<>());
       }
-      planNodeBean.getParams().put(Constants.EVALUATION_FILTERS_KEY, filters);
+      planNodeBean.getParams().putValue(Constants.EVALUATION_FILTERS_KEY, filters);
     }
   }
 

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/core/AlertEvaluatorTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/core/AlertEvaluatorTest.java
@@ -22,12 +22,12 @@ import ai.startree.thirdeye.detectionpipeline.plan.DataFetcherPlanNode;
 import ai.startree.thirdeye.detectionpipeline.plan.IndexFillerPlanNode;
 import ai.startree.thirdeye.spi.datalayer.Predicate;
 import ai.startree.thirdeye.spi.datalayer.Predicate.OPER;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertMetadataDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
 import ai.startree.thirdeye.spi.metric.DimensionType;
-import java.util.HashMap;
 import java.util.List;
 import org.testng.annotations.Test;
 
@@ -49,10 +49,10 @@ public class AlertEvaluatorTest {
             new PlanNodeBean().setName("root").setType(ANOMALY_DETECTOR_TYPE),
             new PlanNodeBean().setName("indexFiller1").setType(INDEX_FILLER_TYPE),
             new PlanNodeBean().setName("indexFiller2").setType(INDEX_FILLER_TYPE)
-            .setParams(new HashMap<>()),
+            .setParams(new TemplatableMap<>()),
             new PlanNodeBean().setName("dataFetcher1").setType(DATA_FETCHER_TYPE),
             new PlanNodeBean().setName("dataFetcher2").setType(DATA_FETCHER_TYPE)
-                .setParams(new HashMap<>())
+                .setParams(new TemplatableMap<>())
         ));
     List<String> filters = List.of("browser=chrome");
 
@@ -70,7 +70,7 @@ public class AlertEvaluatorTest {
 
     // check the filter value for one data fetcher
     List<QueryPredicate> injectedFilters = (List<QueryPredicate>) alertTemplateDTO
-        .getNodes().get(3).getParams().get(EVALUATION_FILTERS_KEY);
+        .getNodes().get(3).getParams().getValue(EVALUATION_FILTERS_KEY);
     assertThat(injectedFilters.size()).isEqualTo(1);
     assertThat(injectedFilters.get(0).getDataset()).isEqualTo(DATASET_NAME);
     assertThat(injectedFilters.get(0).getMetricType()).isEqualTo(DimensionType.STRING);

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import ai.startree.thirdeye.spi.api.AlertEvaluationApi;
 import ai.startree.thirdeye.spi.api.PlanNodeApi;
+import ai.startree.thirdeye.spi.json.ThirdEyeSerialization;
 import ai.startree.thirdeye.util.StringTemplateUtils;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
@@ -38,10 +38,10 @@ public class AlertResourceTest {
     URL resource = requireNonNull(classLoader.getResource("alertEvaluation.json"));
     final String jsonString = Resources.toString(resource, StandardCharsets.UTF_8);
     resource = classLoader.getResource("alertEvaluation-context.json");
-    final Map<String, Object> alertEvaluationPlanApiContext = new ObjectMapper()
+    final Map<String, Object> alertEvaluationPlanApiContext = ThirdEyeSerialization.newObjectMapper()
         .readValue(resource.openStream(), Map.class);
 
-    final AlertEvaluationApi api = new ObjectMapper().readValue(StringTemplateUtils.renderTemplate(
+    final AlertEvaluationApi api = ThirdEyeSerialization.newObjectMapper().readValue(StringTemplateUtils.renderTemplate(
         jsonString,
         alertEvaluationPlanApiContext), AlertEvaluationApi.class);
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/PlanNodeApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/PlanNodeApi.java
@@ -13,12 +13,12 @@
  */
 package ai.startree.thirdeye.spi.api;
 
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Map;
 
 /**
  * PlanNodeApi is self-described detection plan node.
@@ -38,7 +38,7 @@ public class PlanNodeApi {
   /**
    * Customized params to init the PlanNode.
    */
-  private Map<String, Object> params;
+  private TemplatableMap<String, Object> params;
   /**
    * Defines the inputs of this PlanNode are set
    */
@@ -66,11 +66,11 @@ public class PlanNodeApi {
     return this;
   }
 
-  public Map<String, Object> getParams() {
+  public TemplatableMap<String, Object> getParams() {
     return params;
   }
 
-  public PlanNodeApi setParams(final Map<String, Object> params) {
+  public PlanNodeApi setParams(final TemplatableMap<String, Object> params) {
     this.params = params;
     return this;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/Templatable.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/Templatable.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
-import java.util.function.Predicate;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -88,20 +87,6 @@ public class Templatable<T> {
   @Override
   public int hashCode() {
     return Objects.hash(templatedValue, value);
-  }
-
-  /**
-   * Returns false if the wrapped value is null. Else return the result of the predicate.
-   *
-   * Used in optional/stream filter() to do check on the wrapped value without losing the Templatable wrapping
-   */
-  public boolean match(Predicate<? super T> predicate, final boolean defaultIfNull) {
-    Objects.requireNonNull(predicate);
-    if (value == null) {
-      return defaultIfNull;
-    } else {
-      return predicate.test(value);
-    }
   }
 
   @Override

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/Templatable.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/Templatable.java
@@ -19,11 +19,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import java.util.function.Predicate;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @JsonInclude(Include.NON_NULL)
 public class Templatable<T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Templatable.class);
 
   private @Nullable String templatedValue;
   private @Nullable T value;
@@ -83,5 +88,28 @@ public class Templatable<T> {
   @Override
   public int hashCode() {
     return Objects.hash(templatedValue, value);
+  }
+
+  /**
+   * Returns false if the wrapped value is null. Else return the result of the predicate.
+   *
+   * Used in optional/stream filter() to do check on the wrapped value without losing the Templatable wrapping
+   */
+  public boolean match(Predicate<? super T> predicate, final boolean defaultIfNull) {
+    Objects.requireNonNull(predicate);
+    if (value == null) {
+      return defaultIfNull;
+    } else {
+      return predicate.test(value);
+    }
+  }
+
+  @Override
+  public String toString() {
+    LOG.error("Calling toString on a Templatable. Most likely caused by an incorrect implementation targeting the wrapped value or a debug mode.");
+    return "Templatable{" +
+        "templatedValue='" + templatedValue + '\'' +
+        ", value=" + value +
+        '}';
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/TemplatableMap.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/TemplatableMap.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.spi.datalayer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Makes it easier to manipulate a map of {@link Templatable}.
+ * */
+public class TemplatableMap<K, V> extends HashMap<K, Templatable<V>> {
+
+  public TemplatableMap() {
+    super();
+  }
+
+  public TemplatableMap(TemplatableMap<K, V> map) {
+    super();
+    putAll(map);
+  }
+
+  public static <K, V> TemplatableMap<K, V> ofValue(K key, V value) {
+    final TemplatableMap<K, V> m = new TemplatableMap<>();
+    m.putValue(key, value);
+    return m;
+  }
+
+  public static <K, V> TemplatableMap<K, V> fromValueMap(Map<K, V> map) {
+    final TemplatableMap<K, V> templatableMap = new TemplatableMap<>();
+    for (K k: map.keySet()) {
+      templatableMap.put(k, new Templatable<V>().setValue(map.get(k)));
+    }
+    return templatableMap;
+  }
+
+  /**
+   * Returns a copy of the map with Templatables unwrapped to their value.
+   * @throws IllegalStateException if the Map contains values for which properties were not applied. ie for which templatedValue is not null and value is null.
+   * */
+  public Map<K, V> valueMap() {
+    final HashMap<K, V> valueMap = new HashMap<>();
+    for (K k : this.keySet()) {
+      final Templatable<V> templatable = this.get(k);
+      checkPropertyIsApplied(templatable);
+      valueMap.put(k, templatable.value());
+    }
+    return valueMap;
+  }
+
+  public V getValue(Object key) {
+    Templatable<V> templatable = get(key);
+    checkPropertyIsApplied(templatable);
+    return templatable.value();
+  }
+
+  public V putValue(K key, V value) {
+    final Templatable<V> old = put(key, new Templatable<V>().setValue(value));
+    if (old == null) {
+      return null;
+    }
+    return old.value();
+  }
+
+  private void checkPropertyIsApplied(final Templatable<V> templatable) {
+    if (templatable.value() == null && templatable.templatedValue() != null) {
+      throw new IllegalStateException("Cannot return value map. Properties not resolved");
+    }
+  }
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/PlanNodeBean.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/PlanNodeBean.java
@@ -13,12 +13,12 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Map;
 
 /**
  * PlanNodeApi is self-described detection plan node.
@@ -38,7 +38,7 @@ public class PlanNodeBean {
   /**
    * Customized params to init the PlanNode.
    */
-  private Map<String, Object> params;
+  private TemplatableMap<String, Object> params;
   /**
    * Defines the inputs of this PlanNode are set
    */
@@ -66,11 +66,11 @@ public class PlanNodeBean {
     return this;
   }
 
-  public Map<String, Object> getParams() {
+  public TemplatableMap<String, Object> getParams() {
     return params;
   }
 
-  public PlanNodeBean setParams(final Map<String, Object> params) {
+  public PlanNodeBean setParams(final TemplatableMap<String, Object> params) {
     this.params = params;
     return this;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/json/ApiTemplatableDeserializer.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/json/ApiTemplatableDeserializer.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye.spi.json;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import ai.startree.thirdeye.spi.datalayer.Templatable;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.type.SimpleType;
 import java.io.IOException;
 
 /**
@@ -48,10 +50,14 @@ class ApiTemplatableDeserializer extends JsonDeserializer<Templatable<?>>
       throws JsonMappingException {
     checkArgument(property != null,
         "Cannot deserialize Templatable object without its generic type. Attempt to use Templatable as root object?");
-    final JavaType wrapperType = property.getType();
-    final JavaType valueType = wrapperType.containedType(0);
     final ApiTemplatableDeserializer deserializer = new ApiTemplatableDeserializer();
-    deserializer.valueType = valueType;
+    final JavaType wrapperType = property.getType();
+    if (wrapperType.getRawClass() == TemplatableMap.class) {
+      deserializer.valueType = SimpleType.constructUnsafe(Object.class);
+    } else {
+      deserializer.valueType = wrapperType.containedType(0);
+    }
+
     return deserializer;
   }
 

--- a/thirdeye-spi/src/test/java/ai/startree/thirdeye/spi/api/PlanNodeApiTest.java
+++ b/thirdeye-spi/src/test/java/ai/startree/thirdeye/spi/api/PlanNodeApiTest.java
@@ -13,7 +13,7 @@
  */
 package ai.startree.thirdeye.spi.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import ai.startree.thirdeye.spi.json.ThirdEyeSerialization;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
@@ -26,7 +26,7 @@ public class PlanNodeApiTest {
   @Test
   public void testInputNode() throws IOException {
     URL resource = PlanNodeApiTest.class.getClassLoader().getResource("inputNode.json");
-    final PlanNodeApi inputNode = new ObjectMapper().readValue(
+    final PlanNodeApi inputNode = ThirdEyeSerialization.newObjectMapper().readValue(
         Resources.toString(resource, StandardCharsets.UTF_8),
         PlanNodeApi.class);
     Assert.assertEquals(inputNode.getName(), "baselineDataFetcher");
@@ -40,7 +40,7 @@ public class PlanNodeApiTest {
   @Test
   public void testDetectionNode() throws IOException {
     URL resource = PlanNodeApiTest.class.getClassLoader().getResource("detectionNode.json");
-    final PlanNodeApi inputNode = new ObjectMapper().readValue(Resources.toString(resource,
+    final PlanNodeApi inputNode = ThirdEyeSerialization.newObjectMapper().readValue(Resources.toString(resource,
         StandardCharsets.UTF_8),
         PlanNodeApi.class);
     Assert.assertEquals(inputNode.getName(), "percentageChangeDetector");

--- a/thirdeye-spi/src/test/java/ai/startree/thirdeye/spi/api/PlanNodeApiTest.java
+++ b/thirdeye-spi/src/test/java/ai/startree/thirdeye/spi/api/PlanNodeApiTest.java
@@ -13,11 +13,14 @@
  */
 package ai.startree.thirdeye.spi.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import ai.startree.thirdeye.spi.json.ThirdEyeSerialization;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -46,6 +49,12 @@ public class PlanNodeApiTest {
     Assert.assertEquals(inputNode.getName(), "percentageChangeDetector");
     Assert.assertEquals(inputNode.getType(), "AnomalyDetector");
     Assert.assertEquals(inputNode.getParams().size(), 6);
+    // parsing templatable with a templated value
+    assertThat(inputNode.getParams().get("metric").templatedValue()).isEqualTo("${metricName}");
+    // parsing templatable with an object value
+    assertThat(inputNode.getParams().get("dimensions").value()).isEqualTo(List.of());
+    // parsing templatable with a string value
+    assertThat(inputNode.getParams().get("detectorName").value()).isEqualTo("PERCENTAGE_CHANGE");
     Assert.assertEquals(inputNode.getInputs().size(), 2);
     Assert.assertEquals(inputNode.getInputs().get(0).getTargetProperty(), "baseline");
     Assert.assertEquals(inputNode.getInputs().get(0).getSourcePlanNode(), "baselineDataFetcher");


### PR DESCRIPTION
params was `Map<String, Object>`
to allow it to be templatable, `Map<String, Templatable<Object>>` is necessary. 

Using a `Map<String, Templatable<Object>>` required changes in many places and was making code hard to read, so a 
`TemplatableMap<String, Object> extends HashMap<String, Templatable<Object>>` is introduced. 
It makes it simpler to manipulate the map of templatable objects.


Main changes: 
- [TemplatableMap](https://github.com/startreedata/thirdeye/pull/631/files#diff-00a9f19cf03ecdd44ca466cde6fbd6046b1c4a59abb6b6d138fe3745c4ac370c)
- PlanNodeBean and PlanNodeApi


TODO: 
- [ ] do changes in startree-thirdeye