### PR TITLE
te 1172 fix access control npe

### DIFF
--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
@@ -246,6 +246,17 @@ public class HappyPathTest {
   }
 
   @Test(dependsOnMethods = "testGetAnomalies")
+  public void testEvaluateWithAlertIdOnly() {
+    // corresponds to the evaluate call performed from an anomaly page - only the alertId is passed
+    final AlertEvaluationApi alertEvaluationApi = alertEvaluationApi(new AlertApi().setId(alertId),
+        PAGEVIEWS_DATASET_START_TIME, EVALUATE_END_TIME);
+
+    final Response response = request("api/alerts/evaluate").post(Entity.json(alertEvaluationApi));
+    assertThat(response.getStatus()).isEqualTo(200);
+
+  }
+
+  @Test(dependsOnMethods = "testGetAnomalies")
   public void testAnomalyFeedback() {
     final Response responseBeforeFeedback = request("api/anomalies/" + anomalyId).get();
     assertThat(responseBeforeFeedback.getStatus()).isEqualTo(200);

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -14,8 +14,6 @@
 package ai.startree.thirdeye.auth;
 
 import ai.startree.thirdeye.alert.AlertTemplateRenderer;
-import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
-import ai.startree.thirdeye.spi.datalayer.bao.AlertTemplateManager;
 import ai.startree.thirdeye.spi.datalayer.dto.AbstractDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
@@ -29,18 +27,15 @@ import javax.ws.rs.core.Response.Status;
 
 public class AuthorizationManager {
 
-  public final AlertManager alertManager;
-  public final AlertTemplateManager alertTemplateManager;
-  public final AccessControl accessControl;
+  private final AlertTemplateRenderer alertTemplateRenderer;
+  private final AccessControl accessControl;
 
   @Inject
   public AuthorizationManager(
-      final AlertManager alertManager,
-      final AlertTemplateManager alertTemplateManager,
+      final AlertTemplateRenderer alertTemplateRenderer,
       final AccessControl accessControl
   ) {
-    this.alertManager = alertManager;
-    this.alertTemplateManager = alertTemplateManager;
+    this.alertTemplateRenderer = alertTemplateRenderer;
     this.accessControl = accessControl;
   }
 
@@ -92,8 +87,7 @@ public class AuthorizationManager {
   private <T extends AbstractDTO> List<ResourceIdentifier> relatedEntities(T entity) {
     if (entity instanceof AlertDTO) {
       final AlertDTO alertDto = (AlertDTO) entity;
-      final AlertTemplateDTO alertTemplateDTO = new AlertTemplateRenderer(
-          alertManager, alertTemplateManager).getTemplate(alertDto.getTemplate());
+      final AlertTemplateDTO alertTemplateDTO = alertTemplateRenderer.getTemplate(alertDto.getTemplate());
       return Collections.singletonList(ResourceIdentifier.from(alertTemplateDTO));
     }
     return new ArrayList<>();

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -236,7 +236,6 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
     ensureExists(alert)
         .setOwner(new UserApi()
             .setPrincipal(principal.getName()));
-    // fixme jackson cyril quickfix for TE-1172 - need redesign - is it authorizationManager or its consumer that is responsible for fetching the complete DTO?
     final AlertDTO alertDTO = optional(alert.getId()).map(this::get).orElseGet(() -> toDto(alert));
     authorizationManager.ensureCanEvaluate(principal, alertDTO);
     return Response.ok(alertEvaluator.evaluate(request)).build();

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -214,7 +214,7 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
       final AlertDTO existing =
           api.getId() == null ? null : ensureExists(dtoManager.findById(api.getId()));
       validate(api, existing);
-      authorizationManager.ensureCanValidate(principal, toDto(api));
+      authorizationManager.ensureCanValidate(principal, optional(existing).orElse(toDto(api)));
     }
 
     return Response.ok().build();
@@ -236,7 +236,9 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
     ensureExists(alert)
         .setOwner(new UserApi()
             .setPrincipal(principal.getName()));
-    authorizationManager.ensureCanEvaluate(principal, toDto(alert));
+    // fixme jackson cyril quickfix for TE-1172 - need redesign - is it authorizationManager or its consumer that is responsible for fetching the complete DTO?
+    final AlertDTO alertDTO = optional(alert.getId()).map(this::get).orElseGet(() -> toDto(alert));
+    authorizationManager.ensureCanEvaluate(principal, alertDTO);
     return Response.ok(alertEvaluator.evaluate(request)).build();
   }
 

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -236,6 +236,7 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
     ensureExists(alert)
         .setOwner(new UserApi()
             .setPrincipal(principal.getName()));
+    // see TE-1172 - ensure the dto passed to the authManager is complete, not only a reference {id:1234}
     final AlertDTO alertDTO = optional(alert.getId()).map(this::get).orElseGet(() -> toDto(alert));
     authorizationManager.ensureCanEvaluate(principal, alertDTO);
     return Response.ok(alertEvaluator.evaluate(request)).build();

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
@@ -22,6 +22,7 @@ import ai.startree.thirdeye.alert.AlertCreater;
 import ai.startree.thirdeye.alert.AlertDeleter;
 import ai.startree.thirdeye.alert.AlertEvaluator;
 import ai.startree.thirdeye.alert.AlertInsightsProvider;
+import ai.startree.thirdeye.alert.AlertTemplateRenderer;
 import ai.startree.thirdeye.auth.AccessControl;
 import ai.startree.thirdeye.auth.AccessControlModule;
 import ai.startree.thirdeye.auth.AccessType;
@@ -104,6 +105,8 @@ public class AlertResourceTest {
     final AlertTemplateManager alertTemplateManager = mock(AlertTemplateManager.class);
     when(alertTemplateManager.findById(2L))
         .thenReturn(((AlertTemplateDTO) new AlertTemplateDTO().setId(2L)).setName("template1"));
+    final AlertTemplateRenderer alertTemplateRenderer = new AlertTemplateRenderer(
+        mock(AlertManager.class), alertTemplateManager);
 
     final AccessControl accessControl = (ThirdEyePrincipal principal, ResourceIdentifier identifier, AccessType accessType)
         -> identifier.name.equals("0");
@@ -116,8 +119,7 @@ public class AlertResourceTest {
         mock(AppAnalyticsService.class),
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
-            mock(AlertManager.class),
-            alertTemplateManager,
+            alertTemplateRenderer,
             accessControl
         )
     ).createMultiple(nobody(), Collections.singletonList(
@@ -129,6 +131,8 @@ public class AlertResourceTest {
   public void testRunTask_withNoAccess() {
     final AlertManager alertManager = mock(AlertManager.class);
     when(alertManager.findById(1L)).thenReturn((AlertDTO) new AlertDTO().setId(1L));
+    final AlertTemplateRenderer alertTemplateRenderer = new AlertTemplateRenderer(alertManager,
+        mock(AlertTemplateManager.class));
 
     new AlertResource(
         alertManager,
@@ -138,8 +142,7 @@ public class AlertResourceTest {
         mock(AppAnalyticsService.class),
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
-            alertManager,
-            mock(AlertTemplateManager.class),
+            alertTemplateRenderer,
             AccessControlModule.alwaysDeny
         )
     ).runTask(nobody(), 1L, 0L, 1L);
@@ -155,8 +158,7 @@ public class AlertResourceTest {
         mock(AppAnalyticsService.class),
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
-            mock(AlertManager.class),
-            mock(AlertTemplateManager.class),
+            mock(AlertTemplateRenderer.class),
             AccessControlModule.alwaysDeny
         )
     ).validateMultiple(
@@ -172,6 +174,7 @@ public class AlertResourceTest {
     final AlertTemplateManager alertTemplateManager = mock(AlertTemplateManager.class);
     when(alertTemplateManager.findById(1L))
         .thenReturn(((AlertTemplateDTO) new AlertTemplateDTO().setId(1L)).setName("template1"));
+    final AlertTemplateRenderer alertTemplateRenderer = new AlertTemplateRenderer(mock(AlertManager.class),alertTemplateManager);
 
     final AccessControl accessControl = (ThirdEyePrincipal principal, ResourceIdentifier identifier, AccessType accessType)
         -> identifier.name.equals("alert1");
@@ -184,8 +187,7 @@ public class AlertResourceTest {
         mock(AppAnalyticsService.class),
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
-            mock(AlertManager.class),
-            alertTemplateManager,
+            alertTemplateRenderer,
             accessControl
         )
     ).validateMultiple(
@@ -199,8 +201,10 @@ public class AlertResourceTest {
   @Test(expectedExceptions = ForbiddenException.class)
   public void testEvaluate_withNoAccessToTemplate() throws ExecutionException {
     final AlertTemplateManager alertTemplateManager = mock(AlertTemplateManager.class);
-    when(alertTemplateManager.findById(1L)).thenReturn((AlertTemplateDTO) new AlertTemplateDTO().setId(
-        1L));
+    when(alertTemplateManager.findById(1L)).thenReturn(
+        (AlertTemplateDTO) new AlertTemplateDTO().setId(
+            1L));
+    final AlertTemplateRenderer alertTemplateRenderer = new AlertTemplateRenderer(mock(AlertManager.class), alertTemplateManager);
 
     new AlertResource(
         mock(AlertManager.class),
@@ -210,8 +214,7 @@ public class AlertResourceTest {
         mock(AppAnalyticsService.class),
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
-            mock(AlertManager.class),
-            alertTemplateManager,
+            alertTemplateRenderer,
             AccessControlModule.alwaysDeny
         )
     ).evaluate(nobody(),
@@ -226,6 +229,7 @@ public class AlertResourceTest {
   public void testReset_withNoAccess() {
     final AlertManager alertManager = mock(AlertManager.class);
     when(alertManager.findById(1L)).thenReturn((AlertDTO) new AlertDTO().setId(1L));
+    final AlertTemplateRenderer alertTemplateRenderer = new AlertTemplateRenderer(alertManager, mock(AlertTemplateManager.class));
 
     new AlertResource(
         alertManager,
@@ -235,8 +239,7 @@ public class AlertResourceTest {
         mock(AppAnalyticsService.class),
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
-            alertManager,
-            mock(AlertTemplateManager.class),
+            alertTemplateRenderer,
             AccessControlModule.alwaysDeny
         )
     ).reset(nobody(), 1L);

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/CrudResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/CrudResourceTest.java
@@ -20,18 +20,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ai.startree.thirdeye.alert.AlertTemplateRenderer;
 import ai.startree.thirdeye.auth.AccessControl;
 import ai.startree.thirdeye.auth.AccessControlModule;
+import ai.startree.thirdeye.auth.AccessType;
 import ai.startree.thirdeye.auth.AuthorizationManager;
+import ai.startree.thirdeye.auth.ResourceIdentifier;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
 import ai.startree.thirdeye.auth.oauth.OidcBindingsCache;
 import ai.startree.thirdeye.datalayer.bao.AbstractManagerImpl;
 import ai.startree.thirdeye.datalayer.dao.GenericPojoDao;
 import ai.startree.thirdeye.spi.api.ThirdEyeCrudApi;
-import ai.startree.thirdeye.auth.ResourceIdentifier;
-import ai.startree.thirdeye.auth.AccessType;
-import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
-import ai.startree.thirdeye.spi.datalayer.bao.AlertTemplateManager;
 import ai.startree.thirdeye.spi.datalayer.dto.AbstractDTO;
 import com.google.common.collect.ImmutableMap;
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
@@ -365,7 +364,7 @@ class DummyResource extends CrudResource<DummyApi, DummyDto> {
     final ImmutableMap<String, String> apiToBeanMap,
     final AccessControl accessControl) {
     super(dtoManager, apiToBeanMap, new AuthorizationManager(
-        mock(AlertManager.class), mock(AlertTemplateManager.class), accessControl));
+        mock(AlertTemplateRenderer.class), accessControl));
   }
 
   @Override

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ai.startree.thirdeye.alert.AlertTemplateRenderer;
 import ai.startree.thirdeye.auth.AccessControlModule;
 import ai.startree.thirdeye.auth.AuthorizationManager;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
@@ -25,8 +26,6 @@ import ai.startree.thirdeye.datasource.cache.DataSourceCache;
 import ai.startree.thirdeye.spi.ThirdEyeStatus;
 import ai.startree.thirdeye.spi.api.StatusApi;
 import ai.startree.thirdeye.spi.api.StatusListApi;
-import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
-import ai.startree.thirdeye.spi.datalayer.bao.AlertTemplateManager;
 import ai.startree.thirdeye.spi.datalayer.bao.DataSourceManager;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSource;
 import javax.ws.rs.core.Response;
@@ -49,8 +48,7 @@ public class DataSourceResourceTest {
         dataSourceCache,
         mock(DataSourceOnboarder.class),
         new AuthorizationManager(
-            mock(AlertManager.class),
-            mock(AlertTemplateManager.class),
+            mock(AlertTemplateRenderer.class),
             AccessControlModule.alwaysAllow
         )
         );


### PR DESCRIPTION
Note: 

- in https://github.com/startreedata/thirdeye/pull/860/files#diff-bb8afb0991edd6ea1a1df622969ccbfec1f23bcb88882f88c888416a144e8af1 the transformation from incomplete DTO to complete DTO is made by the resource
- in https://github.com/startreedata/thirdeye/pull/860/files#diff-9fd90e5ff69e9a40acedb4864d6baa0d480df290cc18ca613f7866a5446bf6a7R89 the transformation from incomplete DTO to complete DTO is made by the authorizationManager 

--> it's not clear yet to me which level should be responsible for this @jacksonargo. I think this will be an important design consideration to avoid bugs.  