### PR TITLE
te 809 add template property metadata

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertTemplateRenderer.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertTemplateRenderer.java
@@ -162,8 +162,7 @@ public class AlertTemplateRenderer {
     final Map<String, Object> legacyDefaultProperties = optional(
         template.getDefaultProperties()).orElse(new HashMap<>());
     properties.putAll(legacyDefaultProperties);
-    final Map<String, Object> defaultProperties = defaultProperties(
-        template.getPropertiesMetadata());
+    final Map<String, Object> defaultProperties = defaultProperties(template.getProperties());
     properties.putAll(defaultProperties);
 
     if (templateProperties != null) {

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-threshold-percentile.json
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-threshold-percentile.json
@@ -172,9 +172,21 @@
     "mergeMaxDuration": "${mergeMaxDuration}",
     "granularity": "${monitoringGranularity}"
   },
+  "propertiesMetadata": [
+    {
+      "name": "timezone",
+      "description": "Timezone used to group by time.",
+      "defaultValue": "UTC",
+      "jsonType": "STRING"
+    },
+    {
+      "name": "timeColumn",
+      "description": "TimeColumn to use to group by time. If set to AUTO (the default value), the Pinot primary time column is used.",
+      "defaultValue": "AUTO",
+      "jsonType": "STRING"
+    }
+  ],
   "defaultProperties": {
-    "timezone": "UTC",
-    "timeColumn": "AUTO",
     "timeColumnFormat": "",
     "completenessDelay": "P0D",
     "mergeMaxGap": "",

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-threshold-percentile.json
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-threshold-percentile.json
@@ -172,7 +172,7 @@
     "mergeMaxDuration": "${mergeMaxDuration}",
     "granularity": "${monitoringGranularity}"
   },
-  "propertiesMetadata": [
+  "properties": [
     {
       "name": "timezone",
       "description": "Timezone used to group by time.",

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
@@ -32,7 +32,7 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
   @Deprecated // use AlertMetadataApi
   private RcaMetadataApi rca;
   private AlertMetadataApi metadata;
-  @Deprecated
+  @Deprecated // use propertiesMetadata
   private Map<String, @Nullable Object> defaultProperties;
   private List<TemplatePropertyMetadata> propertiesMetadata;
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.api;
 
+import ai.startree.thirdeye.spi.template.TemplatePropertyMetadata;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,9 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
   @Deprecated // use AlertMetadataApi
   private RcaMetadataApi rca;
   private AlertMetadataApi metadata;
+  @Deprecated
   private Map<String, @Nullable Object> defaultProperties;
+  private List<TemplatePropertyMetadata> propertiesMetadata;
 
   public Long getId() {
     return id;
@@ -126,13 +129,25 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
     return this;
   }
 
+  @Deprecated
   public Map<String, Object> getDefaultProperties() {
     return defaultProperties;
   }
 
+  @Deprecated
   public AlertTemplateApi setDefaultProperties(
       final Map<String, Object> defaultProperties) {
     this.defaultProperties = defaultProperties;
+    return this;
+  }
+
+  public List<TemplatePropertyMetadata> getPropertiesMetadata() {
+    return propertiesMetadata;
+  }
+
+  public AlertTemplateApi setPropertiesMetadata(
+      final List<TemplatePropertyMetadata> propertiesMetadata) {
+    this.propertiesMetadata = propertiesMetadata;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
@@ -34,7 +34,7 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
   private AlertMetadataApi metadata;
   @Deprecated // use propertiesMetadata
   private Map<String, @Nullable Object> defaultProperties;
-  private List<TemplatePropertyMetadata> propertiesMetadata;
+  private List<TemplatePropertyMetadata> properties;
 
   public Long getId() {
     return id;
@@ -141,13 +141,13 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
     return this;
   }
 
-  public List<TemplatePropertyMetadata> getPropertiesMetadata() {
-    return propertiesMetadata;
+  public List<TemplatePropertyMetadata> getProperties() {
+    return properties;
   }
 
-  public AlertTemplateApi setPropertiesMetadata(
-      final List<TemplatePropertyMetadata> propertiesMetadata) {
-    this.propertiesMetadata = propertiesMetadata;
+  public AlertTemplateApi setProperties(
+      final List<TemplatePropertyMetadata> properties) {
+    this.properties = properties;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.template.TemplatePropertyMetadata;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Date;
 import java.util.List;
@@ -32,7 +33,9 @@ public class AlertTemplateDTO extends AbstractDTO {
   @JsonIgnore
   private RcaMetadataDTO rca;
   private AlertMetadataDTO metadata;
+  @Deprecated
   private Map<String, @Nullable Object> defaultProperties;
+  private List<TemplatePropertyMetadata> propertiesMetadata;
 
   public String getName() {
     return name;
@@ -120,13 +123,25 @@ public class AlertTemplateDTO extends AbstractDTO {
     return this;
   }
 
+  @Deprecated
   public Map<String, Object> getDefaultProperties() {
     return defaultProperties;
   }
 
+  @Deprecated
   public AlertTemplateDTO setDefaultProperties(
       final Map<String, Object> defaultProperties) {
     this.defaultProperties = defaultProperties;
+    return this;
+  }
+
+  public List<TemplatePropertyMetadata> getPropertiesMetadata() {
+    return propertiesMetadata;
+  }
+
+  public AlertTemplateDTO setPropertiesMetadata(
+      final List<TemplatePropertyMetadata> propertiesMetadata) {
+    this.propertiesMetadata = propertiesMetadata;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
@@ -33,7 +33,7 @@ public class AlertTemplateDTO extends AbstractDTO {
   @JsonIgnore
   private RcaMetadataDTO rca;
   private AlertMetadataDTO metadata;
-  @Deprecated
+  @Deprecated // use propertiesMetadata
   private Map<String, @Nullable Object> defaultProperties;
   private List<TemplatePropertyMetadata> propertiesMetadata;
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
@@ -35,7 +35,7 @@ public class AlertTemplateDTO extends AbstractDTO {
   private AlertMetadataDTO metadata;
   @Deprecated // use propertiesMetadata
   private Map<String, @Nullable Object> defaultProperties;
-  private List<TemplatePropertyMetadata> propertiesMetadata;
+  private List<TemplatePropertyMetadata> properties;
 
   public String getName() {
     return name;
@@ -135,13 +135,13 @@ public class AlertTemplateDTO extends AbstractDTO {
     return this;
   }
 
-  public List<TemplatePropertyMetadata> getPropertiesMetadata() {
-    return propertiesMetadata;
+  public List<TemplatePropertyMetadata> getProperties() {
+    return properties;
   }
 
-  public AlertTemplateDTO setPropertiesMetadata(
-      final List<TemplatePropertyMetadata> propertiesMetadata) {
-    this.propertiesMetadata = propertiesMetadata;
+  public AlertTemplateDTO setProperties(
+      final List<TemplatePropertyMetadata> properties) {
+    this.properties = properties;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
@@ -22,7 +22,14 @@ import java.util.List;
 @JsonInclude(Include.NON_NULL)
 public class TemplatePropertyMetadata {
 
+  /**
+   * Exact name in the template
+   */
   private String name;
+  /**
+   * Markdown description.
+   */
+  private String description;
   private Object defaultValue;
   /**
    * Used to set a defaultValue to null. (defaultValue=null is interpreted as no defaultValue).
@@ -118,6 +125,15 @@ public class TemplatePropertyMetadata {
 
   public TemplatePropertyMetadata setJsonType(final JsonType jsonType) {
     this.jsonType = jsonType;
+    return this;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public TemplatePropertyMetadata setDescription(final String description) {
+    this.description = description;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
@@ -14,9 +14,12 @@
 package ai.startree.thirdeye.spi.template;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
 public class TemplatePropertyMetadata {
 
   private String name;
@@ -32,6 +35,8 @@ public class TemplatePropertyMetadata {
 
   /**
    * Helps the UI build input fields.
+   * If minValue is set and maxValue is null, this means there is no maxValue (in effect
+   * Double.MAX_VALUE or Integer.MAX_VALUE) and vice versa.
    */
   private Number minValue;
   private Number maxValue;

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
@@ -45,12 +45,12 @@ public class TemplatePropertyMetadata {
    * If minValue is set and maxValue is null, this means there is no maxValue (in effect
    * Double.MAX_VALUE or Integer.MAX_VALUE) and vice versa.
    */
-  private Number minValue;
-  private Number maxValue;
+  private Number min;
+  private Number max;
   /**
    * Should not be combined with min/maxValue
    */
-  private List<Object> allowedValues;
+  private List<Object> options;
   /**
    * Helps the UI build input fields.
    */
@@ -92,30 +92,30 @@ public class TemplatePropertyMetadata {
     return this;
   }
 
-  public Number getMinValue() {
-    return minValue;
+  public Number getMin() {
+    return min;
   }
 
-  public TemplatePropertyMetadata setMinValue(final Number minValue) {
-    this.minValue = minValue;
+  public TemplatePropertyMetadata setMin(final Number min) {
+    this.min = min;
     return this;
   }
 
-  public Number getMaxValue() {
-    return maxValue;
+  public Number getMax() {
+    return max;
   }
 
-  public TemplatePropertyMetadata setMaxValue(final Number maxValue) {
-    this.maxValue = maxValue;
+  public TemplatePropertyMetadata setMax(final Number max) {
+    this.max = max;
     return this;
   }
 
-  public List<Object> getAllowedValues() {
-    return allowedValues;
+  public List<Object> getOptions() {
+    return options;
   }
 
-  public TemplatePropertyMetadata setAllowedValues(final List<Object> allowedValues) {
-    this.allowedValues = allowedValues;
+  public TemplatePropertyMetadata setOptions(final List<Object> options) {
+    this.options = options;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.spi.template;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TemplatePropertyMetadata {
+
+  private String name;
+  private Object defaultValue;
+  /**
+   * Used to set a defaultValue to null. (defaultValue=null is interpreted as no defaultValue).
+   */
+  private boolean defaultIsNull = false;
+  /**
+   * If defaultValue is null and defaultIsNull is false, the UI can show this value as an example.
+   */
+  private Object exampleValue;
+
+  /**
+   * Helps the UI build input fields.
+   */
+  private Number minValue;
+  private Number maxValue;
+  /**
+   * Should not be combined with min/maxValue
+   */
+  private List<Object> allowedValues;
+  /**
+   * Helps the UI build input fields.
+   */
+  private JsonType jsonType;
+
+  public String getName() {
+    return name;
+  }
+
+  public TemplatePropertyMetadata setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public Object getDefaultValue() {
+    return defaultValue;
+  }
+
+  public TemplatePropertyMetadata setDefaultValue(final Object defaultValue) {
+    this.defaultValue = defaultValue;
+    return this;
+  }
+
+  public Object getExampleValue() {
+    return exampleValue;
+  }
+
+  public TemplatePropertyMetadata setExampleValue(final Object exampleValue) {
+    this.exampleValue = exampleValue;
+    return this;
+  }
+
+  public boolean isDefaultIsNull() {
+    return defaultIsNull;
+  }
+
+  public TemplatePropertyMetadata setDefaultIsNull(final boolean defaultIsNull) {
+    this.defaultIsNull = defaultIsNull;
+    return this;
+  }
+
+  public Number getMinValue() {
+    return minValue;
+  }
+
+  public TemplatePropertyMetadata setMinValue(final Number minValue) {
+    this.minValue = minValue;
+    return this;
+  }
+
+  public Number getMaxValue() {
+    return maxValue;
+  }
+
+  public TemplatePropertyMetadata setMaxValue(final Number maxValue) {
+    this.maxValue = maxValue;
+    return this;
+  }
+
+  public List<Object> getAllowedValues() {
+    return allowedValues;
+  }
+
+  public TemplatePropertyMetadata setAllowedValues(final List<Object> allowedValues) {
+    this.allowedValues = allowedValues;
+    return this;
+  }
+
+  public JsonType getJsonType() {
+    return jsonType;
+  }
+
+  public TemplatePropertyMetadata setJsonType(final JsonType jsonType) {
+    this.jsonType = jsonType;
+    return this;
+  }
+
+  /**
+   * See spec https://json-schema.org/understanding-json-schema/reference/type.html
+   */
+  public enum JsonType {
+    STRING, NUMBER, INTEGER, OBJECT, ARRAY, BOOLEAN, NULL
+  }
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/template/TemplatePropertyMetadata.java
@@ -35,10 +35,6 @@ public class TemplatePropertyMetadata {
    * Used to set a defaultValue to null. (defaultValue=null is interpreted as no defaultValue).
    */
   private boolean defaultIsNull = false;
-  /**
-   * If defaultValue is null and defaultIsNull is false, the UI can show this value as an example.
-   */
-  private Object exampleValue;
 
   /**
    * Helps the UI build input fields.
@@ -71,15 +67,6 @@ public class TemplatePropertyMetadata {
 
   public TemplatePropertyMetadata setDefaultValue(final Object defaultValue) {
     this.defaultValue = defaultValue;
-    return this;
-  }
-
-  public Object getExampleValue() {
-    return exampleValue;
-  }
-
-  public TemplatePropertyMetadata setExampleValue(final Object exampleValue) {
-    this.exampleValue = exampleValue;
     return this;
   }
 


### PR DESCRIPTION
Add more metadata to template properties.

In alert templates:
Deprecate: 
```json
"defaultProperties": {
  "varName": value
}
```

introduce: 
```json 
"properties": [
  {
    "name": "varName",
    "description": "Does this and that [markdown](link)"
    "defaultValue": "defaultVal",
    "defaultIsNull": false,
    "min": ...
    "max: ...
    "options":  ...
    "jsonType": ...
  }
],
```


Note:
- breaks the fronted @spham92 because the frontend differentiates default to mandatory variables by looking into `defaultProperties`. Need to also look into propertiesMetadata now
- We can add more fields, like javaType, recommended UI component (eg horizontal range vs numeric input box). Just want to make sure this is compatible with dimension exploration use cases @suvodeep-pyne. In particular, will this make it possible to have a "default value for enumeration"?  

Given it breaks the frontend we will migrate all templates once frontend is fixed.
A partial migration in `startree-threshold-percentile` is introduced for frontend testing.