### PR TITLE
[server] fix alert plays from epoch zero

### DIFF
--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
@@ -65,6 +65,7 @@ public class SchedulingTest {
   private static final AlertApi ALERT_API;
 
   private static final TimeProvider CLOCK = TimeProvider.instance();
+  private static final long PAGEVIEWS_DATASET_START_TIME = 1580601600000L;
   // alert can be created at any time in the day
   private static final long MARCH_24_2020_15H33 = 1585063980_000L;
   // = MARCH_24_2020_15H33 - delay P3D and floor granularity P1D (config in alert json)
@@ -161,7 +162,7 @@ public class SchedulingTest {
 
     // check that lastTimestamp just after creation is 0
     long alertLastTimestamp = getAlertLastTimestamp();
-    assertThat(alertLastTimestamp).isEqualTo(0);
+    assertThat(alertLastTimestamp).isEqualTo(PAGEVIEWS_DATASET_START_TIME);
   }
 
   @Test(dependsOnMethods = "testCreateAlertLastTimestamp", timeOut = 60000L)

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/alert/AlertCreater.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/alert/AlertCreater.java
@@ -81,8 +81,7 @@ public class AlertCreater {
     if (dto.getLastTimestamp() < minimumOnboardingStartTime) {
       dto.setLastTimestamp(minimumLastTimestamp(dto));
     }
-    final Long id = alertManager.save(dto);
-    dto.setId(id);
+    alertManager.save(dto);
     return dto;
   }
 

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -179,12 +179,9 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
       @FormParam("end") final Long endTime
   ) {
     ensureExists(startTime, "start");
+    ensureExists(get(id));
 
-    final AlertDTO dto = get(id);
-    alertCreater.createOnboardingTask(dto,
-        startTime,
-        safeEndTime(endTime)
-    );
+    alertCreater.createOnboardingTask(id, startTime, safeEndTime(endTime));
 
     return Response.ok().build();
   }
@@ -257,9 +254,6 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
 
     alertDeleter.deleteAssociatedAnomalies(dto.getId());
 
-    /* Reset the last timestamp after deleting all anomalies */
-    dto.setLastTimestamp(0);
-
-    return respondOk(toApi(alertCreater.saveAndOnboard(dto)));
+    return respondOk(toApi(alertCreater.reset(dto)));
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -259,11 +259,7 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
 
     /* Reset the last timestamp after deleting all anomalies */
     dto.setLastTimestamp(0);
-    dtoManager.save(dto);
 
-    /* Create a task to rerun all historical anomalies */
-    alertCreater.createOnboardingTask(dto);
-
-    return respondOk(toApi(dto));
+    return respondOk(toApi(alertCreater.saveAndOnboard(dto)));
   }
 }


### PR DESCRIPTION
fixes alert having lastTimestamp=0, resulting in pressure when the pipeline tries to run from epoch 0.
the strategy of the fix is to enforce the creation of anomalies with a corrected lastTimestamp, not correct it afterwards
also it reduces the surface of potential mistakes, only saveAndOnboard(alertDto) is shared by alert creation and alert reset

In particular, it fixes 2 cases: 
```
- alert save with lastTimestamp=0 
- coordinator crashes before creating the onboarding task
- another worker picks the alert with lastTimestamp=0
```
and 
```
- alert save with lastTimestamp=0 
- onboarding is launched with runtime corrected timestamp
- onboarding fails, lastTimestamp is still zero
- another worker picks the alert with lastTimestamp=0
```


The other solution was to fix the lastTimestamp at running time, but this was making things more complex.