### PR TITLE
feat(ui): improve customization api for time series chart tooltip

### DIFF
--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -444,7 +444,7 @@ export const TimeSeriesChartInternal: FunctionComponent<
                 />
             )}
 
-            {currentZoom && (
+            {isZoomEnabled && currentZoom && (
                 <Box
                     position="absolute"
                     right={CHART_MARGINS.right + 10}

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.interfaces.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.interfaces.ts
@@ -21,16 +21,19 @@ export enum SeriesType {
     AREA_CLOSED = "areaclosed",
     CUSTOM = "custom",
 }
-export interface DataPoint {
+export interface DataPoint<ExtraData = unknown> {
     x: number;
     y: number;
+    extraData?: ExtraData;
 }
 
-export interface ThresholdDataPoint extends DataPoint {
+export interface ThresholdDataPoint<ExtraData = unknown>
+    extends DataPoint<ExtraData> {
     y1: number; // y1 is used in Threshold shapes
 }
 
-export interface LineDataPoint extends ThresholdDataPoint {
+export interface LineDataPoint<ExtraData = unknown>
+    extends ThresholdDataPoint<ExtraData> {
     x1: number; // x1 is used in Line only shapes
 }
 
@@ -45,15 +48,17 @@ export interface Series {
     xAccessor?: (d: DataPoint | ThresholdDataPoint) => Date;
     x1Accessor?: (d: LineDataPoint) => Date;
     yAccessor?: (d: DataPoint | ThresholdDataPoint) => number;
-    tooltipValueFormatter?: (
-        value: number,
-        d: DataPoint | ThresholdDataPoint | LineDataPoint,
-        series: NormalizedSeries
-    ) => string;
-    tooltipFormatter?: (
-        d: DataPoint | ThresholdDataPoint | LineDataPoint,
-        series: NormalizedSeries
-    ) => string;
+    tooltip?: {
+        valueFormatter?: (value: number) => string;
+        pointFormatter?: (
+            d: DataPoint | ThresholdDataPoint | LineDataPoint,
+            series: NormalizedSeries
+        ) => React.ReactElement | string;
+        tooltipFormatter?: (
+            d: DataPoint | ThresholdDataPoint | LineDataPoint,
+            series: NormalizedSeries
+        ) => React.ReactElement | string;
+    };
     strokeDasharray?: string;
     /** Fields specific to areaclosed */
     // See https://airbnb.io/visx/docs/gradient#LinearGradient
@@ -78,15 +83,17 @@ export interface NormalizedSeries {
     xAccessor: (d: DataPoint | ThresholdDataPoint) => Date;
     x1Accessor: (d: LineDataPoint) => Date;
     yAccessor: (d: DataPoint | ThresholdDataPoint) => number;
-    tooltipValueFormatter: (
-        value: number,
-        d: DataPoint | ThresholdDataPoint | LineDataPoint,
-        series: NormalizedSeries
-    ) => string;
-    tooltipFormatter?: (
-        d: DataPoint | ThresholdDataPoint | LineDataPoint,
-        series: NormalizedSeries
-    ) => string;
+    tooltip: {
+        valueFormatter: (value: number) => string;
+        pointFormatter: (
+            d: DataPoint | ThresholdDataPoint | LineDataPoint,
+            series: NormalizedSeries
+        ) => React.ReactElement | string;
+        tooltipFormatter?: (
+            d: DataPoint | ThresholdDataPoint | LineDataPoint,
+            series: NormalizedSeries
+        ) => React.ReactElement | string;
+    };
     strokeDasharray?: string;
     /** Fields specific to areaclosed */
     // See https://airbnb.io/visx/docs/gradient#LinearGradient

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.test.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.test.ts
@@ -13,7 +13,9 @@
  */
 import { SeriesType } from "./time-series-chart.interfaces";
 import {
-    defaultTooltipValueFormatter,
+    defaultAreaSeriesPointFormatter,
+    defaultPointFormatter,
+    defaultValueFormatter,
     defaultX1Accessor,
     defaultXAccessor,
     defaultY1Accessor,
@@ -103,7 +105,10 @@ describe("Time Series Chart Utils", () => {
             yAccessor: defaultYAccessor,
             y1Accessor: defaultY1Accessor,
             strokeWidth: 1,
-            tooltipValueFormatter: defaultTooltipValueFormatter,
+            tooltip: {
+                pointFormatter: defaultAreaSeriesPointFormatter,
+                valueFormatter: defaultValueFormatter,
+            },
             fillOpacity: 1,
             stroke: undefined,
             color: "#FFF",
@@ -118,7 +123,10 @@ describe("Time Series Chart Utils", () => {
             yAccessor: defaultYAccessor,
             y1Accessor: defaultY1Accessor,
             strokeWidth: 1,
-            tooltipValueFormatter: defaultTooltipValueFormatter,
+            tooltip: {
+                pointFormatter: defaultPointFormatter,
+                valueFormatter: defaultValueFormatter,
+            },
             fillOpacity: 1,
             stroke: undefined,
         });

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.utils.ts
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import React from "react";
 import {
     DataPoint,
     LineDataPoint,
@@ -114,10 +115,48 @@ export function normalizeSeries(
             x1Accessor: item.x1Accessor ?? defaultX1Accessor,
             yAccessor: item.yAccessor ?? defaultYAccessor,
             y1Accessor: item.y1Accessor ?? defaultY1Accessor,
-            tooltipValueFormatter:
-                item.tooltipValueFormatter ?? defaultTooltipValueFormatter,
+            ...generateDefaultSeriesTooltipConfiguration(item.tooltip, item),
         };
     });
+}
+
+function generateDefaultSeriesTooltipConfiguration(
+    tooltipConfiguration:
+        | {
+              valueFormatter?: (value: number) => string;
+              pointFormatter?: (
+                  d: DataPoint | ThresholdDataPoint | LineDataPoint,
+                  series: NormalizedSeries
+              ) => React.ReactElement | string;
+              tooltipFormatter?: (
+                  d: DataPoint | ThresholdDataPoint | LineDataPoint,
+                  series: NormalizedSeries
+              ) => React.ReactElement | string;
+          }
+        | undefined,
+    series: Series
+): Pick<NormalizedSeries, "tooltip"> {
+    if (tooltipConfiguration === undefined) {
+        return {
+            tooltip: {
+                valueFormatter: defaultValueFormatter,
+                pointFormatter:
+                    series.type === SeriesType.AREA_CLOSED
+                        ? defaultAreaSeriesPointFormatter
+                        : defaultPointFormatter,
+            },
+        };
+    }
+
+    return {
+        tooltip: {
+            ...tooltipConfiguration,
+            valueFormatter:
+                tooltipConfiguration.valueFormatter ?? defaultValueFormatter,
+            pointFormatter:
+                tooltipConfiguration.pointFormatter ?? defaultPointFormatter,
+        },
+    };
 }
 
 export const syncEnabledDisabled = (seriesData: Series): boolean => {
@@ -140,6 +179,24 @@ export const defaultY1Accessor = (d: ThresholdDataPoint): number => {
     return d.y1;
 };
 
-export const defaultTooltipValueFormatter = (value: number): string => {
+export const defaultValueFormatter = (value: number): string => {
     return value.toString();
+};
+
+export const defaultPointFormatter = (
+    dataPoint: DataPoint,
+    series: NormalizedSeries
+): string => {
+    return series.tooltip.valueFormatter(dataPoint.y);
+};
+
+export const defaultAreaSeriesPointFormatter = (
+    dataPoint: DataPoint,
+    series: NormalizedSeries
+): string => {
+    const d = dataPoint as ThresholdDataPoint;
+
+    return `${series.tooltip.valueFormatter(
+        d.y
+    )} - ${series.tooltip.valueFormatter(d.y1)}`;
 };

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-popover.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-popover.component.tsx
@@ -15,12 +15,7 @@ import { Grid, Typography } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
 import { formatDateAndTimeV1 } from "../../../../platform/utils";
 import { useAlertEvaluationTimeSeriesTooltipStyles } from "../../alert-evaluation-time-series/alert-evaluation-time-series-tooltip/alert-evaluation-time-series-tooltip.styles";
-import {
-    DataPoint,
-    NormalizedSeries,
-    SeriesType,
-    ThresholdDataPoint,
-} from "../time-series-chart.interfaces";
+import { DataPoint, NormalizedSeries } from "../time-series-chart.interfaces";
 import { TooltipPopoverProps } from "./tooltip.interfaces";
 import { useTooltipStyles } from "./tooltip.styles";
 import { getDataPointsInSeriesForXValue } from "./tooltip.utils";
@@ -67,46 +62,37 @@ export const TooltipPopover: FunctionComponent<TooltipPopoverProps> = ({
                                     ? colorScale(series.name as string)
                                     : series.color;
 
-                            let displayValue = series.tooltipValueFormatter(
-                                dataPoint.y,
-                                dataPoint,
-                                series
-                            );
-
-                            if (series.tooltipFormatter) {
-                                displayValue = series.tooltipFormatter(
-                                    dataPoint,
-                                    series
-                                );
-                            } else if (series.type === SeriesType.AREA_CLOSED) {
-                                displayValue = `${series.tooltipValueFormatter(
-                                    dataPoint.y,
-                                    dataPoint,
-                                    series
-                                )} - ${series.tooltipValueFormatter(
-                                    (dataPoint as ThresholdDataPoint).y1,
-                                    dataPoint,
-                                    series
-                                )}`;
-                            }
-
                             return (
-                                <tr key={series.name}>
-                                    <td
-                                        style={{
-                                            color,
-                                        }}
-                                    >
-                                        {series.name}
-                                    </td>
-                                    <td
-                                        className={
-                                            timeSeriesChartTooltipClasses.valueCell
-                                        }
-                                    >
-                                        {displayValue}
-                                    </td>
-                                </tr>
+                                <>
+                                    {series.tooltip.tooltipFormatter !==
+                                        undefined &&
+                                        series.tooltip.tooltipFormatter(
+                                            dataPoint,
+                                            series
+                                        )}
+                                    {series.tooltip.tooltipFormatter ===
+                                        undefined && (
+                                        <tr key={series.name}>
+                                            <td
+                                                style={{
+                                                    color,
+                                                }}
+                                            >
+                                                {series.name}
+                                            </td>
+                                            <td
+                                                className={
+                                                    timeSeriesChartTooltipClasses.valueCell
+                                                }
+                                            >
+                                                {series.tooltip.pointFormatter(
+                                                    dataPoint,
+                                                    series
+                                                )}
+                                            </td>
+                                        </tr>
+                                    )}
+                                </>
                             );
                         })}
                     </tbody>


### PR DESCRIPTION
Allows users of time series chart to customize the tooltip rendering even further but exposing a few functions in the new `tooltip` property of a `series` object. Default behavior is the same as before