### PR TITLE
refactor(ui): use common grid configuration for form section for alert creation

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-details.component.tsx
@@ -22,6 +22,7 @@ import {
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PageContentsCardV1 } from "../../../platform/components";
+import { InputSection } from "../../form-basics/input-section/input-section.component";
 import { useAlertWizardV2Styles } from "../alert-wizard-v2.styles";
 import { AlertDetailsProps } from "./alert-details.interfaces";
 import { AlertFrequency } from "./alert-frequency/alert-frequency.component";
@@ -64,8 +65,25 @@ function AlertDetails({
                     </Box>
                 </Grid>
 
-                <Grid container item xs={12}>
-                    <Grid item lg={2} md={4} sm={12} xs={12}>
+                <InputSection
+                    inputComponent={
+                        <>
+                            <TextField
+                                fullWidth
+                                data-testid="name-input-container"
+                                error={nameHasError}
+                                value={name}
+                                variant="outlined"
+                                onChange={handleNameChange}
+                            />
+                            {nameHasError && (
+                                <FormHelperText error>
+                                    {t("message.please-enter-valid-name")}
+                                </FormHelperText>
+                            )}
+                        </>
+                    }
+                    labelComponent={
                         <InputLabel
                             shrink
                             className={classes.label}
@@ -74,39 +92,16 @@ function AlertDetails({
                         >
                             {t("label.name-of-your-alert")}
                         </InputLabel>
-                    </Grid>
-                    <Grid item lg={3} md={5} sm={12} xs={12}>
-                        <TextField
-                            fullWidth
-                            data-testid="name-input-container"
-                            error={nameHasError}
-                            value={name}
-                            variant="outlined"
-                            onChange={handleNameChange}
-                        />
-                        {nameHasError && (
-                            <FormHelperText error>
-                                {t("message.please-enter-valid-name")}
-                            </FormHelperText>
-                        )}
-                    </Grid>
-                </Grid>
+                    }
+                />
 
-                <Grid container item xs={12}>
-                    <Grid item lg={2} md={4} sm={12} xs={12}>
-                        <Typography variant="body2">
-                            {t("label.description")}
-                        </Typography>
-
-                        <Typography variant="caption">
-                            ({t("label.optional")})
-                        </Typography>
-                    </Grid>
-                    <Grid item lg={3} md={5} sm={12} xs={12}>
+                <InputSection
+                    helperLabel={t("label.optional")}
+                    inputComponent={
                         <TextField
                             fullWidth
                             multiline
-                            rows={6}
+                            minRows={6}
                             value={description}
                             variant="outlined"
                             onChange={(
@@ -120,8 +115,9 @@ function AlertDetails({
                                 });
                             }}
                         />
-                    </Grid>
-                </Grid>
+                    }
+                    label={t("label.description")}
+                />
 
                 <AlertFrequency
                     alert={alert}

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-details/alert-frequency/alert-date-time-cron-advance/alert-date-time-cron-advance.component.tsx
@@ -13,7 +13,6 @@
  */
 import {
     FormHelperText,
-    Grid,
     InputLabel,
     Link,
     TextField,
@@ -23,6 +22,7 @@ import CronValidator from "cron-expression-validator";
 import cronstrue from "cronstrue";
 import React, { FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { InputSection } from "../../../../form-basics/input-section/input-section.component";
 import { useAlertWizardV2Styles } from "../../../alert-wizard-v2.styles";
 import { AlertDateTimeCronAdvanceProps } from "./alert-date-time-cron-advance.interfaces";
 
@@ -40,63 +40,67 @@ export const AlertDateTimeCronAdvance: FunctionComponent<
     };
 
     return (
-        <Grid container item xs={12}>
-            <Grid item lg={2} md={4} sm={12} xs={12}>
-                <InputLabel
-                    shrink
-                    className={classes.label}
-                    data-testid="cron-input-label"
-                    error={!isCronValid}
-                >
-                    {t("label.cron")}
-                </InputLabel>
-                <Typography variant="caption">
-                    <Link
-                        href="http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html"
-                        target="_blank"
-                    >
-                        {t("label.documentation")}
-                    </Link>
-                </Typography>
-            </Grid>
-            <Grid item lg={3} md={5} sm={12} xs={12}>
-                <TextField
-                    fullWidth
-                    data-testid="cron-input"
-                    error={!isCronValid}
-                    value={currentCron}
-                    variant="outlined"
-                    onChange={(e) =>
-                        handleCronInputChange(e.currentTarget.value)
-                    }
-                />
+        <InputSection
+            inputComponent={
+                <>
+                    <TextField
+                        fullWidth
+                        data-testid="cron-input"
+                        error={!isCronValid}
+                        value={currentCron}
+                        variant="outlined"
+                        onChange={(e) =>
+                            handleCronInputChange(e.currentTarget.value)
+                        }
+                    />
 
-                {isCronValid && (
-                    <FormHelperText className={classes.label}>
-                        {cronstrue.toString(currentCron, {
-                            verbose: true,
-                        })}
-                    </FormHelperText>
-                )}
+                    {isCronValid && (
+                        <FormHelperText className={classes.label}>
+                            {cronstrue.toString(currentCron, {
+                                verbose: true,
+                            })}
+                        </FormHelperText>
+                    )}
 
-                {/* If there are errors, render them */}
-                {!isCronValid && (
-                    <FormHelperText
-                        error
+                    {/* If there are errors, render them */}
+                    {!isCronValid && (
+                        <FormHelperText
+                            error
+                            className={classes.label}
+                            data-testid="error-message-container"
+                        >
+                            {t("message.invalid-cron-input-1")}
+                            <Link
+                                href="http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html"
+                                target="_blank"
+                            >
+                                {t("label.cron-documentation")}
+                            </Link>
+                            {t("message.invalid-cron-input-2")}
+                        </FormHelperText>
+                    )}
+                </>
+            }
+            labelComponent={
+                <>
+                    <InputLabel
+                        shrink
                         className={classes.label}
-                        data-testid="error-message-container"
+                        data-testid="cron-input-label"
+                        error={!isCronValid}
                     >
-                        {t("message.invalid-cron-input-1")}
+                        {t("label.cron")}
+                    </InputLabel>
+                    <Typography variant="caption">
                         <Link
                             href="http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html"
                             target="_blank"
                         >
-                            {t("label.cron-documentation")}
+                            {t("label.documentation")}
                         </Link>
-                        {t("message.invalid-cron-input-2")}
-                    </FormHelperText>
-                )}
-            </Grid>
-        </Grid>
+                    </Typography>
+                </>
+            }
+        />
     );
 };

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-properties-builder.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-properties-builder.component.tsx
@@ -33,6 +33,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { getAlertTemplatesUpdatePath } from "../../../../utils/routes/routes.util";
+import { InputSection } from "../../../form-basics/input-section/input-section.component";
 import { useAlertWizardV2Styles } from "../../alert-wizard-v2.styles";
 import { setUpFieldInputRenderConfig } from "../alert-template.utils";
 import {
@@ -118,13 +119,8 @@ export const AlertTemplatePropertiesBuilder: FunctionComponent<
             </Grid>
             {requiredKeys.map((item, idx) => {
                 return (
-                    <Grid container item key={item.key} xs={12}>
-                        <Grid item lg={2} md={4} xs={12}>
-                            <Box paddingBottom={1} paddingTop={1}>
-                                <label>{item.key}</label>
-                            </Box>
-                        </Grid>
-                        <Grid item lg={3} md={5} xs={12}>
+                    <InputSection
+                        inputComponent={
                             <TextField
                                 fullWidth
                                 data-testid={`textfield-${item.key}`}
@@ -140,8 +136,14 @@ export const AlertTemplatePropertiesBuilder: FunctionComponent<
                                     );
                                 }}
                             />
-                        </Grid>
-                    </Grid>
+                        }
+                        key={item.key}
+                        labelComponent={
+                            <Box paddingBottom={1} paddingTop={1}>
+                                <label>{item.key}</label>
+                            </Box>
+                        }
+                    />
                 );
             })}
             {!showMore && optionalKeys.length > 0 && (
@@ -183,13 +185,8 @@ export const AlertTemplatePropertiesBuilder: FunctionComponent<
                     </Grid>
                     {optionalKeys.map((item, idx) => {
                         return (
-                            <Grid container item key={item.key} xs={12}>
-                                <Grid item lg={2} md={4} xs={12}>
-                                    <Box paddingBottom={1} paddingTop={1}>
-                                        <label>{item.key}</label>
-                                    </Box>
-                                </Grid>
-                                <Grid item lg={3} md={5} xs={12}>
+                            <InputSection
+                                inputComponent={
                                     <TextField
                                         fullWidth
                                         data-testid={`textfield-${item.key}`}
@@ -206,8 +203,14 @@ export const AlertTemplatePropertiesBuilder: FunctionComponent<
                                             )
                                         }
                                     />
-                                </Grid>
-                            </Grid>
+                                }
+                                key={item.key}
+                                labelComponent={
+                                    <Box paddingBottom={1} paddingTop={1}>
+                                        <label>{item.key}</label>
+                                    </Box>
+                                }
+                            />
                         );
                     })}
                 </>

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template.component.tsx
@@ -26,6 +26,7 @@ import { PageContentsCardV1 } from "../../../platform/components";
 import { AlertTemplate as AlertTemplateType } from "../../../rest/dto/alert-template.interfaces";
 import { TemplatePropertiesObject } from "../../../rest/dto/alert.interfaces";
 import { getAlertTemplatesCreatePath } from "../../../utils/routes/routes.util";
+import { InputSection } from "../../form-basics/input-section/input-section.component";
 import { useAlertWizardV2Styles } from "../alert-wizard-v2.styles";
 import { AlertTemplatePropertiesBuilder } from "./alert-template-properties-builder/alert-template-properties-builder.component";
 import { AlertTemplateProps } from "./alert-template.interfaces";
@@ -168,54 +169,49 @@ function AlertTemplate({
                     </Box>
                 </Grid>
 
-                <Grid item xs={12}>
-                    <Grid container>
-                        <Grid item lg={2} md={4} sm={12} xs={12}>
-                            <InputLabel
-                                shrink
-                                className={classes.label}
-                                data-testid="template-type-input-label"
-                            >
-                                {t("label.template-type")}
-                            </InputLabel>
-                        </Grid>
-                        <Grid item lg={3} md={5} sm={12} xs={12}>
-                            <Autocomplete<AlertTemplateType>
-                                fullWidth
-                                getOptionLabel={(option) =>
-                                    option.name as string
+                <InputSection
+                    inputComponent={
+                        <Autocomplete<AlertTemplateType>
+                            fullWidth
+                            getOptionLabel={(option) => option.name as string}
+                            noOptionsText={t(
+                                "message.no-filter-options-available-entity",
+                                {
+                                    entity: t("label.alert-template"),
                                 }
-                                noOptionsText={t(
-                                    "message.no-filter-options-available-entity",
-                                    {
-                                        entity: t("label.alert-template"),
-                                    }
-                                )}
-                                options={alertTemplateOptions}
-                                renderInput={(params) => (
-                                    <TextField
-                                        {...params}
-                                        InputProps={{
-                                            ...params.InputProps,
-                                            // Override class name so the size of input is smaller
-                                            className:
-                                                classes.autoCompleteInput,
-                                        }}
-                                        placeholder={t(
-                                            "message.click-here-to-select-alert-template"
-                                        )}
-                                        variant="outlined"
-                                    />
-                                )}
-                                renderOption={renderAlertTemplateSelectOption}
-                                value={selectedAlertTemplate}
-                                onChange={(_, selectedValue) => {
-                                    handleAlertTemplateChange(selectedValue);
-                                }}
-                            />
-                        </Grid>
-                    </Grid>
-                </Grid>
+                            )}
+                            options={alertTemplateOptions}
+                            renderInput={(params) => (
+                                <TextField
+                                    {...params}
+                                    InputProps={{
+                                        ...params.InputProps,
+                                        // Override class name so the size of input is smaller
+                                        className: classes.autoCompleteInput,
+                                    }}
+                                    placeholder={t(
+                                        "message.click-here-to-select-alert-template"
+                                    )}
+                                    variant="outlined"
+                                />
+                            )}
+                            renderOption={renderAlertTemplateSelectOption}
+                            value={selectedAlertTemplate}
+                            onChange={(_, selectedValue) => {
+                                handleAlertTemplateChange(selectedValue);
+                            }}
+                        />
+                    }
+                    labelComponent={
+                        <InputLabel
+                            shrink
+                            className={classes.label}
+                            data-testid="template-type-input-label"
+                        >
+                            {t("label.template-type")}
+                        </InputLabel>
+                    }
+                />
 
                 {selectedAlertTemplate && (
                     <AlertTemplatePropertiesBuilder

--- a/thirdeye-ui/src/app/components/form-basics/input-section/input-section.component.tsx
+++ b/thirdeye-ui/src/app/components/form-basics/input-section/input-section.component.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { Grid, Typography } from "@material-ui/core";
+import React, { FunctionComponent } from "react";
+import { InputSectionProps } from "./input-section.interfaces";
+
+export const InputSection: FunctionComponent<InputSectionProps> = ({
+    label,
+    helperLabel,
+    labelComponent,
+    inputComponent,
+}) => {
+    return (
+        <Grid container item xs={12}>
+            <Grid item lg={2} md={4} sm={12} xs={12}>
+                {!!labelComponent && labelComponent}
+                {!labelComponent && label && (
+                    <>
+                        <Typography variant="body2">{label}</Typography>
+                        {helperLabel && (
+                            <Typography variant="caption">
+                                {helperLabel}
+                            </Typography>
+                        )}
+                    </>
+                )}
+            </Grid>
+            <Grid item lg={3} md={5} sm={12} xs={12}>
+                {inputComponent}
+            </Grid>
+        </Grid>
+    );
+};

--- a/thirdeye-ui/src/app/components/form-basics/input-section/input-section.interfaces.ts
+++ b/thirdeye-ui/src/app/components/form-basics/input-section/input-section.interfaces.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { ReactElement } from "react";
+
+export interface InputSectionProps {
+    label?: string;
+    helperLabel?: string;
+    labelComponent?: ReactElement;
+    inputComponent: ReactElement;
+}

--- a/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
@@ -355,28 +355,29 @@ export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
                         alertTemplateOptions,
                     ]}
                 />
-                <Box textAlign="right" width="100%">
-                    <PageContentsCardV1>
-                        <Button
-                            className={classes.footerBtn}
-                            color="secondary"
-                            onClick={handlePageExitChecks}
-                        >
-                            {t("label.cancel")}
-                        </Button>
-                        <Button
-                            className={classes.footerBtn}
-                            color="primary"
-                            disabled={!isAlertValid}
-                            onClick={handleCreateAlertClick}
-                        >
-                            {t("label.create-entity", {
-                                entity: t("label.alert"),
-                            })}
-                        </Button>
-                    </PageContentsCardV1>
-                </Box>
             </PageContentsGridV1>
+
+            <Box textAlign="right" width="100%">
+                <PageContentsCardV1>
+                    <Button
+                        className={classes.footerBtn}
+                        color="secondary"
+                        onClick={handlePageExitChecks}
+                    >
+                        {t("label.cancel")}
+                    </Button>
+                    <Button
+                        className={classes.footerBtn}
+                        color="primary"
+                        disabled={!isAlertValid}
+                        onClick={handleCreateAlertClick}
+                    >
+                        {t("label.create-entity", {
+                            entity: t("label.alert"),
+                        })}
+                    </Button>
+                </PageContentsCardV1>
+            </Box>
         </PageV1>
     );
 };


### PR DESCRIPTION
Refactoring Alert Wizard to use newly created `InputSection` component which abstracts away the Grid configuration that is commonly used in Edwin's design for all of his form input

![image](https://user-images.githubusercontent.com/2080348/185471269-2f0014e8-14c1-4e75-a784-ae0ed0b70674.png)
