### PR TITLE
[server] added count endpoint to CrudResource. Accepts predicates from query params.

### DIFF
--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
@@ -238,6 +238,24 @@ public class HappyPathTest {
   }
 
   @Test(dependsOnMethods = "testGetSingleAnomaly")
+  public void testAnomalyCount() {
+    // without filters
+    Response response = request("api/anomalies/count").get();
+    assertThat(response.getStatus()).isEqualTo(200);
+    Integer anomalyCount = response.readEntity(Integer.class);
+    assertThat(anomalyCount).isEqualTo(4);
+
+    // there are only 2 anomalies that have startTime greater than or equal this value
+    long startTime = 1585353600000L;
+
+    // with filters
+    response = request("api/anomalies/count?startTime=[gte]" + startTime).get();
+    assertThat(response.getStatus()).isEqualTo(200);
+    anomalyCount = response.readEntity(Integer.class);
+    assertThat(anomalyCount).isEqualTo(2);
+  }
+
+  @Test(dependsOnMethods = "testGetSingleAnomaly")
   public void testGetHeatmap() {
     Response response = request("api/rca/metrics/heatmap?id=" + anomalyId).get();
     assertThat(response.getStatus()).isEqualTo(200);

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
@@ -28,6 +28,7 @@ import ai.startree.thirdeye.spi.api.AlertApi;
 import ai.startree.thirdeye.spi.api.AlertEvaluationApi;
 import ai.startree.thirdeye.spi.api.AlertInsightsApi;
 import ai.startree.thirdeye.spi.api.AnomalyApi;
+import ai.startree.thirdeye.spi.api.CountApi;
 import ai.startree.thirdeye.spi.api.DataSourceApi;
 import ai.startree.thirdeye.spi.api.DimensionAnalysisResultApi;
 import ai.startree.thirdeye.spi.api.EmailSchemeApi;
@@ -242,7 +243,7 @@ public class HappyPathTest {
     // without filters
     Response response = request("api/anomalies/count").get();
     assertThat(response.getStatus()).isEqualTo(200);
-    Integer anomalyCount = response.readEntity(Integer.class);
+    Long anomalyCount = response.readEntity(CountApi.class).getCount();
     assertThat(anomalyCount).isEqualTo(4);
 
     // there are only 2 anomalies that have startTime greater than or equal this value
@@ -251,7 +252,7 @@ public class HappyPathTest {
     // with filters
     response = request("api/anomalies/count?startTime=[gte]" + startTime).get();
     assertThat(response.getStatus()).isEqualTo(200);
-    anomalyCount = response.readEntity(Integer.class);
+    anomalyCount = response.readEntity(CountApi.class).getCount();
     assertThat(anomalyCount).isEqualTo(2);
   }
 

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
@@ -329,16 +329,10 @@ public abstract class CrudResource<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exte
   ) {
     final MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
     final CountApi api = new CountApi();
-    try {
-      final Long count = queryParameters.size() > 0
-          ? dtoManager.count(new DaoFilterBuilder(apiToIndexMap).buildFilter(queryParameters)
-          .getPredicate())
-          : dtoManager.count();
-      api.setCount(count);
-    } catch (Exception e) {
-      api.setMessage(e.getMessage());
-      log.error(e.getMessage(), e);
-    }
+    final Long count = queryParameters.size() > 0
+      ? dtoManager.count(new DaoFilterBuilder(apiToIndexMap).buildFilter(queryParameters).getPredicate())
+      : dtoManager.count();
+    api.setCount(count);
     return Response.ok(api).build();
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
@@ -30,6 +30,7 @@ import static java.util.Objects.requireNonNull;
 import ai.startree.thirdeye.DaoFilterBuilder;
 import ai.startree.thirdeye.RequestCache;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
+import ai.startree.thirdeye.spi.api.CountApi;
 import ai.startree.thirdeye.spi.api.ThirdEyeCrudApi;
 import ai.startree.thirdeye.spi.datalayer.DaoFilter;
 import ai.startree.thirdeye.spi.datalayer.Predicate;
@@ -327,9 +328,17 @@ public abstract class CrudResource<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exte
       @Context UriInfo uriInfo
   ) {
     final MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
-    final Long count = queryParameters.size() > 0
-        ? dtoManager.count(new DaoFilterBuilder(apiToIndexMap).buildFilter(queryParameters).getPredicate())
-        : dtoManager.count();
-    return Response.ok(count).build();
+    final CountApi api = new CountApi();
+    try {
+      final Long count = queryParameters.size() > 0
+          ? dtoManager.count(new DaoFilterBuilder(apiToIndexMap).buildFilter(queryParameters)
+          .getPredicate())
+          : dtoManager.count();
+      api.setCount(count);
+    } catch (Exception e) {
+      api.setMessage(e.getMessage());
+      log.error(e.getMessage(), e);
+    }
+    return Response.ok(api).build();
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
@@ -318,4 +318,18 @@ public abstract class CrudResource<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exte
     dtoManager.findAll().forEach(this::deleteDto);
     return Response.ok().build();
   }
+
+  @GET
+  @Path("/count")
+  @Timed
+  public Response countWithPredicate(
+      @ApiParam(hidden = true) @Auth ThirdEyePrincipal principal,
+      @Context UriInfo uriInfo
+  ) {
+    final MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
+    final Long count = queryParameters.size() > 0
+        ? dtoManager.count(new DaoFilterBuilder(apiToIndexMap).buildFilter(queryParameters).getPredicate())
+        : dtoManager.count();
+    return Response.ok(count).build();
+  }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/CountApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/CountApi.java
@@ -15,7 +15,6 @@ package ai.startree.thirdeye.spi.api;
 
 public class CountApi {
   private Long count;
-  private String message;
 
   public Long getCount() {
     return count;
@@ -23,15 +22,6 @@ public class CountApi {
 
   public CountApi setCount(final Long count) {
     this.count = count;
-    return this;
-  }
-
-  public String getMessage() {
-    return message;
-  }
-
-  public CountApi setMessage(final String message) {
-    this.message = message;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/CountApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/CountApi.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package ai.startree.thirdeye.spi.api;
 
 public class CountApi {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/CountApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/CountApi.java
@@ -1,0 +1,24 @@
+package ai.startree.thirdeye.spi.api;
+
+public class CountApi {
+  private Long count;
+  private String message;
+
+  public Long getCount() {
+    return count;
+  }
+
+  public CountApi setCount(final Long count) {
+    this.count = count;
+    return this;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public CountApi setMessage(final String message) {
+    this.message = message;
+    return this;
+  }
+}


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1048

#### Description

Endpoint : /api/{entity}/count
Example : `/api/tasks/count?status=FAILED`
Response: 
```
{
    "count" : 10
}
```
