### PR TITLE
chore(ui): TE-1063 added missing type definition to otherProps

### DIFF
--- a/thirdeye-ui/src/app/platform/components/page-v1/page-contents-grid-v1/page-contents-card-v1/page-contents-card-v1.interfaces.ts
+++ b/thirdeye-ui/src/app/platform/components/page-v1/page-contents-grid-v1/page-contents-card-v1/page-contents-card-v1.interfaces.ts
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import type { CardProps } from "@material-ui/core/Card";
 import { ReactNode } from "react";
 
 export interface PageContentsCardV1Props {
@@ -19,4 +20,5 @@ export interface PageContentsCardV1Props {
     disablePadding?: boolean;
     className?: string;
     children?: ReactNode;
+    otherProps?: CardProps;
 }


### PR DESCRIPTION
#### Issue(s)

[TE-1063](https://cortexdata.atlassian.net/browse/TE-1063)

#### Description

- Added Material UI's Card component props type definition to `otherProps` since it is passed as de-structured props to the Card component

#### Screenshots

![Screenshot 2022-11-15 at 15 22 04](https://user-images.githubusercontent.com/20799363/201888124-2c17d588-7902-4952-8d04-61e9fd1a271d.png)
