### PR TITLE
scripts default to pinot v0.11.0

### DIFF
--- a/scripts/load-datasets.sh
+++ b/scripts/load-datasets.sh
@@ -16,7 +16,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TE_REPO="${SCRIPT_DIR}/.."
 if [ -z "${PINOT_VERSION}" ]; then
-  PINOT_VERSION=0.9.3
+  PINOT_VERSION=0.11.0
 fi
 if [ -z "${CONTROLLER_HOST}" ]; then
   CONTROLLER_HOST=localhost

--- a/scripts/start-pinot.sh
+++ b/scripts/start-pinot.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_DIR="${SCRIPT_DIR}/.."
 
 if [ -z "${PINOT_VERSION}" ]; then
-    PINOT_VERSION=0.9.3
+    PINOT_VERSION=0.11.0
 fi
 
 export PINOT_INSTALL_TMP_DIR="${REPO_DIR}/tmp/pinot-bin"


### PR DESCRIPTION
Pinot v0.9.3 no longers exists in https://downloads.apache.org/pinot/, so let's use 0.11.0.