### PR TITLE
feat(ui): update time selector component to min and max selectable dates

### DIFF
--- a/thirdeye-ui/src/app/components/time-range/time-range-button-with-context/time-range-button.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/time-range-button-with-context/time-range-button.component.tsx
@@ -24,7 +24,7 @@ import { TimeRangeButtonWithContextProps } from "./time-range-button.interfaces"
 
 export const TimeRangeButtonWithContext: FunctionComponent<
     TimeRangeButtonWithContextProps
-> = ({ onTimeRangeChange }) => {
+> = ({ onTimeRangeChange, maxDate, minDate }) => {
     const { recentCustomTimeRangeDurations, setTimeRangeDuration } =
         useTimeRange();
     const [searchParams, setSearchParams] = useSearchParams();
@@ -68,6 +68,8 @@ export const TimeRangeButtonWithContext: FunctionComponent<
 
     return (
         <TimeRangeButton
+            maxDate={maxDate}
+            minDate={minDate}
             recentCustomTimeRangeDurations={recentCustomTimeRangeDurations}
             timeRangeDuration={timeRangeDuration}
             onChange={onHandleTimeRangeChange}

--- a/thirdeye-ui/src/app/components/time-range/time-range-button-with-context/time-range-button.interfaces.ts
+++ b/thirdeye-ui/src/app/components/time-range/time-range-button-with-context/time-range-button.interfaces.ts
@@ -17,8 +17,12 @@ export interface TimeRangeButtonProps {
     timeRangeDuration: TimeRangeDuration;
     recentCustomTimeRangeDurations?: TimeRangeDuration[];
     onChange?: (timeRangeDuration: TimeRangeDuration) => void;
+    maxDate?: number;
+    minDate?: number;
 }
 
 export interface TimeRangeButtonWithContextProps {
     onTimeRangeChange?: (start: number, end: number) => void;
+    maxDate?: number;
+    minDate?: number;
 }

--- a/thirdeye-ui/src/app/components/time-range/time-range-button/time-range-button.interfaces.ts
+++ b/thirdeye-ui/src/app/components/time-range/time-range-button/time-range-button.interfaces.ts
@@ -17,4 +17,6 @@ export interface TimeRangeButtonProps {
     timeRangeDuration: TimeRangeDuration;
     recentCustomTimeRangeDurations?: TimeRangeDuration[];
     onChange?: (timeRangeDuration: TimeRangeDuration) => void;
+    maxDate?: number;
+    minDate?: number;
 }

--- a/thirdeye-ui/src/app/components/time-range/time-range-list/time-range-list.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/time-range-list/time-range-list.component.tsx
@@ -12,26 +12,52 @@
  * the License.
  */
 import { List, ListItem, ListItemText, ListSubheader } from "@material-ui/core";
-import { isEmpty } from "lodash";
+import { inRange, isEmpty } from "lodash";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { TooltipV1 } from "../../../platform/components";
 import {
     formatTimeRange,
     formatTimeRangeDuration,
+    getTimeRangeDuration,
 } from "../../../utils/time-range/time-range.util";
 import { TimeRange } from "../time-range-provider/time-range-provider.interfaces";
 import { TimeRangeListProps } from "./time-range-list.interfaces";
 
-export const TimeRangeList: FunctionComponent<TimeRangeListProps> = (
-    props: TimeRangeListProps
-) => {
+export const TimeRangeList: FunctionComponent<TimeRangeListProps> = ({
+    recentCustomTimeRangeDurations,
+    selectedTimeRange,
+    onClick,
+    maxDate,
+    minDate,
+}) => {
     const { t } = useTranslation();
+    let filteredRecentTimeRanges = recentCustomTimeRangeDurations || [];
+    const usedMaxDate = maxDate ?? Number.MAX_VALUE;
+    const usedMinDate = minDate ?? 0;
+
+    const filteredQuickSelections = Object.values(TimeRange)
+        .filter((timeRange) => typeof timeRange === "string")
+        .filter((timeRange) => {
+            const { startTime, endTime } = getTimeRangeDuration(timeRange);
+
+            return (
+                inRange(startTime, usedMinDate, usedMaxDate) &&
+                inRange(endTime, usedMinDate, usedMaxDate)
+            );
+        });
+
+    filteredRecentTimeRanges = filteredRecentTimeRanges.filter((item) => {
+        return (
+            inRange(item.startTime, usedMinDate, usedMaxDate) &&
+            inRange(item.endTime, usedMinDate, usedMaxDate)
+        );
+    });
 
     return (
         <List dense>
             {/* Recent custom time range durations label */}
-            {!isEmpty(props.recentCustomTimeRangeDurations) && (
+            {!isEmpty(recentCustomTimeRangeDurations) && (
                 <ListSubheader disableSticky>
                     <ListItemText
                         primary={t("label.recent-custom")}
@@ -44,74 +70,68 @@ export const TimeRangeList: FunctionComponent<TimeRangeListProps> = (
             )}
 
             {/* Recent custom time range durations */}
-            {props.recentCustomTimeRangeDurations &&
-                props.recentCustomTimeRangeDurations.map(
-                    (recentCustomTimeRangeDuration, index) => (
-                        <TooltipV1
-                            visible
-                            key={index}
-                            placement="right"
-                            title={formatTimeRangeDuration(
-                                recentCustomTimeRangeDuration
-                            )}
+            {filteredRecentTimeRanges.map(
+                (recentCustomTimeRangeDuration, index) => (
+                    <TooltipV1
+                        visible
+                        key={index}
+                        placement="right"
+                        title={formatTimeRangeDuration(
+                            recentCustomTimeRangeDuration
+                        )}
+                    >
+                        <ListItem
+                            button
+                            divider={
+                                index ===
+                                (recentCustomTimeRangeDurations &&
+                                    recentCustomTimeRangeDurations.length - 1)
+                            }
+                            onClick={() =>
+                                onClick &&
+                                onClick(recentCustomTimeRangeDuration)
+                            }
                         >
-                            <ListItem
-                                button
-                                divider={
-                                    index ===
-                                    (props.recentCustomTimeRangeDurations &&
-                                        props.recentCustomTimeRangeDurations
-                                            .length - 1)
-                                }
-                                onClick={() =>
-                                    props.onClick &&
-                                    props.onClick(recentCustomTimeRangeDuration)
-                                }
-                            >
-                                <ListItemText
-                                    primary={formatTimeRangeDuration(
-                                        recentCustomTimeRangeDuration
-                                    )}
-                                    primaryTypographyProps={{
-                                        variant: "button",
-                                        color: "primary",
-                                        noWrap: true,
-                                    }}
-                                />
-                            </ListItem>
-                        </TooltipV1>
-                    )
-                )}
+                            <ListItemText
+                                primary={formatTimeRangeDuration(
+                                    recentCustomTimeRangeDuration
+                                )}
+                                primaryTypographyProps={{
+                                    variant: "button",
+                                    color: "primary",
+                                    noWrap: true,
+                                }}
+                            />
+                        </ListItem>
+                    </TooltipV1>
+                )
+            )}
 
             {/* Time ranges */}
-            {Object.values(TimeRange)
-                .filter((timeRange) => typeof timeRange === "string")
-                .map((timeRange, index) => (
-                    <ListItem
-                        button
-                        divider={
-                            timeRange === TimeRange.CUSTOM ||
-                            timeRange === TimeRange.LAST_30_DAYS ||
-                            timeRange === TimeRange.YESTERDAY ||
-                            timeRange === TimeRange.LAST_WEEK ||
-                            timeRange === TimeRange.LAST_MONTH
-                        }
-                        key={index}
-                        selected={timeRange === props.selectedTimeRange}
-                        onClick={() =>
-                            props.onClick && props.onClick(timeRange)
-                        }
-                    >
-                        <ListItemText
-                            primary={formatTimeRange(timeRange)}
-                            primaryTypographyProps={{
-                                variant: "button",
-                                color: "primary",
-                                noWrap: true,
-                            }}
-                        />
-                    </ListItem>
-                ))}
+            {filteredQuickSelections.map((timeRange, index) => (
+                <ListItem
+                    button
+                    divider={
+                        timeRange === TimeRange.CUSTOM ||
+                        timeRange === TimeRange.LAST_30_DAYS ||
+                        timeRange === TimeRange.YESTERDAY ||
+                        timeRange === TimeRange.LAST_WEEK ||
+                        timeRange === TimeRange.LAST_MONTH
+                    }
+                    key={index}
+                    selected={timeRange === selectedTimeRange}
+                    onClick={() => onClick && onClick(timeRange)}
+                >
+                    <ListItemText
+                        primary={formatTimeRange(timeRange)}
+                        primaryTypographyProps={{
+                            variant: "button",
+                            color: "primary",
+                            noWrap: true,
+                        }}
+                    />
+                </ListItem>
+            ))}
         </List>
     );
 };

--- a/thirdeye-ui/src/app/components/time-range/time-range-list/time-range-list.interfaces.ts
+++ b/thirdeye-ui/src/app/components/time-range/time-range-list/time-range-list.interfaces.ts
@@ -20,4 +20,6 @@ export interface TimeRangeListProps {
     recentCustomTimeRangeDurations?: TimeRangeDuration[];
     selectedTimeRange?: TimeRange;
     onClick?: (eventObject: TimeRangeDuration | TimeRange) => void;
+    maxDate?: number;
+    minDate?: number;
 }

--- a/thirdeye-ui/src/app/components/time-range/time-range-select/time-range-select.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/time-range-select/time-range-select.component.tsx
@@ -19,20 +19,46 @@ import {
     MenuItem,
     Select,
 } from "@material-ui/core";
-import { isEmpty } from "lodash";
+import { inRange, isEmpty } from "lodash";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import {
     formatTimeRange,
     formatTimeRangeDuration,
+    getTimeRangeDuration,
 } from "../../../utils/time-range/time-range.util";
 import { TimeRange } from "../time-range-provider/time-range-provider.interfaces";
 import { TimeRangeSelectProps } from "./time-range-select.interfaces";
 
-export const TimeRangeSelect: FunctionComponent<TimeRangeSelectProps> = (
-    props: TimeRangeSelectProps
-) => {
+export const TimeRangeSelect: FunctionComponent<TimeRangeSelectProps> = ({
+    recentCustomTimeRangeDurations,
+    selectedTimeRange,
+    onChange,
+    maxDate,
+    minDate,
+}) => {
     const { t } = useTranslation();
+    let filteredRecentTimeRanges = recentCustomTimeRangeDurations || [];
+    const usedMaxDate = maxDate ?? Number.MAX_VALUE;
+    const usedMinDate = minDate ?? 0;
+
+    const filteredQuickSelections = Object.values(TimeRange)
+        .filter((timeRange) => typeof timeRange === "string")
+        .filter((timeRange) => {
+            const { startTime, endTime } = getTimeRangeDuration(timeRange);
+
+            return (
+                inRange(startTime, usedMinDate, usedMaxDate) &&
+                inRange(endTime, usedMinDate, usedMaxDate)
+            );
+        });
+
+    filteredRecentTimeRanges = filteredRecentTimeRanges.filter((item) => {
+        return (
+            inRange(item.startTime, usedMinDate, usedMaxDate) &&
+            inRange(item.endTime, usedMinDate, usedMaxDate)
+        );
+    });
 
     return (
         <FormControl fullWidth variant="outlined">
@@ -45,10 +71,10 @@ export const TimeRangeSelect: FunctionComponent<TimeRangeSelectProps> = (
             <Select
                 label={t("label.time-range")}
                 labelId="time-range-select-label"
-                value={props.selectedTimeRange}
+                value={selectedTimeRange}
             >
                 {/* Recent custom time range durations label */}
-                {!isEmpty(props.recentCustomTimeRangeDurations) && (
+                {!isEmpty(recentCustomTimeRangeDurations) && (
                     <ListSubheader disableSticky>
                         <ListItemText
                             primary={t("label.recent-custom")}
@@ -58,65 +84,57 @@ export const TimeRangeSelect: FunctionComponent<TimeRangeSelectProps> = (
                 )}
 
                 {/* Recent custom time range durations */}
-                {props.recentCustomTimeRangeDurations &&
-                    props.recentCustomTimeRangeDurations.map(
-                        (recentCustomTimeRangeDuration, index) => (
-                            <MenuItem
-                                divider={
-                                    index ===
-                                    (props.recentCustomTimeRangeDurations &&
-                                        props.recentCustomTimeRangeDurations
-                                            .length - 1)
-                                }
-                                key={index}
-                                onClick={() =>
-                                    props.onChange &&
-                                    props.onChange(
-                                        recentCustomTimeRangeDuration
-                                    )
-                                }
-                            >
-                                <ListItemText
-                                    primary={formatTimeRangeDuration(
-                                        recentCustomTimeRangeDuration
-                                    )}
-                                    primaryTypographyProps={{
-                                        variant: "button",
-                                        color: "primary",
-                                    }}
-                                />
-                            </MenuItem>
-                        )
-                    )}
-
-                {/* Time ranges */}
-                {Object.values(TimeRange)
-                    .filter((timeRange) => typeof timeRange === "string")
-                    .map((timeRange, index) => (
+                {filteredRecentTimeRanges.map(
+                    (recentCustomTimeRangeDuration, index) => (
                         <MenuItem
                             divider={
-                                timeRange === TimeRange.CUSTOM ||
-                                timeRange === TimeRange.LAST_30_DAYS ||
-                                timeRange === TimeRange.YESTERDAY ||
-                                timeRange === TimeRange.LAST_WEEK ||
-                                timeRange === TimeRange.LAST_MONTH
+                                index ===
+                                (recentCustomTimeRangeDurations &&
+                                    recentCustomTimeRangeDurations.length - 1)
                             }
                             key={index}
-                            selected={timeRange === props.selectedTimeRange}
-                            value={timeRange}
                             onClick={() =>
-                                props.onChange && props.onChange(timeRange)
+                                onChange &&
+                                onChange(recentCustomTimeRangeDuration)
                             }
                         >
                             <ListItemText
-                                primary={formatTimeRange(timeRange)}
+                                primary={formatTimeRangeDuration(
+                                    recentCustomTimeRangeDuration
+                                )}
                                 primaryTypographyProps={{
                                     variant: "button",
                                     color: "primary",
                                 }}
                             />
                         </MenuItem>
-                    ))}
+                    )
+                )}
+
+                {/* Time ranges */}
+                {filteredQuickSelections.map((timeRange, index) => (
+                    <MenuItem
+                        divider={
+                            timeRange === TimeRange.CUSTOM ||
+                            timeRange === TimeRange.LAST_30_DAYS ||
+                            timeRange === TimeRange.YESTERDAY ||
+                            timeRange === TimeRange.LAST_WEEK ||
+                            timeRange === TimeRange.LAST_MONTH
+                        }
+                        key={index}
+                        selected={timeRange === selectedTimeRange}
+                        value={timeRange}
+                        onClick={() => onChange && onChange(timeRange)}
+                    >
+                        <ListItemText
+                            primary={formatTimeRange(timeRange)}
+                            primaryTypographyProps={{
+                                variant: "button",
+                                color: "primary",
+                            }}
+                        />
+                    </MenuItem>
+                ))}
             </Select>
         </FormControl>
     );

--- a/thirdeye-ui/src/app/components/time-range/time-range-select/time-range-select.interfaces.ts
+++ b/thirdeye-ui/src/app/components/time-range/time-range-select/time-range-select.interfaces.ts
@@ -20,4 +20,6 @@ export interface TimeRangeSelectProps {
     recentCustomTimeRangeDurations?: TimeRangeDuration[];
     selectedTimeRange?: TimeRange;
     onChange?: (eventObject: TimeRangeDuration | TimeRange) => void;
+    maxDate?: number;
+    minDate?: number;
 }

--- a/thirdeye-ui/src/app/components/time-range/time-range-selector-popover-content/time-range-selector-popover-content.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/time-range-selector-popover-content/time-range-selector-popover-content.component.tsx
@@ -48,6 +48,8 @@ export const TimeRangeSelectorPopoverContent: FunctionComponent<
 > = ({
     timeRangeDuration,
     onClose,
+    minDate,
+    maxDate,
     ...props
 }: TimeRangeSelectorPopoverProps) => {
     const timeRangeSelectorPopoverClasses = useTimeRangeSelectorPopoverStyles();
@@ -188,6 +190,8 @@ export const TimeRangeSelectorPopoverContent: FunctionComponent<
                                 }
                             >
                                 <TimeRangeList
+                                    maxDate={maxDate}
+                                    minDate={minDate}
                                     recentCustomTimeRangeDurations={
                                         props.recentCustomTimeRangeDurations
                                     }
@@ -251,6 +255,16 @@ export const TimeRangeSelectorPopoverContent: FunctionComponent<
                                             ToolbarComponent={
                                                 DateTimePickerToolbar
                                             }
+                                            maxDate={
+                                                maxDate
+                                                    ? new Date(maxDate)
+                                                    : undefined
+                                            }
+                                            minDate={
+                                                minDate
+                                                    ? new Date(minDate)
+                                                    : undefined
+                                            }
                                             value={
                                                 new Date(
                                                     componentTimeRangeDuration.startTime
@@ -294,6 +308,11 @@ export const TimeRangeSelectorPopoverContent: FunctionComponent<
                                             hideTabs
                                             ToolbarComponent={
                                                 DateTimePickerToolbar
+                                            }
+                                            maxDate={
+                                                maxDate
+                                                    ? new Date(maxDate)
+                                                    : undefined
                                             }
                                             minDate={
                                                 new Date(

--- a/thirdeye-ui/src/app/components/time-range/time-range-selector-popover-content/time-range-selector-popover-content.interfaces.ts
+++ b/thirdeye-ui/src/app/components/time-range/time-range-selector-popover-content/time-range-selector-popover-content.interfaces.ts
@@ -20,8 +20,8 @@ export interface TimeRangeSelectorPopoverProps {
     recentCustomTimeRangeDurations?: TimeRangeDuration[];
     selectedTimeRange?: TimeRange;
     onChange?: (eventObject: TimeRangeDuration) => void;
-
     timeRangeDuration?: TimeRangeDuration;
-
     onClose?: () => void;
+    maxDate?: number;
+    minDate?: number;
 }


### PR DESCRIPTION
Support optional min and max dates in the time range selector. Providing a min and max will cause the quick selection list to be filtered for available selections that match the range as well as the selectable dates in the custom date picker


![image](https://user-images.githubusercontent.com/2080348/189197095-a14d6118-2e99-42ef-b152-b740c49d54cb.png)
