### PR TITLE
chore(ui): append content hash to production build filenames

### DIFF
--- a/thirdeye-ui/webpack.config.prod.js
+++ b/thirdeye-ui/webpack.config.prod.js
@@ -32,7 +32,7 @@ module.exports = {
     output: {
         path: outputPath,
         filename: "thirdeye-ui.js",
-        chunkFilename: "[name].js",
+        chunkFilename: "[name].[contenthash].js",
         publicPath: "/", // Ensures bundle is served from absolute path as opposed to relative
     },
 


### PR DESCRIPTION
Add content hash to the file names in production build to bust caching for new deployments