### PR TITLE
refactor(ui): remove assumption of output_AnomalyDetectorResult_0 key

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
@@ -27,7 +27,10 @@ import {
 import { ActionStatus } from "../../../../rest/actions.interfaces";
 import { useGetEvaluation } from "../../../../rest/alerts/alerts.actions";
 import { AlertEvaluation } from "../../../../rest/dto/alert.interfaces";
-import { createAlertEvaluation } from "../../../../utils/alerts/alerts.util";
+import {
+    createAlertEvaluation,
+    extractDetectionEvaluation,
+} from "../../../../utils/alerts/alerts.util";
 import { generateChartOptionsForAlert } from "../../../rca/anomaly-time-series-card/anomaly-time-series-card.utils";
 import { TimeRangeButtonWithContext } from "../../../time-range/time-range-button-with-context/time-range-button.component";
 import { TimeRangeQueryStringKey } from "../../../time-range/time-range-provider/time-range-provider.interfaces";
@@ -89,8 +92,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
         if (currentAlertEvaluation) {
             const timeseriesConfiguration = generateChartOptionsForAlert(
                 currentAlertEvaluation,
-                currentAlertEvaluation.detectionEvaluations
-                    .output_AnomalyDetectorResult_0.anomalies,
+                extractDetectionEvaluation(currentAlertEvaluation)[0].anomalies,
                 t
             );
 

--- a/thirdeye-ui/src/app/components/anomaly-dimension-analysis/algorithm-table/algorithm-table.utils.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-dimension-analysis/algorithm-table/algorithm-table.utils.tsx
@@ -16,6 +16,7 @@ import React from "react";
 import { formatLargeNumberV1 } from "../../../platform/utils";
 import { AlertEvaluation } from "../../../rest/dto/alert.interfaces";
 import { AnomalyDimensionAnalysisMetricRow } from "../../../rest/dto/rca.interfaces";
+import { extractDetectionEvaluation } from "../../../utils/alerts/alerts.util";
 import { EMPTY_STRING_DISPLAY } from "../../../utils/anomalies/anomalies.util";
 import {
     baselineComparisonOffsetToHumanReadable,
@@ -85,8 +86,10 @@ export const generateComparisonChartOptions = (
     comparisonOffset: string,
     translation: (labelName: string) => string = (s) => s
 ): TimeSeriesChartProps => {
-    const filteredTimeSeriesData =
-        filtered.detectionEvaluations.output_AnomalyDetectorResult_0.data;
+    const filteredTimeSeriesData = extractDetectionEvaluation(filtered)[0].data;
+    const nonFilteredTimeSeriesData =
+        extractDetectionEvaluation(nonFiltered)[0].data;
+
     const series = [
         {
             enabled: false,
@@ -108,15 +111,12 @@ export const generateComparisonChartOptions = (
         },
         {
             name: translation("label.non-filtered"),
-            data: nonFiltered.detectionEvaluations.output_AnomalyDetectorResult_0.data.current.map(
-                (value, idx) => {
-                    return {
-                        y: value,
-                        x: nonFiltered.detectionEvaluations
-                            .output_AnomalyDetectorResult_0.data.timestamp[idx],
-                    };
-                }
-            ),
+            data: nonFilteredTimeSeriesData.current.map((value, idx) => {
+                return {
+                    y: value,
+                    x: nonFilteredTimeSeriesData.timestamp[idx],
+                };
+            }),
             enabled: false,
         },
         {
@@ -124,8 +124,7 @@ export const generateComparisonChartOptions = (
             data: filteredTimeSeriesData.current.map((value, idx) => {
                 return {
                     y: value,
-                    x: filtered.detectionEvaluations
-                        .output_AnomalyDetectorResult_0.data.timestamp[idx],
+                    x: filteredTimeSeriesData.timestamp[idx],
                 };
             }),
         },
@@ -134,8 +133,7 @@ export const generateComparisonChartOptions = (
             data: filteredTimeSeriesData.expected.map((value, idx) => {
                 return {
                     y: value,
-                    x: filtered.detectionEvaluations
-                        .output_AnomalyDetectorResult_0.data.timestamp[idx],
+                    x: filteredTimeSeriesData.timestamp[idx],
                 };
             }),
         },

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.utils.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.utils.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../../platform/utils";
 import { AlertEvaluation } from "../../../rest/dto/alert.interfaces";
 import { Anomaly } from "../../../rest/dto/anomaly.interfaces";
+import { extractDetectionEvaluation } from "../../../utils/alerts/alerts.util";
 import { Dimension } from "../../../utils/material-ui/dimension.util";
 import { Palette } from "../../../utils/material-ui/palette.util";
 import { concatKeyValueWithEqual } from "../../../utils/params/params.util";
@@ -54,8 +55,7 @@ export const generateSeriesDataForEvaluation = (
             const [filteredAlertEvaluation, filterOptions] =
                 alertEvalAndFilters;
             const filteredAlertEvaluationTimeSeriesData =
-                filteredAlertEvaluation.detectionEvaluations
-                    .output_AnomalyDetectorResult_0.data;
+                extractDetectionEvaluation(filteredAlertEvaluation)[0].data;
 
             return {
                 name: filterOptions.map(concatKeyValueWithEqual).join(" & "),
@@ -77,9 +77,7 @@ export const generateSeriesDataForEvaluation = (
         }
     );
 
-    const timeSeriesData =
-        alertEvaluation.detectionEvaluations.output_AnomalyDetectorResult_0
-            .data;
+    const timeSeriesData = extractDetectionEvaluation(alertEvaluation)[0].data;
 
     return [
         {
@@ -171,6 +169,9 @@ export const generateChartOptions = (
     let series: Series[] = [];
 
     if (alertEvaluation) {
+        const timeseriesData =
+            extractDetectionEvaluation(alertEvaluation)[0].data;
+
         series = generateSeriesDataForEvaluation(
             alertEvaluation,
             filteredAlertEvaluation,
@@ -180,10 +181,8 @@ export const generateChartOptions = (
             generateSeriesForAnomalies(
                 [anomaly],
                 translation,
-                alertEvaluation.detectionEvaluations
-                    .output_AnomalyDetectorResult_0.data.timestamp,
-                alertEvaluation.detectionEvaluations
-                    .output_AnomalyDetectorResult_0.data.current
+                timeseriesData.timestamp,
+                timeseriesData.current
             )
         );
     }
@@ -419,9 +418,7 @@ export const generateChartOptionsForAlert = (
     translation: (id: string) => string,
     navigate?: NavigateFunction
 ): TimeSeriesChartProps => {
-    const data =
-        alertEvaluation.detectionEvaluations.output_AnomalyDetectorResult_0
-            .data;
+    const data = extractDetectionEvaluation(alertEvaluation)[0].data;
     let series: Series[] = [];
 
     if (alertEvaluation !== null) {

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -46,6 +46,7 @@ import { UiAlert } from "../../rest/dto/ui-alert.interfaces";
 import { getAllSubscriptionGroups } from "../../rest/subscription-groups/subscription-groups.rest";
 import {
     createAlertEvaluation,
+    extractDetectionEvaluation,
     getUiAlert,
 } from "../../utils/alerts/alerts.util";
 import { PROMISES } from "../../utils/constants/constants.util";
@@ -87,8 +88,7 @@ export const AlertsViewPage: FunctionComponent = () => {
     useEffect(() => {
         if (evaluation) {
             if (anomalies) {
-                evaluation.detectionEvaluations.output_AnomalyDetectorResult_0.anomalies =
-                    anomalies;
+                extractDetectionEvaluation(evaluation)[0].anomalies = anomalies;
             }
             setAlertEvaluation(evaluation);
         }

--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
@@ -45,6 +45,7 @@ import { AlertEvaluation } from "../../rest/dto/alert.interfaces";
 import { Anomaly } from "../../rest/dto/anomaly.interfaces";
 import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
 import { useGetInvestigations } from "../../rest/rca/rca.actions";
+import { extractDetectionEvaluation } from "../../utils/alerts/alerts.util";
 import {
     createAlertEvaluation,
     getUiAnomaly,
@@ -106,7 +107,7 @@ export const AnomaliesViewPage: FunctionComponent = () => {
         }
         // Only filter for the current anomaly
         const anomalyDetectionResults =
-            evaluation.detectionEvaluations.output_AnomalyDetectorResult_0;
+            extractDetectionEvaluation(evaluation)[0];
         anomalyDetectionResults.anomalies = [anomaly];
         setAlertEvaluation(evaluation);
     }, [evaluation, anomaly]);

--- a/thirdeye-ui/src/app/rest/dto/detection.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/detection.interfaces.ts
@@ -14,9 +14,9 @@
 import { Anomaly } from "./anomaly.interfaces";
 
 export interface DetectionEvaluation {
-    mape: number;
     data: DetectionData;
     anomalies: Anomaly[];
+    enumerationItem?: EnumerationItem;
 }
 
 export interface DetectionData {
@@ -25,4 +25,11 @@ export interface DetectionData {
     expected: number[];
     upperBound: number[];
     lowerBound: number[];
+}
+
+export interface EnumerationItem {
+    name: string;
+    params: {
+        [key: string]: number | string;
+    };
 }

--- a/thirdeye-ui/src/app/utils/alerts/alerts.util.test.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts.util.test.ts
@@ -12,7 +12,12 @@
  * the License.
  */
 import { cloneDeep } from "lodash";
-import { Alert, AlertNodeType } from "../../rest/dto/alert.interfaces";
+import {
+    Alert,
+    AlertEvaluation,
+    AlertNodeType,
+} from "../../rest/dto/alert.interfaces";
+import { DetectionEvaluation } from "../../rest/dto/detection.interfaces";
 import { SubscriptionGroup } from "../../rest/dto/subscription-group.interfaces";
 import { UiAlert } from "../../rest/dto/ui-alert.interfaces";
 import {
@@ -21,6 +26,7 @@ import {
     createEmptyUiAlert,
     createEmptyUiAlertDatasetAndMetric,
     createEmptyUiAlertSubscriptionGroup,
+    extractDetectionEvaluation,
     filterAlerts,
     getUiAlert,
     getUiAlerts,
@@ -187,6 +193,12 @@ describe("Alerts Util", () => {
 
     it("omitNonUpdatableData should return appropriate alert for update alert", () => {
         expect(omitNonUpdatableData(mockAlert3)).toEqual({});
+    });
+
+    it("extractEvaluationData should return array of detection results", () => {
+        expect(extractDetectionEvaluation(mockAlertEvaluation)).toEqual(
+            mockDetectionEvaluations
+        );
     });
 });
 
@@ -411,3 +423,65 @@ const mockUiAlert3 = {
 const mockUiAlerts = [mockUiAlert1, mockUiAlert2, mockUiAlert3];
 
 const mockSearchWords = ["testNameMetric3", "testNameSubscriptionGroup11"];
+
+const mockDetectionEvaluations = [
+    {
+        data: {
+            timestamp: [1, 2, 3],
+            upperBound: [4, 5, 6],
+            lowerBound: [7, 8, 9],
+            current: [10, 11, 12],
+            expected: [13, 14, 15],
+        },
+        anomalies: [
+            {
+                startTime: 16,
+                endTime: 17,
+                avgCurrentVal: 18,
+                avgBaselineVal: 19,
+            },
+            {
+                startTime: 20,
+                endTime: 21,
+                avgCurrentVal: 22,
+                avgBaselineVal: 23,
+            },
+        ],
+    },
+    {
+        data: {
+            timestamp: [24],
+            upperBound: [25],
+            lowerBound: [26],
+            current: [27],
+            expected: [28],
+        },
+        anomalies: [
+            {
+                startTime: 29,
+                endTime: 30,
+                avgCurrentVal: 31,
+                avgBaselineVal: 32,
+            },
+            {
+                startTime: 33,
+                endTime: 34,
+                avgCurrentVal: 35,
+                avgBaselineVal: 36,
+            },
+        ],
+    },
+];
+
+const mockAlertEvaluation = {
+    alert: {} as Alert,
+    detectionEvaluations: {
+        detectionEvaluation1:
+            mockDetectionEvaluations[0] as DetectionEvaluation,
+        detectionEvaluation2:
+            mockDetectionEvaluations[1] as DetectionEvaluation,
+    },
+    start: 37,
+    end: 38,
+    lastTimestamp: 39,
+} as AlertEvaluation;

--- a/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
@@ -21,6 +21,7 @@ import {
     EditableAlert,
 } from "../../rest/dto/alert.interfaces";
 import { AnomalyFeedbackType } from "../../rest/dto/anomaly.interfaces";
+import { DetectionEvaluation } from "../../rest/dto/detection.interfaces";
 import { SubscriptionGroup } from "../../rest/dto/subscription-group.interfaces";
 import {
     UiAlert,
@@ -28,6 +29,11 @@ import {
     UiAlertSubscriptionGroup,
 } from "../../rest/dto/ui-alert.interfaces";
 import { deepSearchStringProperty } from "../search/search.util";
+
+export const DEFAULT_FEEDBACK = {
+    type: AnomalyFeedbackType.NO_FEEDBACK,
+    comment: "",
+};
 
 // fixme cyril update this template
 export const createDefaultAlert = (): EditableAlert => {
@@ -367,7 +373,10 @@ const mapSubscriptionGroupsToAlertIds = (
     return subscriptionGroupsToAlertIdsMap;
 };
 
-export const DEFAULT_FEEDBACK = {
-    type: AnomalyFeedbackType.NO_FEEDBACK,
-    comment: "",
+export const extractDetectionEvaluation = (
+    evaluationDataPayload: AlertEvaluation
+): DetectionEvaluation[] => {
+    return Object.keys(evaluationDataPayload.detectionEvaluations).map(
+        (k) => evaluationDataPayload.detectionEvaluations[k]
+    );
 };


### PR DESCRIPTION
With dimension exploration coming, we can no longer assume there will be just one detection result. This PR sets it up so we maintain current feature parity while opening for the possibility of using more than 1