### PR TITLE
[core] add PostProcessor operator

### DIFF
--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/PlanNodeFactory.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/PlanNodeFactory.java
@@ -71,14 +71,18 @@ public class PlanNodeFactory {
   private final Map<String, Class<? extends PlanNode>> planNodeTypeToClassMap;
   private final DataSourceCache dataSourceCache;
   private final DetectionRegistry detectionRegistry;
+  private final PostProcessorRegistry postProcessorRegistry;
   private final EventManager eventDao;
   private final DatasetConfigManager datasetDao;
 
   @Inject
-  public PlanNodeFactory(final DataSourceCache dataSourceCache, final DetectionRegistry detectionRegistry, final EventManager eventDao,
+  public PlanNodeFactory(final DataSourceCache dataSourceCache,
+      final DetectionRegistry detectionRegistry, final PostProcessorRegistry postProcessorRegistry,
+      final EventManager eventDao,
       final DatasetConfigManager datasetDao) {
     this.dataSourceCache = dataSourceCache;
     this.detectionRegistry = detectionRegistry;
+    this.postProcessorRegistry = postProcessorRegistry;
     this.planNodeTypeToClassMap = buildPlanNodeTypeToClassMap();
     this.eventDao = eventDao;
     this.datasetDao = datasetDao;
@@ -117,6 +121,7 @@ public class PlanNodeFactory {
         .setProperties(ImmutableMap.of(
             Constants.DATA_SOURCE_CACHE_REF_KEY, dataSourceCache,
             Constants.DETECTION_REGISTRY_REF_KEY, detectionRegistry,
+            Constants.POST_PROCESSOR_REGISTRY_REF_KEY, postProcessorRegistry,
             Constants.EVENT_MANAGER_REF_KEY, eventDao,
             Constants.DATASET_DAO_REF_KEY, datasetDao
         ));

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/PostProcessorRegistry.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/PostProcessorRegistry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.detectionpipeline;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import ai.startree.thirdeye.spi.detection.AbstractSpec;
+import ai.startree.thirdeye.spi.detection.postprocessing.AnomalyPostProcessor;
+import ai.startree.thirdeye.spi.detection.postprocessing.AnomalyPostProcessorFactory;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The anomaly PostProcessor registry.
+ */
+@Singleton
+public class PostProcessorRegistry {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PostProcessorRegistry.class);
+
+  private final Map<String, AnomalyPostProcessorFactory> anomalyPostProcessorFactoryMap = new HashMap<>();
+
+  @Inject
+  public PostProcessorRegistry() {
+  }
+
+  public void addAnomalyPostProcessorFactory(final AnomalyPostProcessorFactory f) {
+    checkState(!anomalyPostProcessorFactoryMap.containsKey(f.name()),
+        "Duplicate AnomalyPostProcessorFactory: " + f.name());
+
+    anomalyPostProcessorFactoryMap.put(f.name(), f);
+  }
+
+  public AnomalyPostProcessor<AbstractSpec> getAnomalyPostProcessor(final String factoryName) {
+    checkArgument(anomalyPostProcessorFactoryMap.containsKey(factoryName),
+        String.format("Anomaly PostProcessor type not registered: %s. Available postProcessors: %s",
+            factoryName,
+            anomalyPostProcessorFactoryMap.keySet()));
+    return anomalyPostProcessorFactoryMap.get(factoryName).build();
+  }
+}

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperator.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperator.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.detectionpipeline.operator;
+
+import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_MISSING_CONFIGURATION_FIELD;
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+import static ai.startree.thirdeye.util.ResourceUtils.ensureExists;
+import static java.util.Objects.requireNonNull;
+
+import ai.startree.thirdeye.detectionpipeline.PostProcessorRegistry;
+import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.ThirdEyeException;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
+import ai.startree.thirdeye.spi.datalayer.dto.AnomalyLabelDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.MergedAnomalyResultDTO;
+import ai.startree.thirdeye.spi.detection.AbstractSpec;
+import ai.startree.thirdeye.spi.detection.postprocessing.AnomalyPostProcessor;
+import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
+import ai.startree.thirdeye.spi.detection.v2.OperatorResult;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.apache.commons.collections4.MapUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class PostProcessorOperator extends DetectionPipelineOperator {
+
+  private AnomalyPostProcessor<AbstractSpec> postProcessor;
+  private final HashMap<String, Set<String>> combinerKeyToResultsKeys = new HashMap<>();
+
+  public PostProcessorOperator() {
+    super();
+  }
+
+  @Override
+  public void init(final OperatorContext context) {
+    super.init(context);
+    final PostProcessorRegistry postProcessorRegistry = (PostProcessorRegistry) context.getProperties()
+        .get(Constants.POST_PROCESSOR_REGISTRY_REF_KEY);
+    requireNonNull(postProcessorRegistry, "PostProcessorRegistry is not set");
+
+    final Map<String, Object> nodeParams = optional(planNode.getParams()).map(TemplatableMap::valueMap)
+        .orElseThrow(() -> new ThirdEyeException(ERR_MISSING_CONFIGURATION_FIELD,
+            "'type' in " + getOperatorName() + "params"));
+
+    final String type = ensureExists(MapUtils.getString(nodeParams, PROP_TYPE),
+        ERR_MISSING_CONFIGURATION_FIELD,
+        "'type' in " + getOperatorName() + "params");
+
+    postProcessor = postProcessorRegistry.getAnomalyPostProcessor(type);
+    final Map<String, Object> componentSpec = getComponentSpec(nodeParams);
+    final AbstractSpec abstractSpec = AbstractSpec.fromProperties(componentSpec,
+        postProcessor.specClass());
+    postProcessor.init(abstractSpec);
+  }
+
+  @Override
+  public void execute() throws Exception {
+    // split combiner results - to add combinerResult from PostProcessor implementations
+    final Map<String, OperatorResult> inputWithSplitCombinerResults = splitCombinerResults(inputMap);
+
+    final Map<String, OperatorResult> outputsWithSplitCombinerResults = postProcessor.postProcess(
+        detectionInterval,
+        inputWithSplitCombinerResults);
+    outputsWithSplitCombinerResults.values().forEach(this::enrichAnomalyLabels);
+
+    // merge back combiner results
+    final Map<String, OperatorResult> output = mergeCombinerResults(outputsWithSplitCombinerResults);
+
+    resultMap.putAll(output);
+  }
+
+  private Map<String, OperatorResult> splitCombinerResults(Map<String, OperatorResult> resultMap) {
+    final Map<String, OperatorResult> inputWithSplitCombinerResults = new HashMap<>(resultMap);
+    for (final Map.Entry<String, OperatorResult> entry : resultMap.entrySet()) {
+      if (entry.getValue() instanceof CombinerResult) {
+        inputWithSplitCombinerResults.remove(entry.getKey());
+        final Map<String, OperatorResult> combinedResults = ((CombinerResult) entry.getValue()).getResults();
+        // potential key override - assumes there will not be 2 CombinerResult in the resultMap that have internal results with the same key - at implementation time this can't happen
+        inputWithSplitCombinerResults.putAll(combinedResults);
+        combinerKeyToResultsKeys.put(entry.getKey(), combinedResults.keySet());
+      }
+    }
+
+    return inputWithSplitCombinerResults;
+  }
+
+  private Map<String, OperatorResult> mergeCombinerResults(
+      final Map<String, OperatorResult> outputsWithSplitCombinerResults) {
+    final Map<String, OperatorResult> output = new HashMap<>(outputsWithSplitCombinerResults);
+    for (final Entry<String, Set<String>> entry : combinerKeyToResultsKeys.entrySet()) {
+      final Map<String, OperatorResult> combinedResults = new HashMap<>();
+      for (final String resultKey : entry.getValue()) {
+        combinedResults.put(resultKey, outputsWithSplitCombinerResults.get(resultKey));
+        output.remove(resultKey);
+      }
+      output.put(entry.getKey(), new CombinerResult(combinedResults));
+    }
+    return output;
+  }
+
+  private void enrichAnomalyLabels(final OperatorResult result) {
+    final List<MergedAnomalyResultDTO> anomalies;
+    // todo cyril default implementation of getAnomalies throws error - obliged to catch here
+    try {
+      anomalies = result.getAnomalies();
+    } catch (final UnsupportedOperationException e) {
+      // no anomalies
+      return;
+    }
+    if (anomalies == null) {
+      return;
+    }
+
+    for (final MergedAnomalyResultDTO anomaly : anomalies) {
+      final @Nullable List<AnomalyLabelDTO> anomalyLabels = anomaly.getAnomalyLabels();
+      if (anomalyLabels == null) {
+        continue;
+      }
+      for (final AnomalyLabelDTO label : anomalyLabels) {
+        label.setSourcePostProcessor(postProcessor.name());
+        label.setSourceNodeName(planNode.getName());
+      }
+    }
+  }
+
+  @Override
+  public String getOperatorName() {
+    return "PostProcessorOperator";
+  }
+}

--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/PostProcessorPlanNode.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/plan/PostProcessorPlanNode.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.detectionpipeline.plan;
+
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+import static java.util.Objects.requireNonNull;
+
+import ai.startree.thirdeye.detectionpipeline.PostProcessorRegistry;
+import ai.startree.thirdeye.detectionpipeline.operator.PostProcessorOperator;
+import ai.startree.thirdeye.spi.Constants;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
+import ai.startree.thirdeye.spi.detection.v2.Operator;
+import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
+import ai.startree.thirdeye.spi.detection.v2.PlanNodeContext;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+public class PostProcessorPlanNode extends DetectionPipelinePlanNode {
+
+  public static final String TYPE = "PostProcessor";
+  private PostProcessorRegistry postProcessorRegistry;
+
+  public PostProcessorPlanNode() {
+    super();
+  }
+
+  @Override
+  public void init(final PlanNodeContext planNodeContext) {
+    super.init(planNodeContext);
+    postProcessorRegistry = (PostProcessorRegistry) planNodeContext.getProperties()
+        .get(Constants.POST_PROCESSOR_REGISTRY_REF_KEY);
+    requireNonNull(postProcessorRegistry, "PostProcessorRegistry is not set");
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  @Override
+  public Map<String, Object> getParams() {
+    return optional(planNodeBean.getParams()).map(TemplatableMap::valueMap).orElse(null);
+  }
+
+  @Override
+  public Operator buildOperator() throws Exception {
+    final PostProcessorOperator postProcessorOperator = new PostProcessorOperator();
+    postProcessorOperator.init(new OperatorContext()
+        .setDetectionInterval(this.detectionInterval)
+        .setInputsMap(inputsMap)
+        .setPlanNode(planNodeBean)
+        .setProperties(ImmutableMap.of(Constants.POST_PROCESSOR_REGISTRY_REF_KEY,
+            postProcessorRegistry))
+    );
+    return postProcessorOperator;
+  }
+}

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/PlanExecutorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/PlanExecutorTest.java
@@ -57,6 +57,7 @@ public class PlanExecutorTest {
     final PlanNodeFactory planNodeFactory = new PlanNodeFactory(
         mock(DataSourceCache.class),
         mock(DetectionRegistry.class),
+        mock(PostProcessorRegistry.class),
         mock(EventManager.class),
         mock(DatasetConfigManager.class));
     planExecutor = new PlanExecutor(planNodeFactory);

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperatorTest.java
@@ -1,0 +1,172 @@
+package ai.startree.thirdeye.detectionpipeline.operator;
+
+import static ai.startree.thirdeye.spi.Constants.POST_PROCESSOR_REGISTRY_REF_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.startree.thirdeye.detectionpipeline.PostProcessorRegistry;
+import ai.startree.thirdeye.spi.datalayer.TemplatableMap;
+import ai.startree.thirdeye.spi.datalayer.dto.AnomalyLabelDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.MergedAnomalyResultDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean;
+import ai.startree.thirdeye.spi.datalayer.dto.PlanNodeBean.InputBean;
+import ai.startree.thirdeye.spi.detection.AbstractSpec;
+import ai.startree.thirdeye.spi.detection.model.AnomalyDetectionResult;
+import ai.startree.thirdeye.spi.detection.postprocessing.AnomalyPostProcessor;
+import ai.startree.thirdeye.spi.detection.v2.OperatorContext;
+import ai.startree.thirdeye.spi.detection.v2.OperatorResult;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class PostProcessorOperatorTest {
+
+  private static final String TEST_POST_PROCESSOR_NAME = "TestPostProcessor";
+  private static final String TEST_POST_PROCESSOR_LABEL_NAME = "testLabel";
+  private static final String METADATA_TEST_VALUE = "testValue";
+  private static final String METADATA_TEST_KEY = "testKey";
+  public static final String NODE_BEAN_NAME = "NodeBeanName";
+
+  private PostProcessorRegistry postProcessorRegistry;
+
+  @BeforeClass
+  public void setUp() {
+    postProcessorRegistry = mock(PostProcessorRegistry.class);
+    when(postProcessorRegistry.getAnomalyPostProcessor(TEST_POST_PROCESSOR_NAME)).thenReturn((AnomalyPostProcessor) new TestPostProcessor());
+  }
+
+  @Test
+  public void testPostProcessorOperatorWithAnomalyDetectionResults() throws Exception {
+    final PlanNodeBean planNodeBean = new PlanNodeBean().setName(NODE_BEAN_NAME)
+        .setParams(TemplatableMap.fromValueMap(ImmutableMap.of(
+            "type", TEST_POST_PROCESSOR_NAME,
+            "component.labelName", TEST_POST_PROCESSOR_LABEL_NAME)));
+    // timeseries is not used by the TestPostProcessor
+    final AnomalyDetectionResult detectionResult0 = AnomalyDetectionResult.from(List.of(), null);
+    final AnomalyDetectionResult detectionResult1 = AnomalyDetectionResult.from(List.of(new MergedAnomalyResultDTO()),
+        null);
+    final AnomalyDetectionResult detectionResult2 = AnomalyDetectionResult.from(List.of(new MergedAnomalyResultDTO(),
+        new MergedAnomalyResultDTO()), null);
+    final Map<String, OperatorResult> inputsMap = Map.of("detectionResult0",
+        detectionResult0,
+        "detectionResult1",
+        detectionResult1,
+        "detectionResult2",
+        detectionResult2);
+    final OperatorContext context = new OperatorContext().setDetectionInterval(new Interval(0L,
+            1L,
+            DateTimeZone.UTC)) // not used
+        .setPlanNode(planNodeBean.setInputs(List.of(new InputBean().setSourcePlanNode("DetectorNode"))))
+        .setInputsMap(inputsMap)
+        .setProperties(Map.of(POST_PROCESSOR_REGISTRY_REF_KEY, postProcessorRegistry));
+    final PostProcessorOperator operator = new PostProcessorOperator();
+    operator.init(context);
+    operator.execute();
+    final Map<String, OperatorResult> outputs = operator.getOutputs();
+    assertThat(outputs.size()).isEqualTo(3);
+    for (final String inputName: List.of("detectionResult0", "detectionResult1", "detectionResult2")) {
+      assertThat(outputs.containsKey(inputName)).isTrue();
+      final OperatorResult r = outputs.get(inputName);
+      assertLabelsAreCorrect(r);
+    }
+  }
+
+  @Test
+  public void testPostProcessorOperatorWithCombinerResult() throws Exception {
+    final PlanNodeBean planNodeBean = new PlanNodeBean().setName(NODE_BEAN_NAME)
+        .setParams(TemplatableMap.fromValueMap(ImmutableMap.of(
+            "type", TEST_POST_PROCESSOR_NAME,
+            "component.labelName", TEST_POST_PROCESSOR_LABEL_NAME)));
+    // timeseries is not used by the TestPostProcessor
+    final AnomalyDetectionResult detectionResult1 = AnomalyDetectionResult.from(List.of(new MergedAnomalyResultDTO()),
+        null);
+    final AnomalyDetectionResult detectionResult2 = AnomalyDetectionResult.from(List.of(new MergedAnomalyResultDTO(),
+        new MergedAnomalyResultDTO()), null);
+    final Map<String, OperatorResult> detectionMap = Map.of("detectionResult1",detectionResult1, "detectionResult2", detectionResult2);
+    final Map<String, OperatorResult> inputsMap = Map.of("combinerResult1", new CombinerResult(detectionMap));
+    final OperatorContext context = new OperatorContext().setDetectionInterval(new Interval(0L,
+            1L,
+            DateTimeZone.UTC)) // not used
+        .setPlanNode(planNodeBean.setInputs(List.of(new InputBean().setSourcePlanNode("DetectorNode"))))
+        .setInputsMap(inputsMap)
+        .setProperties(Map.of(POST_PROCESSOR_REGISTRY_REF_KEY, postProcessorRegistry));
+    final PostProcessorOperator operator = new PostProcessorOperator();
+    operator.init(context);
+    operator.execute();
+    final Map<String, OperatorResult> outputs = operator.getOutputs();
+    assertThat(outputs.size()).isEqualTo(1);
+    assertThat(outputs.containsKey("combinerResult1")).isTrue();
+    final OperatorResult result = outputs.get("combinerResult1");
+    assertThat(result.getAnomalies().size()).isEqualTo(3);
+    assertLabelsAreCorrect(result);
+  }
+
+  private void assertLabelsAreCorrect(final OperatorResult r) {
+    for (final MergedAnomalyResultDTO anomaly: r.getAnomalies()) {
+      assertThat(anomaly.getAnomalyLabels().size()).isEqualTo(1);
+      final AnomalyLabelDTO label = anomaly.getAnomalyLabels().get(0);
+      assertThat(label.getName()).isEqualTo(TEST_POST_PROCESSOR_LABEL_NAME);
+      assertThat(label.getSourceNodeName()).isEqualTo(NODE_BEAN_NAME);
+      assertThat(label.getSourcePostProcessor()).isEqualTo(TEST_POST_PROCESSOR_NAME);
+      assertThat(label.getMetadata()).isEqualTo(Map.of(METADATA_TEST_KEY, METADATA_TEST_VALUE));
+      assertThat(label.isIgnore()).isTrue();
+    }
+  }
+
+  private static class TestPostProcessorSpec extends AbstractSpec {
+
+    private String labelName;
+
+    public String getLabelName() {
+      return labelName;
+    }
+
+    public TestPostProcessorSpec setLabelName(final String labelName) {
+      this.labelName = labelName;
+      return this;
+    }
+  }
+
+  private static class TestPostProcessor implements AnomalyPostProcessor<TestPostProcessorSpec> {
+
+    private String labelName;
+
+    @Override
+    public void init(final TestPostProcessorSpec spec) {
+      this.labelName = spec.getLabelName();
+    }
+
+    @Override
+    public Class<TestPostProcessorSpec> specClass() {
+      return TestPostProcessorSpec.class;
+    }
+
+    @Override
+    public String name() {
+      return TEST_POST_PROCESSOR_NAME;
+    }
+
+    @Override
+    public Map<String, OperatorResult> postProcess(final Interval detectionInterval,
+        final Map<String, OperatorResult> resultMap) throws Exception {
+      for (final OperatorResult r : resultMap.values()) {
+        if (r instanceof AnomalyDetectionResult) {
+          final AnomalyDetectionResult detectionResult = (AnomalyDetectionResult) r;
+          for (final MergedAnomalyResultDTO anomaly : detectionResult.getAnomalies()) {
+            // override existing labels - don't do this in real implementation - ok for tests
+            final AnomalyLabelDTO anomalyLabel = new AnomalyLabelDTO().setIgnore(true)
+                .setName(labelName)
+                .setMetadata(Map.of(METADATA_TEST_KEY, METADATA_TEST_VALUE));
+            anomaly.setAnomalyLabels(List.of(anomalyLabel));
+          }
+        }
+      }
+      return resultMap;
+    }
+  }
+}

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperatorTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package ai.startree.thirdeye.detectionpipeline.operator;
 
 import static ai.startree.thirdeye.spi.Constants.POST_PROCESSOR_REGISTRY_REF_KEY;

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import ai.startree.thirdeye.core.BootstrapResourcesRegistry;
 import ai.startree.thirdeye.datasource.DataSourcesLoader;
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
+import ai.startree.thirdeye.detectionpipeline.PostProcessorRegistry;
 import ai.startree.thirdeye.notification.NotificationServiceRegistry;
 import ai.startree.thirdeye.rootcause.ContributorsFinderRunner;
 import ai.startree.thirdeye.spi.Plugin;
@@ -27,6 +28,7 @@ import ai.startree.thirdeye.spi.bootstrap.BootstrapResourcesProviderFactory;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSourceFactory;
 import ai.startree.thirdeye.spi.detection.AnomalyDetectorFactory;
 import ai.startree.thirdeye.spi.detection.EventTriggerFactory;
+import ai.startree.thirdeye.spi.detection.postprocessing.AnomalyPostProcessorFactory;
 import ai.startree.thirdeye.spi.notification.NotificationServiceFactory;
 import ai.startree.thirdeye.spi.rca.ContributorsFinderFactory;
 import com.google.inject.Inject;
@@ -61,6 +63,7 @@ public class PluginLoader {
   private final NotificationServiceRegistry notificationServiceRegistry;
   private final ContributorsFinderRunner contributorsFinderRunner;
   private final BootstrapResourcesRegistry bootstrapResourcesRegistry;
+  private final PostProcessorRegistry postProcessorRegistry;
 
   private final AtomicBoolean loading = new AtomicBoolean();
   private final File pluginsDir;
@@ -72,12 +75,14 @@ public class PluginLoader {
       final NotificationServiceRegistry notificationServiceRegistry,
       final ContributorsFinderRunner contributorsFinderRunner,
       final BootstrapResourcesRegistry bootstrapResourcesRegistry,
+      final PostProcessorRegistry postProcessorRegistry,
       final PluginLoaderConfiguration config) {
     this.dataSourcesLoader = dataSourcesLoader;
     this.detectionRegistry = detectionRegistry;
     this.notificationServiceRegistry = notificationServiceRegistry;
     this.contributorsFinderRunner = contributorsFinderRunner;
     this.bootstrapResourcesRegistry = bootstrapResourcesRegistry;
+    this.postProcessorRegistry = postProcessorRegistry;
     pluginsDir = new File(config.getPluginsPath());
   }
 
@@ -130,6 +135,9 @@ public class PluginLoader {
     }
     for (BootstrapResourcesProviderFactory f: plugin.getBootstrapResourcesProviderFactories()) {
       bootstrapResourcesRegistry.addBootstrapResourcesProviderFactory(f);
+    }
+    for (AnomalyPostProcessorFactory f: plugin.getAnomalyPostProcessorFactories()) {
+      postProcessorRegistry.addAnomalyPostProcessorFactory(f);
     }
     log.info("Installed plugin: " + plugin.getClass().getName());
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
@@ -101,6 +101,7 @@ public interface Constants {
   String EVALUATION_FILTERS_KEY = "evaluation.filters";
   String DATA_SOURCE_CACHE_REF_KEY = "$DataSourceCache";
   String DETECTION_REGISTRY_REF_KEY = "$DetectionRegistry";
+  String POST_PROCESSOR_REGISTRY_REF_KEY = "$PostProcessorRegistry";
   String EVENT_MANAGER_REF_KEY = "$EventManager";
   String DATASET_DAO_REF_KEY = "$DatasetDAO";
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
@@ -17,6 +17,7 @@ import ai.startree.thirdeye.spi.bootstrap.BootstrapResourcesProviderFactory;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSourceFactory;
 import ai.startree.thirdeye.spi.detection.AnomalyDetectorFactory;
 import ai.startree.thirdeye.spi.detection.EventTriggerFactory;
+import ai.startree.thirdeye.spi.detection.postprocessing.AnomalyPostProcessorFactory;
 import ai.startree.thirdeye.spi.notification.NotificationServiceFactory;
 import ai.startree.thirdeye.spi.rca.ContributorsFinderFactory;
 import java.util.Collections;
@@ -44,6 +45,10 @@ public interface Plugin {
   }
 
   default Iterable<BootstrapResourcesProviderFactory> getBootstrapResourcesProviderFactories() {
+    return Collections.emptyList();
+  }
+
+  default Iterable<AnomalyPostProcessorFactory> getAnomalyPostProcessorFactories() {
     return Collections.emptyList();
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/AnomalyDetector.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/AnomalyDetector.java
@@ -20,6 +20,7 @@ import org.joda.time.Interval;
 public interface AnomalyDetector<T extends AbstractSpec> extends BaseComponent<T> {
 
   // Keys available in Map<String, DataTable> timeSeriesMap
+  // todo cyril move this to Constants
   String KEY_CURRENT = "current";
   String KEY_BASELINE = "baseline";
   String KEY_CURRENT_EVENTS = "current_events";

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/postprocessing/AnomalyPostProcessor.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/postprocessing/AnomalyPostProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.spi.detection.postprocessing;
+
+import ai.startree.thirdeye.spi.detection.AbstractSpec;
+import ai.startree.thirdeye.spi.detection.BaseComponent;
+import ai.startree.thirdeye.spi.detection.v2.OperatorResult;
+import java.util.Map;
+import org.joda.time.Interval;
+
+public interface AnomalyPostProcessor<T extends AbstractSpec> extends BaseComponent<T> {
+
+  /**
+   * Spec class of the PostProcessor.
+   */
+  Class<T> specClass();
+
+  /**
+   * Value to put in AnomalyLabelDTO$sourcePostProcessor field.
+   */
+  String name();
+
+  /**
+   * Run postProcessing operations on a map of results.
+   */
+  Map<String, OperatorResult> postProcess(final Interval detectionInterval,
+      final Map<String, OperatorResult> resultMap)
+      throws Exception;
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/postprocessing/AnomalyPostProcessorFactory.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/postprocessing/AnomalyPostProcessorFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.spi.detection.postprocessing;
+
+import ai.startree.thirdeye.spi.detection.AbstractSpec;
+
+public interface AnomalyPostProcessorFactory {
+
+  String name();
+
+  <T extends AbstractSpec> AnomalyPostProcessor<T> build();
+}


### PR DESCRIPTION
add plugin interfaces and postProcessor operator

Step 2 of anomaly filtering plan
https://docs.google.com/document/d/1YVsTY_c0RFZBKYz757M9aEboYB5kixppgRvqbJmsZ04/edit#heading=h.b01zovq9nib3

WIP: 
- [X] add tests
- [X] merge https://github.com/startreedata/thirdeye/pull/678 first

Worth checking:  
- namings 
- technique to construct the `<T extends AbstractSpec> spec` for the `PostProcessor` --> simpler than how it's done in DetectorOperator/DetectorRegistry IMO
- registry 

Out of scope: 
- adding a plugin with an implementation
- adding plugin build logic to assembly
