### PR TITLE
relatedEntities() returns empty list if alert template is null

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -94,7 +94,9 @@ public class AuthorizationManager {
       final AlertDTO alertDto = (AlertDTO) entity;
       final AlertTemplateDTO alertTemplateDTO = new AlertTemplateRenderer(
           alertManager, alertTemplateManager).getTemplate(alertDto.getTemplate());
-      return Collections.singletonList(ResourceIdentifier.from(alertTemplateDTO));
+      if (alertTemplateDTO != null) {
+        return Collections.singletonList(ResourceIdentifier.from(alertTemplateDTO));
+      }
     }
     return new ArrayList<>();
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -236,7 +236,7 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
     ensureExists(alert)
         .setOwner(new UserApi()
             .setPrincipal(principal.getName()));
-    authorizationManager.ensureCanEvaluate(principal, toDto(alert));
+    authorizationManager.ensureCanEvaluate(principal, get(alert.getId()));
     return Response.ok(alertEvaluator.evaluate(request)).build();
   }
 


### PR DESCRIPTION
Fixes issue in https://github.com/startreedata/thirdeye/pull/845#discussion_r1060453161
