### PR TITLE
fix(ui): maintain enabaled and disabled items when zoom changes

### DIFF
--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
@@ -49,7 +49,10 @@ import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.compo
 import { TimeRangeButtonWithContext } from "../../time-range/time-range-button-with-context/time-range-button.component";
 import { TimeRangeQueryStringKey } from "../../time-range/time-range-provider/time-range-provider.interfaces";
 import { TimeSeriesChart } from "../../visualizations/time-series-chart/time-series-chart.component";
-import { ZoomDomain } from "../../visualizations/time-series-chart/time-series-chart.interfaces";
+import {
+    TimeSeriesChartProps,
+    ZoomDomain,
+} from "../../visualizations/time-series-chart/time-series-chart.interfaces";
 import { AnomalyTimeSeriesCardProps } from "./anomaly-time-series-card.interfaces";
 import {
     determineInitialZoom,
@@ -79,6 +82,8 @@ export const AnomalyTimeSeriesCard: FunctionComponent<
     const [searchParams, setSearchParams] = useSearchParams();
     const { t } = useTranslation();
     const { notify } = useNotificationProviderV1();
+    const [timeSeriesOptions, setTimeSeriesOptions] =
+        useState<TimeSeriesChartProps>();
 
     const {
         getEvaluation,
@@ -169,6 +174,19 @@ export const AnomalyTimeSeriesCard: FunctionComponent<
                   );
         }
     }, [errorMessages, getEvaluationRequestStatus]);
+
+    useEffect(() => {
+        if (alertEvaluation && anomaly) {
+            setTimeSeriesOptions(
+                generateChartOptions(
+                    alertEvaluation,
+                    anomaly,
+                    filteredAlertEvaluation,
+                    t
+                )
+            );
+        }
+    }, [alertEvaluation, anomaly, filteredAlertEvaluation]);
 
     const handleChartHeightChange = (height: number): void => {
         setChartHeight(height);
@@ -287,17 +305,12 @@ export const AnomalyTimeSeriesCard: FunctionComponent<
             )}
             {anomaly &&
                 getEvaluationRequestStatus === ActionStatus.Done &&
-                alertEvaluation !== null && (
+                timeSeriesOptions && (
                     <CardContent>
                         <TimeSeriesChart
                             events={events}
                             height={chartHeight}
-                            {...generateChartOptions(
-                                alertEvaluation,
-                                anomaly,
-                                filteredAlertEvaluation,
-                                t
-                            )}
+                            {...timeSeriesOptions}
                             LegendComponent={(props) => (
                                 <RCAChartLegend
                                     {...props}

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -118,7 +118,6 @@ export const TimeSeriesChartInternal: FunctionComponent<
     events,
     LegendComponent = Legend,
 }) => {
-    const [instanceId] = useState(Math.random());
     const [currentZoom, setCurrentZoom] = useState<ZoomDomain | undefined>(
         initialZoom
     );
@@ -199,7 +198,6 @@ export const TimeSeriesChartInternal: FunctionComponent<
 
     // If series changed, reset everything
     useEffect(() => {
-        console.log(instanceId, "Series changed");
         setProcessedMainChartSeries(normalizeSeries(series, currentZoom));
         setProcessedBrushChartSeries(normalizeSeries(series));
         setEnabledDisabledSeriesMapping(series.map(syncEnabledDisabled));
@@ -241,7 +239,6 @@ export const TimeSeriesChartInternal: FunctionComponent<
     };
 
     const handleBrushChange = (domain: ZoomDomain | null): void => {
-        console.log(instanceId, "handleBrushChange");
         if (!domain) {
             return;
         }
@@ -267,7 +264,6 @@ export const TimeSeriesChartInternal: FunctionComponent<
     };
 
     const handleBrushClick = (): void => {
-        console.log(instanceId, "handleBrushClick");
         const seriesDataCopy = series.map((seriesData, idx) => {
             const copied = { ...seriesData };
             copied.enabled = enabledDisabledSeriesMapping[idx];

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -118,6 +118,7 @@ export const TimeSeriesChartInternal: FunctionComponent<
     events,
     LegendComponent = Legend,
 }) => {
+    const [instanceId] = useState(Math.random());
     const [currentZoom, setCurrentZoom] = useState<ZoomDomain | undefined>(
         initialZoom
     );
@@ -198,6 +199,7 @@ export const TimeSeriesChartInternal: FunctionComponent<
 
     // If series changed, reset everything
     useEffect(() => {
+        console.log(instanceId, "Series changed");
         setProcessedMainChartSeries(normalizeSeries(series, currentZoom));
         setProcessedBrushChartSeries(normalizeSeries(series));
         setEnabledDisabledSeriesMapping(series.map(syncEnabledDisabled));
@@ -239,6 +241,7 @@ export const TimeSeriesChartInternal: FunctionComponent<
     };
 
     const handleBrushChange = (domain: ZoomDomain | null): void => {
+        console.log(instanceId, "handleBrushChange");
         if (!domain) {
             return;
         }
@@ -264,6 +267,7 @@ export const TimeSeriesChartInternal: FunctionComponent<
     };
 
     const handleBrushClick = (): void => {
+        console.log(instanceId, "handleBrushClick");
         const seriesDataCopy = series.map((seriesData, idx) => {
             const copied = { ...seriesData };
             copied.enabled = enabledDisabledSeriesMapping[idx];


### PR DESCRIPTION
fixing bug where changing the zoom would cause the enabled disabled series to reset to default