### PR TITLE
Access control hooks for GET and DELETE

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
@@ -71,7 +71,7 @@ public abstract class CrudResource<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exte
 
   private static final Logger log = LoggerFactory.getLogger(CrudResource.class);
 
-  private static final AccessController accessController = AccessControlBuilder.build();
+  public AccessController accessController = AccessControlBuilder.build();
 
   protected final AbstractManager<DtoT> dtoManager;
   protected final ImmutableMap<String, String> apiToIndexMap;

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControl.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControl.java
@@ -1,0 +1,14 @@
+package ai.startree.thirdeye.spi.authorization;
+
+import java.net.http.HttpHeaders;
+
+public interface AccessControl {
+
+  boolean hasAccess(
+      String name,
+      String namespace,
+      EntityType entityType,
+      AccessType accessType,
+      HttpHeaders httpHeaders
+  );
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControlBuilder.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControlBuilder.java
@@ -2,7 +2,7 @@ package ai.startree.thirdeye.spi.authorization;
 
 public class AccessControlBuilder {
 
-  public static AccessControl build() {
+  public static AccessController build() {
     return new AlwaysAllow();
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControlBuilder.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControlBuilder.java
@@ -1,0 +1,8 @@
+package ai.startree.thirdeye.spi.authorization;
+
+public class AccessControlBuilder {
+
+  public static AccessControl build() {
+    return new AlwaysAllow();
+  }
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControllable.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessControllable.java
@@ -1,0 +1,14 @@
+package ai.startree.thirdeye.spi.authorization;
+
+public interface AccessControllable {
+
+  String getName();
+
+  default String getNamespace() {
+    return "default";
+  }
+
+  default EntityType getEntityType() {
+    return EntityType.Any;
+  }
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessController.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessController.java
@@ -2,7 +2,7 @@ package ai.startree.thirdeye.spi.authorization;
 
 import java.net.http.HttpHeaders;
 
-public interface AccessControl {
+public interface AccessController {
 
   boolean hasAccess(
       String name,

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessType.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessType.java
@@ -1,0 +1,5 @@
+package ai.startree.thirdeye.spi.authorization;
+
+public enum AccessType {
+  CREATE, READ, UPDATE, DELETE
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessType.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AccessType.java
@@ -1,5 +1,5 @@
 package ai.startree.thirdeye.spi.authorization;
 
 public enum AccessType {
-  CREATE, READ, UPDATE, DELETE
+  READ, UPDATE
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AlwaysAllow.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AlwaysAllow.java
@@ -2,7 +2,7 @@ package ai.startree.thirdeye.spi.authorization;
 
 import java.net.http.HttpHeaders;
 
-public class AlwaysAllow implements AccessControl {
+public class AlwaysAllow implements AccessController {
 
   @Override
   public boolean hasAccess(

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AlwaysAllow.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/AlwaysAllow.java
@@ -1,0 +1,17 @@
+package ai.startree.thirdeye.spi.authorization;
+
+import java.net.http.HttpHeaders;
+
+public class AlwaysAllow implements AccessControl {
+
+  @Override
+  public boolean hasAccess(
+      String name,
+      String namespace,
+      EntityType entityType,
+      AccessType accessType,
+      HttpHeaders httpHeaders
+  ) {
+    return true;
+  }
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/EntityType.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/EntityType.java
@@ -1,6 +1,5 @@
 package ai.startree.thirdeye.spi.authorization;
 
 public enum EntityType {
-  Any,
-  Alert, AlertTemplate
+  Any, Alert
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/EntityType.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/authorization/EntityType.java
@@ -1,0 +1,6 @@
+package ai.startree.thirdeye.spi.authorization;
+
+public enum EntityType {
+  Any,
+  Alert, AlertTemplate
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AbstractDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AbstractDTO.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.authorization.AccessControllable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.io.Serializable;
@@ -22,7 +23,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 @JsonInclude(Include.NON_NULL)
-public abstract class AbstractDTO implements Serializable {
+public abstract class AbstractDTO implements Serializable, AccessControllable {
 
   private Long id;
   private int version;
@@ -33,6 +34,11 @@ public abstract class AbstractDTO implements Serializable {
 
   public Long getId() {
     return id;
+  }
+
+  @Override
+  public String getName() {
+    return id.toString();
   }
 
   public AbstractDTO setId(final Long id) {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertDTO.java
@@ -53,6 +53,7 @@ public class AlertDTO extends AbstractDTO {
     this.owners = owners;
   }
 
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertDTO.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.authorization.EntityType;
 import ai.startree.thirdeye.spi.detection.BaseComponent;
 import ai.startree.thirdeye.spi.detection.health.DetectionHealth;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -56,6 +57,11 @@ public class AlertDTO extends AbstractDTO {
   @Override
   public String getName() {
     return name;
+  }
+
+  @Override
+  public EntityType getEntityType() {
+    return EntityType.Alert;
   }
 
   public void setName(String name) {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.authorization.EntityType;
 import ai.startree.thirdeye.spi.template.TemplatePropertyMetadata;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Date;
@@ -37,6 +38,12 @@ public class AlertTemplateDTO extends AbstractDTO {
   private Map<String, @Nullable Object> defaultProperties;
   private List<TemplatePropertyMetadata> properties;
 
+  @Override
+  public EntityType getEntityType() {
+    return EntityType.AlertTemplate;
+  }
+
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertTemplateDTO.java
@@ -13,7 +13,6 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
-import ai.startree.thirdeye.spi.authorization.EntityType;
 import ai.startree.thirdeye.spi.template.TemplatePropertyMetadata;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Date;
@@ -37,11 +36,6 @@ public class AlertTemplateDTO extends AbstractDTO {
   @Deprecated // use propertiesMetadata
   private Map<String, @Nullable Object> defaultProperties;
   private List<TemplatePropertyMetadata> properties;
-
-  @Override
-  public EntityType getEntityType() {
-    return EntityType.AlertTemplate;
-  }
 
   @Override
   public String getName() {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DataSourceDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DataSourceDTO.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.authorization.EntityType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,6 +31,7 @@ public class DataSourceDTO extends AbstractDTO {
   private Map<String, Object> properties = new HashMap<>();
   private List<DataSourceMetaBean> metaList = new ArrayList<>();
 
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DataSourceDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DataSourceDTO.java
@@ -13,7 +13,6 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
-import ai.startree.thirdeye.spi.authorization.EntityType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/EnumerationItemDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/EnumerationItemDTO.java
@@ -29,6 +29,7 @@ public class EnumerationItemDTO extends AbstractDTO {
   private Map<String, Object> params;
   private List<AlertDTO> alerts;
 
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/EventDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/EventDTO.java
@@ -37,6 +37,7 @@ public class EventDTO extends AbstractDTO {
    */
   Map<String, List<String>> targetDimensionMap;
 
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/MetricConfigDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/MetricConfigDTO.java
@@ -60,6 +60,7 @@ public class MetricConfigDTO extends AbstractDTO {
     this.datasetConfig = datasetConfig;
   }
 
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/RcaInvestigationDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/RcaInvestigationDTO.java
@@ -37,6 +37,7 @@ public class RcaInvestigationDTO extends AbstractDTO {
   private Long analysisRangeStart;
   private Long analysisRangeEnd;
 
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/RootcauseTemplateDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/RootcauseTemplateDTO.java
@@ -25,6 +25,7 @@ public class RootcauseTemplateDTO extends AbstractDTO {
   long metricId;
   List<Map<String, Object>> modules;
 
+  @Override
   public String getName() {
     return name;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/SubscriptionGroupDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/SubscriptionGroupDTO.java
@@ -52,6 +52,7 @@ public class SubscriptionGroupDTO extends AbstractDTO {
     return this;
   }
 
+  @Override
   public String getName() {
     return name;
   }


### PR DESCRIPTION
Jira: https://cortexdata.atlassian.net/browse/TE-1096

This change adds access control hooks for getting and deleting ThirdEye generic resources. I'm saving the PUT/POST methods and resource specific methods for subsequent prs.

The hooks check that the requester has access to do whatever operation. The access control check always returns true, so no API behavior is changed.


