### PR TITLE
fix(ui): TE-1045 ensure alerts stay within screen

### DIFF
--- a/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-display-v1/notification-display-v1.component.tsx
+++ b/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-display-v1/notification-display-v1.component.tsx
@@ -72,6 +72,8 @@ export const NotificationDisplayV1: FunctionComponent<NotificationDisplayV1Props
                                 action: notification.nonDismissible
                                     ? notificationDisplayV1Classes.notificationActionHidden
                                     : notificationDisplayV1Classes.notificationActionVisible,
+                                message:
+                                    notificationDisplayV1Classes.snackBarContainer,
                             }}
                             severity={notification.type}
                             onClose={handleClose}

--- a/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-display-v1/notification-display-v1.styles.ts
+++ b/thirdeye-ui/src/app/platform/components/notification-provider-v1/notification-display-v1/notification-display-v1.styles.ts
@@ -21,4 +21,8 @@ export const useNotificationDisplayV1Styles = makeStyles({
     notificationActionHidden: {
         display: "none",
     },
+    snackBarContainer: {
+        maxWidth: "90vw",
+        overflowWrap: "break-word",
+    },
 });


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1045

#### Description

Very long error messages without space in them causes  the displayed alert to go beyond the screen size. Adding a max width and overflow wrap css rules to fix

#### Screenshots

Before:
![image](https://user-images.githubusercontent.com/2080348/200382737-8cffbbba-7f59-41db-a635-d4e8430befcf.png)

After:
![image](https://user-images.githubusercontent.com/2080348/200382759-8c51a542-f726-486a-be31-77e1d1c8f056.png)
