### PR TITLE
add startTime and endTime params to /tasks

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/TaskResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/TaskResource.java
@@ -56,6 +56,8 @@ public class TaskResource extends CrudResource<TaskApi, TaskDTO> {
       .put("status", "status")
       .put("created", "createTime")
       .put("updated", "updateTime")
+      .put("startTime", "startTime")
+      .put("endTime", "endTime")
       .build();
   public static final String N_DAYS_TO_DELETE = "30";
   public static final String MAX_ENTRIES_TO_DELETE = "1000";


### PR DESCRIPTION
Make /tasks accept startTime and endTime params.

Tested via http requests to `http://localhost:8080/api/tasks?startTime=[gt]1666155900248` and `http://localhost:8080/api/tasks?startTime=[lt]1666155900248`