### PR TITLE
[core] replace groovy by commons-text for string templating

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -795,9 +795,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-all</artifactId>
-        <version>2.4.21</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>

--- a/thirdeye-core/pom.xml
+++ b/thirdeye-core/pom.xml
@@ -74,8 +74,8 @@
 
     <!-- This is used to replace params in a string template -->
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import org.apache.commons.text.StringSubstitutor;
 
 public class StringTemplateUtils {
 
@@ -37,11 +38,11 @@ public class StringTemplateUtils {
     GROOVY_TEMPLATE_ENGINE.setEscapeBackslash(true);
   }
 
-  public static String renderTemplate(final String template, final Map<String, Object> newContext)
-      throws IOException, ClassNotFoundException {
+  public static String renderTemplate(final String template, final Map<String, Object> newContext) {
     final Map<String, Object> contextMap = getDefaultContextMap();
     contextMap.putAll(newContext);
-    return GROOVY_TEMPLATE_ENGINE.createTemplate(template).make(contextMap).toString();
+    StringSubstitutor sub = new StringSubstitutor(contextMap);
+    return sub.replace(template);
   }
 
   /**

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -41,7 +41,7 @@ public class StringTemplateUtils {
   public static String renderTemplate(final String template, final Map<String, Object> newContext) {
     final Map<String, Object> contextMap = getDefaultContextMap();
     contextMap.putAll(newContext);
-    StringSubstitutor sub = new StringSubstitutor(contextMap);
+    final StringSubstitutor sub = new StringSubstitutor(contextMap);
     return sub.replace(template);
   }
 

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -17,7 +17,6 @@ import ai.startree.thirdeye.spi.datalayer.Templatable;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import groovy.text.SimpleTemplateEngine;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -29,13 +28,10 @@ import java.util.TimeZone;
 import org.apache.commons.text.StringSubstitutor;
 
 public class StringTemplateUtils {
-
-  private static final SimpleTemplateEngine GROOVY_TEMPLATE_ENGINE = new SimpleTemplateEngine();
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
   static {
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-    GROOVY_TEMPLATE_ENGINE.setEscapeBackslash(true);
   }
 
   public static String renderTemplate(final String template, final Map<String, Object> newContext) {

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -13,6 +13,9 @@
  */
 package ai.startree.thirdeye.util;
 
+import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_TEMPLATE_MISSING_PROPERTY;
+
+import ai.startree.thirdeye.spi.ThirdEyeException;
 import ai.startree.thirdeye.spi.datalayer.Templatable;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,8 +40,13 @@ public class StringTemplateUtils {
   public static String renderTemplate(final String template, final Map<String, Object> newContext) {
     final Map<String, Object> contextMap = getDefaultContextMap();
     contextMap.putAll(newContext);
-    final StringSubstitutor sub = new StringSubstitutor(contextMap);
-    return sub.replace(template);
+    final StringSubstitutor sub = new StringSubstitutor(contextMap)
+        .setEnableUndefinedVariableException(true);
+    try {
+      return sub.replace(template);
+    } catch (IllegalArgumentException e) {
+      throw new ThirdEyeException(ERR_TEMPLATE_MISSING_PROPERTY, e);
+    }
   }
 
   /**

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye.util;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import ai.startree.thirdeye.spi.ThirdEyeException;
 import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -41,9 +42,17 @@ public class StringTemplateUtilsTest {
   public void testStringReplacementWithBackSlash() throws IOException, ClassNotFoundException {
     final Map<String, Object> values = Map.of("k1", "v1", "k2", "v2");
     final Map<String, String> map1 = StringTemplateUtils.applyContext(
-        new HashMap<>(Map.of("k", "${k1}")),
+        new HashMap<>(Map.of("k\\testBackslash", "\\withBackSlashes\\${k1}")),
         values);
-    assertThat(map1).isEqualTo(Map.of("k", "v1"));
+    assertThat(map1).isEqualTo(Map.of("k\\testBackslash", "\\withBackSlashes\\v1"));
+  }
+
+  @Test
+  public void testFailAtMissingValue() {
+    final Map<String, Object> values = Map.of("k2", "v2");
+    assertThatThrownBy(() -> StringTemplateUtils.applyContext(
+        new HashMap<>(Map.of("k", "${k1}")),
+        values)).isInstanceOf(ThirdEyeException.class);
   }
 
   @Test

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
@@ -38,6 +38,15 @@ public class StringTemplateUtilsTest {
   }
 
   @Test
+  public void testStringReplacementWithBackSlash() throws IOException, ClassNotFoundException {
+    final Map<String, Object> values = Map.of("k1", "v1", "k2", "v2");
+    final Map<String, String> map1 = StringTemplateUtils.applyContext(
+        new HashMap<>(Map.of("k", "${k1}")),
+        values);
+    assertThat(map1).isEqualTo(Map.of("k", "v1"));
+  }
+
+  @Test
   public void testTemplatableFieldReplacement() throws IOException, ClassNotFoundException {
     // check that the replacement is done correctly with Templatable<T>, for different Ts
     final String datasetKey = "datasetDto";

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/core/ExceptionHandler.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/core/ExceptionHandler.java
@@ -15,7 +15,6 @@ package ai.startree.thirdeye.core;
 
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_ALERT_PIPELINE_EXECUTION;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_DATA_UNAVAILABLE;
-import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_TEMPLATE_MISSING_PROPERTY;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_TIMEOUT;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_UNKNOWN;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_UNKNOWN_RCA_ALGORITHM;
@@ -27,7 +26,6 @@ import ai.startree.thirdeye.spi.ThirdEyeException;
 import ai.startree.thirdeye.spi.api.StatusApi;
 import ai.startree.thirdeye.spi.api.StatusListApi;
 import com.google.common.collect.ImmutableMap;
-import groovy.lang.MissingPropertyException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +41,6 @@ public class ExceptionHandler {
   private static final Map<Class<?>, Function<Throwable, StatusApi>> ALERT_HANDLERS = ImmutableMap.<Class<?>, Function<Throwable, StatusApi>>builder()
       .put(TimeoutException.class, e -> statusApi(ERR_TIMEOUT))
       .put(DataProviderException.class, e -> statusApi(ERR_DATA_UNAVAILABLE, e.getMessage()))
-      .put(MissingPropertyException.class,
-          e -> statusApi(ERR_TEMPLATE_MISSING_PROPERTY,
-              ((MissingPropertyException) e).getProperty()))
       .put(ExecutionException.class,
           e -> statusApi(ERR_ALERT_PIPELINE_EXECUTION, e.getCause().getMessage()))
       .put(ThirdEyeException.class,
@@ -59,9 +54,6 @@ public class ExceptionHandler {
 
   private static final Map<Class<?>, Function<Throwable, StatusApi>> RCA_HANDLERS = ImmutableMap.<Class<?>, Function<Throwable, StatusApi>>builder()
       .put(TimeoutException.class, e -> statusApi(ERR_TIMEOUT))
-      .put(MissingPropertyException.class,
-          e -> statusApi(ERR_TEMPLATE_MISSING_PROPERTY,
-              ((MissingPropertyException) e).getProperty()))
       .put(ThirdEyeException.class,
           e -> {
             final ThirdEyeException thirdEyeException = (ThirdEyeException) e;


### PR DESCRIPTION
replace groovy by apache commons text for template variable replacements
fixes an important memory leak described here: 
https://cortexdata.atlassian.net/browse/TE-1038

Risk: 
- some behavior of groovy templating were not unit tested. I tried to add a few tests.


Other options considered:
- update groovy to fix the leak: did not solve the issue - groovy does not expect a runtime to create many templates
- instead of creating a groovy template every time, maintain a hashmap of created groovy templates. Match te templates to groovy templates.
--> means we have to maintain a cache with TTL ourselves. Don't want to do this. Speed is not really an issue here. (pipeline execution time >> template resolution time)

Note on speed: 
I did a very quick benchmark, commons text seems to be faster.
average templating time with groovy: 15ms
average templating time commons-text: 0.5ms
benchmark is not realistic because: 
- groovy was stressed by its own memory leak 
- the template used was very small (10 chars), TE templates are bigger (10000 chars)
- groovy expects a template to be reused, which is not the case in the current implem
At least it shows we should not worry about this for the moment.