### PR TITLE
[core] rollback to groovy for templating and hotfix class leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -795,9 +795,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>1.10.0</version>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <version>2.4.21</version>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>

--- a/thirdeye-core/pom.xml
+++ b/thirdeye-core/pom.xml
@@ -74,8 +74,8 @@
 
     <!-- This is used to replace params in a string template -->
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -13,13 +13,11 @@
  */
 package ai.startree.thirdeye.util;
 
-import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_TEMPLATE_MISSING_PROPERTY;
-
-import ai.startree.thirdeye.spi.ThirdEyeException;
 import ai.startree.thirdeye.spi.datalayer.Templatable;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import groovy.text.SimpleTemplateEngine;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -28,25 +26,22 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
-import org.apache.commons.text.StringSubstitutor;
 
 public class StringTemplateUtils {
+
+  private static final SimpleTemplateEngine GROOVY_TEMPLATE_ENGINE = new SimpleTemplateEngine();
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
   static {
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    GROOVY_TEMPLATE_ENGINE.setEscapeBackslash(true);
   }
 
-  public static String renderTemplate(final String template, final Map<String, Object> newContext) {
+  public static String renderTemplate(final String template, final Map<String, Object> newContext)
+      throws IOException, ClassNotFoundException {
     final Map<String, Object> contextMap = getDefaultContextMap();
     contextMap.putAll(newContext);
-    final StringSubstitutor sub = new StringSubstitutor(contextMap)
-        .setEnableUndefinedVariableException(true);
-    try {
-      return sub.replace(template);
-    } catch (IllegalArgumentException e) {
-      throw new ThirdEyeException(ERR_TEMPLATE_MISSING_PROPERTY, e);
-    }
+    return GROOVY_TEMPLATE_ENGINE.createTemplate(template).make(contextMap).toString();
   }
 
   /**

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/StringTemplateUtils.java
@@ -17,6 +17,7 @@ import ai.startree.thirdeye.spi.datalayer.Templatable;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import groovy.lang.GroovyShell;
 import groovy.text.SimpleTemplateEngine;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -29,7 +30,8 @@ import java.util.TimeZone;
 
 public class StringTemplateUtils {
 
-  private static final SimpleTemplateEngine GROOVY_TEMPLATE_ENGINE = new SimpleTemplateEngine();
+  private static final GroovyShell GROOVY_SHELL = new GroovyShell();
+  private static final SimpleTemplateEngine GROOVY_TEMPLATE_ENGINE = new SimpleTemplateEngine(GROOVY_SHELL);
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
   static {
@@ -41,7 +43,9 @@ public class StringTemplateUtils {
       throws IOException, ClassNotFoundException {
     final Map<String, Object> contextMap = getDefaultContextMap();
     contextMap.putAll(newContext);
-    return GROOVY_TEMPLATE_ENGINE.createTemplate(template).make(contextMap).toString();
+    final String rendered = GROOVY_TEMPLATE_ENGINE.createTemplate(template).make(contextMap).toString();
+    GROOVY_SHELL.resetLoadedClasses();
+    return rendered;
   }
 
   /**

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
@@ -16,7 +16,6 @@ package ai.startree.thirdeye.util;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import ai.startree.thirdeye.spi.ThirdEyeException;
 import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -36,23 +35,6 @@ public class StringTemplateUtilsTest {
         new HashMap<>(Map.of("k", "${k1}")),
         values);
     assertThat(map1).isEqualTo(Map.of("k", "v1"));
-  }
-
-  @Test
-  public void testStringReplacementWithBackSlash() throws IOException, ClassNotFoundException {
-    final Map<String, Object> values = Map.of("k1", "v1", "k2", "v2");
-    final Map<String, String> map1 = StringTemplateUtils.applyContext(
-        new HashMap<>(Map.of("k\\testBackslash", "\\withBackSlashes\\${k1}")),
-        values);
-    assertThat(map1).isEqualTo(Map.of("k\\testBackslash", "\\withBackSlashes\\v1"));
-  }
-
-  @Test
-  public void testFailAtMissingValue() {
-    final Map<String, Object> values = Map.of("k2", "v2");
-    assertThatThrownBy(() -> StringTemplateUtils.applyContext(
-        new HashMap<>(Map.of("k", "${k1}")),
-        values)).isInstanceOf(ThirdEyeException.class);
   }
 
   @Test

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import ai.startree.thirdeye.spi.datalayer.Templatable;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import groovy.lang.MissingPropertyException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +36,14 @@ public class StringTemplateUtilsTest {
         new HashMap<>(Map.of("k", "${k1}")),
         values);
     assertThat(map1).isEqualTo(Map.of("k", "v1"));
+  }
+
+  @Test
+  public void testFailAtMissingValue() {
+    final Map<String, Object> values = Map.of("k2", "v2");
+    assertThatThrownBy(() -> StringTemplateUtils.applyContext(
+        new HashMap<>(Map.of("k", "${k1}")),
+        values)).isInstanceOf(MissingPropertyException.class);
   }
 
   @Test

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/util/StringTemplateUtilsTest.java
@@ -47,6 +47,13 @@ public class StringTemplateUtilsTest {
   }
 
   @Test
+  public void testRecursiveVariables() throws IOException, ClassNotFoundException {
+    final Map<String, Object> values = Map.of("v1", "${v1}");
+    final Map<String, String> map1 = StringTemplateUtils.applyContext(new HashMap<>(Map.of("k", "${v1}")), values);
+    assertThat(map1).isEqualTo(Map.of("k", "${v1}"));
+  }
+
+  @Test
   public void testTemplatableFieldReplacement() throws IOException, ClassNotFoundException {
     // check that the replacement is done correctly with Templatable<T>, for different Ts
     final String datasetKey = "datasetDto";

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/core/ExceptionHandler.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/core/ExceptionHandler.java
@@ -15,6 +15,7 @@ package ai.startree.thirdeye.core;
 
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_ALERT_PIPELINE_EXECUTION;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_DATA_UNAVAILABLE;
+import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_TEMPLATE_MISSING_PROPERTY;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_TIMEOUT;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_UNKNOWN;
 import static ai.startree.thirdeye.spi.ThirdEyeStatus.ERR_UNKNOWN_RCA_ALGORITHM;
@@ -26,6 +27,7 @@ import ai.startree.thirdeye.spi.ThirdEyeException;
 import ai.startree.thirdeye.spi.api.StatusApi;
 import ai.startree.thirdeye.spi.api.StatusListApi;
 import com.google.common.collect.ImmutableMap;
+import groovy.lang.MissingPropertyException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,9 @@ public class ExceptionHandler {
   private static final Map<Class<?>, Function<Throwable, StatusApi>> ALERT_HANDLERS = ImmutableMap.<Class<?>, Function<Throwable, StatusApi>>builder()
       .put(TimeoutException.class, e -> statusApi(ERR_TIMEOUT))
       .put(DataProviderException.class, e -> statusApi(ERR_DATA_UNAVAILABLE, e.getMessage()))
+      .put(MissingPropertyException.class,
+          e -> statusApi(ERR_TEMPLATE_MISSING_PROPERTY,
+              ((MissingPropertyException) e).getProperty()))
       .put(ExecutionException.class,
           e -> statusApi(ERR_ALERT_PIPELINE_EXECUTION, e.getCause().getMessage()))
       .put(ThirdEyeException.class,
@@ -54,6 +59,9 @@ public class ExceptionHandler {
 
   private static final Map<Class<?>, Function<Throwable, StatusApi>> RCA_HANDLERS = ImmutableMap.<Class<?>, Function<Throwable, StatusApi>>builder()
       .put(TimeoutException.class, e -> statusApi(ERR_TIMEOUT))
+      .put(MissingPropertyException.class,
+          e -> statusApi(ERR_TEMPLATE_MISSING_PROPERTY,
+              ((MissingPropertyException) e).getProperty()))
       .put(ThirdEyeException.class,
           e -> {
             final ThirdEyeException thirdEyeException = (ThirdEyeException) e;


### PR DESCRIPTION
This reverts commit 4a0ec1053fb7215a58d133e6cf6972e352a0b6b6.

recursive variable resolution should be disabled, but it seems it's not
maybe an issue in commons-text
https://commons.apache.org/proper/commons-text/apidocs/org/apache/commons/text/StringSubstitutor.html

will retry but for the moment I want to get back to a working state, and add more templating tests
