### PR TITLE
[k8s] make helm template javaOpts compatible with commas

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
@@ -84,7 +84,7 @@ spec:
       - name: coordinator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: 
+        args:
         - "server"
         env:
           {{- range $name, $secret := .Values.secrets }}
@@ -106,9 +106,8 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
-              {{- toYaml .Values.coordinator.javaOpts | nindent 14 }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
-              -Djavax.net.ssl.trustStorePassword=changeit
+              -Djavax.net.ssl.trustStorePassword=changeit {{.Values.coordinator.javaOpts}}
         ports:
           - containerPort: {{ .Values.coordinator.port }}
             protocol: TCP

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
@@ -103,7 +103,7 @@ spec:
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
-              -Djavax.net.ssl.trustStorePassword=changeit {{.Values.coordinator.javaOpts}}
+              -Djavax.net.ssl.trustStorePassword=changeit {{.Values.scheduler.javaOpts}}
         ports:
           - containerPort: {{ .Values.scheduler.port }}
             protocol: TCP

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
@@ -102,9 +102,8 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
-              {{- toYaml .Values.scheduler.javaOpts | nindent 14 }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
-              -Djavax.net.ssl.trustStorePassword=changeit
+              -Djavax.net.ssl.trustStorePassword=changeit {{.Values.coordinator.javaOpts}}
         ports:
           - containerPort: {{ .Values.scheduler.port }}
             protocol: TCP

--- a/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
-              -Djavax.net.ssl.trustStorePassword=changeit {{.Values.coordinator.javaOpts}}
+              -Djavax.net.ssl.trustStorePassword=changeit {{.Values.worker.javaOpts}}
         ports:
           - containerPort: {{ .Values.worker.port }}
             protocol: TCP

--- a/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecretsName | quote}}
       {{- end }}
-      nodeSelector: 
+      nodeSelector:
         {{- toYaml .Values.worker.nodeSelector | nindent 8 }}
       affinity:
         {{- toYaml .Values.worker.affinity | nindent 8 }}
@@ -106,9 +106,8 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
-              {{- toYaml .Values.worker.javaOpts | nindent 14 }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
-              -Djavax.net.ssl.trustStorePassword=changeit
+              -Djavax.net.ssl.trustStorePassword=changeit {{.Values.coordinator.javaOpts}}
         ports:
           - containerPort: {{ .Values.worker.port }}
             protocol: TCP


### PR DESCRIPTION
some java options can have commas in their arguments: 

```
-XX:StartFlightRecording=settings=default,delay=3m,disk=true,name=te-run,filename=te-run.jfr,maxsize=500M,maxage=2h
```

