### PR TITLE
Add plugin method to set up access control

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye;
 import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static java.util.Objects.requireNonNull;
 
+import ai.startree.thirdeye.auth.AccessControlProvider;
 import ai.startree.thirdeye.core.BootstrapResourcesRegistry;
 import ai.startree.thirdeye.datasource.DataSourcesLoader;
 import ai.startree.thirdeye.detectionpipeline.DetectionRegistry;
@@ -65,6 +66,7 @@ public class PluginLoader {
   private final ContributorsFinderRunner contributorsFinderRunner;
   private final BootstrapResourcesRegistry bootstrapResourcesRegistry;
   private final PostProcessorRegistry postProcessorRegistry;
+  private final AccessControlProvider accessControlProvider;
 
   private final AtomicBoolean loading = new AtomicBoolean();
   private final File pluginsDir;
@@ -77,13 +79,15 @@ public class PluginLoader {
       final ContributorsFinderRunner contributorsFinderRunner,
       final BootstrapResourcesRegistry bootstrapResourcesRegistry,
       final PostProcessorRegistry postProcessorRegistry,
-      final PluginLoaderConfiguration config) {
+      final PluginLoaderConfiguration config,
+      final AccessControlProvider accessControlProvider) {
     this.dataSourcesLoader = dataSourcesLoader;
     this.detectionRegistry = detectionRegistry;
     this.notificationServiceRegistry = notificationServiceRegistry;
     this.contributorsFinderRunner = contributorsFinderRunner;
     this.bootstrapResourcesRegistry = bootstrapResourcesRegistry;
     this.postProcessorRegistry = postProcessorRegistry;
+    this.accessControlProvider = accessControlProvider;
     pluginsDir = new File(config.getPluginsPath());
   }
 
@@ -143,6 +147,7 @@ public class PluginLoader {
     for (EnumeratorFactory f : plugin.getEnumeratorFactories()) {
       detectionRegistry.addEnumeratorFactory(f);
     }
+    optional(plugin.getAccessControl()).ifPresent(accessControlProvider::set);
 
     log.info("Installed plugin: " + plugin.getClass().getName());
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
@@ -79,8 +79,8 @@ public class PluginLoader {
       final ContributorsFinderRunner contributorsFinderRunner,
       final BootstrapResourcesRegistry bootstrapResourcesRegistry,
       final PostProcessorRegistry postProcessorRegistry,
-      final PluginLoaderConfiguration config,
-      final AccessControlProvider accessControlProvider) {
+      final AccessControlProvider accessControlProvider,
+      final PluginLoaderConfiguration config) {
     this.dataSourcesLoader = dataSourcesLoader;
     this.detectionRegistry = detectionRegistry;
     this.notificationServiceRegistry = notificationServiceRegistry;
@@ -147,8 +147,10 @@ public class PluginLoader {
     for (EnumeratorFactory f : plugin.getEnumeratorFactories()) {
       detectionRegistry.addEnumeratorFactory(f);
     }
-    optional(plugin.getAccessControl(accessControlProvider.getConfig()))
-        .ifPresent(accessControlProvider::setAccessControl);
+    if (accessControlProvider.getConfig().enabled) {
+      optional(plugin.getAccessControl(accessControlProvider.getConfig()))
+          .ifPresent(accessControlProvider::setAccessControl);
+    }
 
     log.info("Installed plugin: " + plugin.getClass().getName());
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
@@ -35,12 +35,14 @@ import ai.startree.thirdeye.spi.notification.NotificationServiceFactory;
 import ai.startree.thirdeye.spi.rca.ContributorsFinderFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -67,6 +69,7 @@ public class PluginLoader {
   private final BootstrapResourcesRegistry bootstrapResourcesRegistry;
   private final PostProcessorRegistry postProcessorRegistry;
   private final AccessControlProvider accessControlProvider;
+  private final Map<String,Object> accessControlConfiguration;
 
   private final AtomicBoolean loading = new AtomicBoolean();
   private final File pluginsDir;
@@ -80,7 +83,8 @@ public class PluginLoader {
       final BootstrapResourcesRegistry bootstrapResourcesRegistry,
       final PostProcessorRegistry postProcessorRegistry,
       final PluginLoaderConfiguration config,
-      final AccessControlProvider accessControlProvider) {
+      final AccessControlProvider accessControlProvider,
+      @Named("AccessControlConfiguration") final Map<String,Object> accessControlConfiguration) {
     this.dataSourcesLoader = dataSourcesLoader;
     this.detectionRegistry = detectionRegistry;
     this.notificationServiceRegistry = notificationServiceRegistry;
@@ -88,7 +92,10 @@ public class PluginLoader {
     this.bootstrapResourcesRegistry = bootstrapResourcesRegistry;
     this.postProcessorRegistry = postProcessorRegistry;
     this.accessControlProvider = accessControlProvider;
+    this.accessControlConfiguration = accessControlConfiguration;
     pluginsDir = new File(config.getPluginsPath());
+
+    System.out.println(accessControlConfiguration);
   }
 
   public void loadPlugins() {
@@ -147,7 +154,7 @@ public class PluginLoader {
     for (EnumeratorFactory f : plugin.getEnumeratorFactories()) {
       detectionRegistry.addEnumeratorFactory(f);
     }
-    optional(plugin.getAccessControl()).ifPresent(accessControlProvider::set);
+    optional(plugin.getAccessControl(accessControlConfiguration)).ifPresent(accessControlProvider::set);
 
     log.info("Installed plugin: " + plugin.getClass().getName());
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/PluginLoader.java
@@ -35,14 +35,12 @@ import ai.startree.thirdeye.spi.notification.NotificationServiceFactory;
 import ai.startree.thirdeye.spi.rca.ContributorsFinderFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.google.inject.name.Named;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -69,7 +67,6 @@ public class PluginLoader {
   private final BootstrapResourcesRegistry bootstrapResourcesRegistry;
   private final PostProcessorRegistry postProcessorRegistry;
   private final AccessControlProvider accessControlProvider;
-  private final Map<String,Object> accessControlConfiguration;
 
   private final AtomicBoolean loading = new AtomicBoolean();
   private final File pluginsDir;
@@ -83,8 +80,7 @@ public class PluginLoader {
       final BootstrapResourcesRegistry bootstrapResourcesRegistry,
       final PostProcessorRegistry postProcessorRegistry,
       final PluginLoaderConfiguration config,
-      final AccessControlProvider accessControlProvider,
-      @Named("AccessControlConfiguration") final Map<String,Object> accessControlConfiguration) {
+      final AccessControlProvider accessControlProvider) {
     this.dataSourcesLoader = dataSourcesLoader;
     this.detectionRegistry = detectionRegistry;
     this.notificationServiceRegistry = notificationServiceRegistry;
@@ -92,10 +88,7 @@ public class PluginLoader {
     this.bootstrapResourcesRegistry = bootstrapResourcesRegistry;
     this.postProcessorRegistry = postProcessorRegistry;
     this.accessControlProvider = accessControlProvider;
-    this.accessControlConfiguration = accessControlConfiguration;
     pluginsDir = new File(config.getPluginsPath());
-
-    System.out.println(accessControlConfiguration);
   }
 
   public void loadPlugins() {
@@ -154,7 +147,8 @@ public class PluginLoader {
     for (EnumeratorFactory f : plugin.getEnumeratorFactories()) {
       detectionRegistry.addEnumeratorFactory(f);
     }
-    optional(plugin.getAccessControl(accessControlConfiguration)).ifPresent(accessControlProvider::set);
+    optional(plugin.getAccessControl(accessControlProvider.getConfig()))
+        .ifPresent(accessControlProvider::setAccessControl);
 
     log.info("Installed plugin: " + plugin.getClass().getName());
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
@@ -51,6 +51,7 @@ public class ThirdEyeServerModule extends AbstractModule {
   private final ThirdEyeServerConfiguration configuration;
   private final DataSource dataSource;
   private final MetricRegistry metricRegistry;
+  private final AccessControlProvider accessControlProvider;
 
   public ThirdEyeServerModule(
       final ThirdEyeServerConfiguration configuration,
@@ -59,6 +60,9 @@ public class ThirdEyeServerModule extends AbstractModule {
     this.configuration = configuration;
     this.dataSource = dataSource;
     this.metricRegistry = metricRegistry;
+
+    this.accessControlProvider = new AccessControlProvider(
+        configuration.getAccessControlConfiguration());
   }
 
   @Override
@@ -75,11 +79,6 @@ public class ThirdEyeServerModule extends AbstractModule {
     bind(AuthConfiguration.class).toInstance(configuration.getAuthConfiguration());
     bind(MetricRegistry.class).toInstance(metricRegistry);
     bind(ThirdEyeServerConfiguration.class).toInstance(configuration);
-
-    final AccessControlProvider accessControlProvider = new AccessControlProvider(
-        configuration.getAccessControlConfiguration());
-    bind(AccessControlProvider.class).toInstance(accessControlProvider);
-    bind(AccessControl.class).toInstance(accessControlProvider);
   }
 
   @Singleton
@@ -152,5 +151,17 @@ public class ThirdEyeServerModule extends AbstractModule {
         .setAuthenticator(authenticator)
         .setPrefix(AUTH_BASIC)
         .buildAuthFilter();
+  }
+
+  @Singleton
+  @Provides
+  public AccessControlProvider getAccessControlProvider() {
+    return this.accessControlProvider;
+  }
+
+  @Singleton
+  @Provides
+  public AccessControl getAccessControl() {
+    return this.accessControlProvider;
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
@@ -37,15 +37,12 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.TypeLiteral;
-import com.google.inject.name.Names;
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.auth.chained.ChainedAuthFilter;
 import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.tomcat.jdbc.pool.DataSource;
 
@@ -79,12 +76,10 @@ public class ThirdEyeServerModule extends AbstractModule {
     bind(MetricRegistry.class).toInstance(metricRegistry);
     bind(ThirdEyeServerConfiguration.class).toInstance(configuration);
 
-    final AccessControlProvider accessControlProvider = new AccessControlProvider();
+    final AccessControlProvider accessControlProvider = new AccessControlProvider(
+        configuration.getAccessControlConfiguration());
     bind(AccessControlProvider.class).toInstance(accessControlProvider);
-    bind(AccessControl.class).toProvider(accessControlProvider);
-    bind(new TypeLiteral<Map<String,Object>>() {})
-        .annotatedWith(Names.named("AccessControlConfiguration"))
-        .toInstance(configuration.getAccessControlConfiguration());
+    bind(AccessControl.class).toInstance(accessControlProvider);
   }
 
   @Singleton

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
@@ -37,12 +37,15 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.auth.chained.ChainedAuthFilter;
 import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.tomcat.jdbc.pool.DataSource;
 
@@ -79,6 +82,9 @@ public class ThirdEyeServerModule extends AbstractModule {
     final AccessControlProvider accessControlProvider = new AccessControlProvider();
     bind(AccessControlProvider.class).toInstance(accessControlProvider);
     bind(AccessControl.class).toProvider(accessControlProvider);
+    bind(new TypeLiteral<Map<String,Object>>() {})
+        .annotatedWith(Names.named("AccessControlConfiguration"))
+        .toInstance(configuration.getAccessControlConfiguration());
   }
 
   @Singleton

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
@@ -17,7 +17,7 @@ import static ai.startree.thirdeye.spi.Constants.AUTH_BASIC;
 import static ai.startree.thirdeye.spi.Constants.AUTH_BEARER;
 import static com.google.common.base.Preconditions.checkState;
 
-import ai.startree.thirdeye.auth.AccessControlModule;
+import ai.startree.thirdeye.auth.AccessControlProvider;
 import ai.startree.thirdeye.auth.AuthConfiguration;
 import ai.startree.thirdeye.auth.ThirdEyeAuthenticatorDisabled;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
@@ -30,6 +30,7 @@ import ai.startree.thirdeye.detectionpipeline.ThirdEyeDetectionPipelineModule;
 import ai.startree.thirdeye.notification.ThirdEyeNotificationModule;
 import ai.startree.thirdeye.scheduler.ThirdEyeSchedulerModule;
 import ai.startree.thirdeye.scheduler.events.MockEventsConfiguration;
+import ai.startree.thirdeye.spi.accessControl.AccessControl;
 import ai.startree.thirdeye.worker.ThirdEyeWorkerModule;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
@@ -71,11 +72,13 @@ public class ThirdEyeServerModule extends AbstractModule {
     install(new ThirdEyeDetectionPipelineModule(configuration.getDetectionPipelineConfiguration()));
     install(new ThirdEyeWorkerModule(configuration.getTaskDriverConfiguration()));
     install(new ThirdEyeSchedulerModule(configuration.getSchedulerConfiguration()));
-    install(new AccessControlModule());
-
     bind(AuthConfiguration.class).toInstance(configuration.getAuthConfiguration());
     bind(MetricRegistry.class).toInstance(metricRegistry);
     bind(ThirdEyeServerConfiguration.class).toInstance(configuration);
+
+    final AccessControlProvider accessControlProvider = new AccessControlProvider();
+    bind(AccessControlProvider.class).toInstance(accessControlProvider);
+    bind(AccessControl.class).toProvider(accessControlProvider);
   }
 
   @Singleton

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AccessControlProvider.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AccessControlProvider.java
@@ -14,27 +14,37 @@
 
 package ai.startree.thirdeye.auth;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 
-public class AccessControlModule extends AbstractModule {
+import ai.startree.thirdeye.spi.accessControl.AccessControl;
+import ai.startree.thirdeye.spi.accessControl.AccessType;
+import ai.startree.thirdeye.spi.accessControl.ResourceIdentifier;
+import com.google.inject.Provider;
+
+public class AccessControlProvider implements Provider<AccessControl> {
 
   public final static AccessControl alwaysAllow = (
-      final ThirdEyePrincipal principal,
+      final String token,
       final ResourceIdentifier identifiers,
       final AccessType accessType
   ) -> true;
 
   public final static AccessControl alwaysDeny = (
-      final ThirdEyePrincipal principal,
+      final String token,
       final ResourceIdentifier identifiers,
       final AccessType accessType
   ) -> false;
 
-  @Singleton
-  @Provides
-  public AccessControl provideAccessControl() {
-    return alwaysAllow;
+  private AccessControl accessControl = null;
+
+  public void set(AccessControl accessControl) {
+    if (this.accessControl != null) {
+      throw new RuntimeException("Access control source can only be set once!");
+    }
+    this.accessControl = accessControl;
+  }
+
+  public AccessControl get() {
+    return optional(this.accessControl).orElse(alwaysAllow);
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AccessControlProvider.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AccessControlProvider.java
@@ -14,13 +14,16 @@
 
 package ai.startree.thirdeye.auth;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import ai.startree.thirdeye.spi.accessControl.AccessControl;
 import ai.startree.thirdeye.spi.accessControl.AccessControlConfiguration;
 import ai.startree.thirdeye.spi.accessControl.AccessType;
 import ai.startree.thirdeye.spi.accessControl.ResourceIdentifier;
 
 /**
- * AccessControlProvider serves as a mutable layer between Guice bindings and the access control implementation from plugins.
+ * AccessControlProvider serves as a mutable layer between Guice bindings and the access control
+ * implementation from plugins.
  */
 public class AccessControlProvider implements AccessControl {
 
@@ -55,9 +58,8 @@ public class AccessControlProvider implements AccessControl {
       return alwaysAllow;
     }
 
-    if (this.accessControl == null) {
-      throw new RuntimeException("Access control is enabled, but no provider has been configured!");
-    }
+    checkState(this.accessControl != null,
+        "Access control is enabled, but no provider has been configured!");
     return this.accessControl;
   }
 

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -13,7 +13,16 @@
  */
 package ai.startree.thirdeye.auth;
 
+import static ai.startree.thirdeye.spi.accessControl.ResourceIdentifier.DEFAULT_ENTITY_TYPE;
+import static ai.startree.thirdeye.spi.accessControl.ResourceIdentifier.DEFAULT_NAME;
+import static ai.startree.thirdeye.spi.accessControl.ResourceIdentifier.DEFAULT_NAMESPACE;
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+
 import ai.startree.thirdeye.alert.AlertTemplateRenderer;
+import ai.startree.thirdeye.datalayer.dao.SubEntities;
+import ai.startree.thirdeye.spi.accessControl.AccessControl;
+import ai.startree.thirdeye.spi.accessControl.AccessType;
+import ai.startree.thirdeye.spi.accessControl.ResourceIdentifier;
 import ai.startree.thirdeye.spi.datalayer.dto.AbstractDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
@@ -21,6 +30,7 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -41,27 +51,27 @@ public class AuthorizationManager {
 
   public <T extends AbstractDTO> void ensureCanCreate(final ThirdEyePrincipal principal,
       final T entity) {
-    ensureHasAccess(principal, ResourceIdentifier.from(entity), AccessType.UPDATE);
+    ensureHasAccess(principal, dtoToId(entity), AccessType.WRITE);
     relatedEntities(entity).forEach(relatedId ->
         ensureHasAccess(principal, relatedId, AccessType.READ));
   }
 
   public <T extends AbstractDTO> void ensureCanDelete(final ThirdEyePrincipal principal,
       final T entity) {
-    ensureHasAccess(principal, ResourceIdentifier.from(entity), AccessType.UPDATE);
+    ensureHasAccess(principal, dtoToId(entity), AccessType.WRITE);
   }
 
   public <T extends AbstractDTO> void ensureCanEdit(final ThirdEyePrincipal principal,
       final T before, final T after) {
-    ensureHasAccess(principal, ResourceIdentifier.from(before), AccessType.UPDATE);
-    ensureHasAccess(principal, ResourceIdentifier.from(after), AccessType.UPDATE);
+    ensureHasAccess(principal, dtoToId(before), AccessType.WRITE);
+    ensureHasAccess(principal, dtoToId(after), AccessType.WRITE);
     relatedEntities(after).forEach(related ->
         ensureHasAccess(principal, related, AccessType.READ));
   }
 
   public <T extends AbstractDTO> void ensureCanRead(final ThirdEyePrincipal principal,
       final T entity) {
-    ensureHasAccess(principal, ResourceIdentifier.from(entity), AccessType.READ);
+    ensureHasAccess(principal, dtoToId(entity), AccessType.READ);
   }
 
   public void ensureCanEvaluate(final ThirdEyePrincipal principal, final AlertDTO entity) {
@@ -72,6 +82,11 @@ public class AuthorizationManager {
     ensureCanCreate(principal, entity);
   }
 
+  public <T extends AbstractDTO> void ensureHasAccess(final ThirdEyePrincipal principal,
+      final T entity, final AccessType accessType) {
+    ensureHasAccess(principal, dtoToId(entity), accessType);
+  }
+
   public void ensureHasAccess(final ThirdEyePrincipal principal,
       final ResourceIdentifier identifier, final AccessType accessType) {
     if (!hasAccess(principal, identifier, accessType)) {
@@ -79,16 +94,29 @@ public class AuthorizationManager {
     }
   }
 
+  public <T extends AbstractDTO> boolean hasAccess(final ThirdEyePrincipal principal,
+      final T entity, final AccessType accessType) {
+    return hasAccess(principal, dtoToId(entity), accessType);
+  }
+
   public boolean hasAccess(final ThirdEyePrincipal principal,
       final ResourceIdentifier identifier, final AccessType accessType) {
-    return accessControl.hasAccess(principal, identifier, accessType);
+    return accessControl.hasAccess(principal.authToken, identifier, accessType);
+  }
+
+  static public <T extends AbstractDTO> ResourceIdentifier dtoToId(final T dto) {
+    return ResourceIdentifier.from(
+        optional(dto.getId()).map(Objects::toString).orElse(DEFAULT_NAME),
+        optional(dto.getNamespace()).orElse(DEFAULT_NAMESPACE),
+        optional(SubEntities.BEAN_TYPE_MAP.get(dto.getClass()))
+            .map(Objects::toString).orElse(DEFAULT_ENTITY_TYPE));
   }
 
   private <T extends AbstractDTO> List<ResourceIdentifier> relatedEntities(T entity) {
     if (entity instanceof AlertDTO) {
       final AlertDTO alertDto = (AlertDTO) entity;
       final AlertTemplateDTO alertTemplateDTO = alertTemplateRenderer.getTemplate(alertDto.getTemplate());
-      return Collections.singletonList(ResourceIdentifier.from(alertTemplateDTO));
+      return Collections.singletonList(dtoToId(alertTemplateDTO));
     }
     return new ArrayList<>();
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -51,27 +51,27 @@ public class AuthorizationManager {
 
   public <T extends AbstractDTO> void ensureCanCreate(final ThirdEyePrincipal principal,
       final T entity) {
-    ensureHasAccess(principal, dtoToId(entity), AccessType.WRITE);
+    ensureHasAccess(principal, resourceId(entity), AccessType.WRITE);
     relatedEntities(entity).forEach(relatedId ->
         ensureHasAccess(principal, relatedId, AccessType.READ));
   }
 
   public <T extends AbstractDTO> void ensureCanDelete(final ThirdEyePrincipal principal,
       final T entity) {
-    ensureHasAccess(principal, dtoToId(entity), AccessType.WRITE);
+    ensureHasAccess(principal, resourceId(entity), AccessType.WRITE);
   }
 
   public <T extends AbstractDTO> void ensureCanEdit(final ThirdEyePrincipal principal,
       final T before, final T after) {
-    ensureHasAccess(principal, dtoToId(before), AccessType.WRITE);
-    ensureHasAccess(principal, dtoToId(after), AccessType.WRITE);
+    ensureHasAccess(principal, resourceId(before), AccessType.WRITE);
+    ensureHasAccess(principal, resourceId(after), AccessType.WRITE);
     relatedEntities(after).forEach(related ->
         ensureHasAccess(principal, related, AccessType.READ));
   }
 
   public <T extends AbstractDTO> void ensureCanRead(final ThirdEyePrincipal principal,
       final T entity) {
-    ensureHasAccess(principal, dtoToId(entity), AccessType.READ);
+    ensureHasAccess(principal, resourceId(entity), AccessType.READ);
   }
 
   public void ensureCanEvaluate(final ThirdEyePrincipal principal, final AlertDTO entity) {
@@ -84,7 +84,7 @@ public class AuthorizationManager {
 
   public <T extends AbstractDTO> void ensureHasAccess(final ThirdEyePrincipal principal,
       final T entity, final AccessType accessType) {
-    ensureHasAccess(principal, dtoToId(entity), accessType);
+    ensureHasAccess(principal, resourceId(entity), accessType);
   }
 
   public void ensureHasAccess(final ThirdEyePrincipal principal,
@@ -96,7 +96,7 @@ public class AuthorizationManager {
 
   public <T extends AbstractDTO> boolean hasAccess(final ThirdEyePrincipal principal,
       final T entity, final AccessType accessType) {
-    return hasAccess(principal, dtoToId(entity), accessType);
+    return hasAccess(principal, resourceId(entity), accessType);
   }
 
   public boolean hasAccess(final ThirdEyePrincipal principal,
@@ -104,7 +104,7 @@ public class AuthorizationManager {
     return accessControl.hasAccess(principal.authToken, identifier, accessType);
   }
 
-  static public <T extends AbstractDTO> ResourceIdentifier dtoToId(final T dto) {
+  static public <T extends AbstractDTO> ResourceIdentifier resourceId(final T dto) {
     return ResourceIdentifier.from(
         optional(dto.getId()).map(Objects::toString).orElse(DEFAULT_NAME),
         optional(dto.getNamespace()).orElse(DEFAULT_NAMESPACE),
@@ -116,7 +116,7 @@ public class AuthorizationManager {
     if (entity instanceof AlertDTO) {
       final AlertDTO alertDto = (AlertDTO) entity;
       final AlertTemplateDTO alertTemplateDTO = alertTemplateRenderer.getTemplate(alertDto.getTemplate());
-      return Collections.singletonList(dtoToId(alertTemplateDTO));
+      return Collections.singletonList(resourceId(alertTemplateDTO));
     }
     return new ArrayList<>();
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
@@ -25,7 +25,9 @@ import ai.startree.thirdeye.worker.task.TaskDriverConfiguration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ThirdEyeServerConfiguration extends Configuration {
 
@@ -67,6 +69,9 @@ public class ThirdEyeServerConfiguration extends Configuration {
 
   @JsonProperty("time")
   private TimeConfiguration timeConfiguration = new TimeConfiguration();
+
+  @JsonProperty("accessControl")
+  private Map<String, Object> accessControlConfiguration = new HashMap<>();
 
   private String phantomJsPath = "";
   private String failureFromAddress;
@@ -258,6 +263,15 @@ public class ThirdEyeServerConfiguration extends Configuration {
   public ThirdEyeServerConfiguration setDetectionPipelineConfiguration(
       final DetectionPipelineConfiguration detectionPipelineConfiguration) {
     this.detectionPipelineConfiguration = detectionPipelineConfiguration;
+    return this;
+  }
+
+  public Map<String, Object> getAccessControlConfiguration() {
+    return this.accessControlConfiguration;
+  }
+
+  public ThirdEyeServerConfiguration setAccessControlConfiguration(Map<String, Object> values) {
+    this.accessControlConfiguration = values;
     return this;
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
@@ -21,13 +21,12 @@ import ai.startree.thirdeye.rootcause.configuration.RcaConfiguration;
 import ai.startree.thirdeye.scheduler.ThirdEyeSchedulerConfiguration;
 import ai.startree.thirdeye.scheduler.dataavailability.DataAvailabilitySchedulingConfiguration;
 import ai.startree.thirdeye.scheduler.events.MockEventsConfiguration;
+import ai.startree.thirdeye.spi.accessControl.AccessControlConfiguration;
 import ai.startree.thirdeye.worker.task.TaskDriverConfiguration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class ThirdEyeServerConfiguration extends Configuration {
 
@@ -71,7 +70,7 @@ public class ThirdEyeServerConfiguration extends Configuration {
   private TimeConfiguration timeConfiguration = new TimeConfiguration();
 
   @JsonProperty("accessControl")
-  private Map<String, Object> accessControlConfiguration = new HashMap<>();
+  private AccessControlConfiguration accessControlConfiguration = new AccessControlConfiguration();
 
   private String phantomJsPath = "";
   private String failureFromAddress;
@@ -266,12 +265,12 @@ public class ThirdEyeServerConfiguration extends Configuration {
     return this;
   }
 
-  public Map<String, Object> getAccessControlConfiguration() {
+  public AccessControlConfiguration getAccessControlConfiguration() {
     return this.accessControlConfiguration;
   }
 
-  public ThirdEyeServerConfiguration setAccessControlConfiguration(Map<String, Object> values) {
-    this.accessControlConfiguration = values;
+  public ThirdEyeServerConfiguration setAccessControlConfiguration(AccessControlConfiguration config) {
+    this.accessControlConfiguration = config;
     return this;
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -24,12 +24,11 @@ import ai.startree.thirdeye.alert.AlertCreater;
 import ai.startree.thirdeye.alert.AlertDeleter;
 import ai.startree.thirdeye.alert.AlertEvaluator;
 import ai.startree.thirdeye.alert.AlertInsightsProvider;
-import ai.startree.thirdeye.auth.AccessType;
 import ai.startree.thirdeye.auth.AuthorizationManager;
-import ai.startree.thirdeye.auth.ResourceIdentifier;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
 import ai.startree.thirdeye.core.AppAnalyticsService;
 import ai.startree.thirdeye.mapper.ApiBeanMapper;
+import ai.startree.thirdeye.spi.accessControl.AccessType;
 import ai.startree.thirdeye.spi.api.AlertApi;
 import ai.startree.thirdeye.spi.api.AlertEvaluationApi;
 import ai.startree.thirdeye.spi.api.AlertInsightsApi;
@@ -163,7 +162,7 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
   public Response getInsights(@ApiParam(hidden = true) @Auth final ThirdEyePrincipal principal,
       @PathParam("id") final Long id) {
     final AlertDTO dto = get(id);
-    authorizationManager.ensureHasAccess(principal, ResourceIdentifier.from(dto), AccessType.READ);
+    authorizationManager.ensureHasAccess(principal, dto, AccessType.READ);
 
     final AlertInsightsApi insights = alertInsightsProvider.getInsights(dto);
     return Response.ok(insights).build();
@@ -194,7 +193,7 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
     final AlertDTO dto = get(id);
     ensureExists(dto);
     ensureExists(startTime, "start");
-    authorizationManager.ensureHasAccess(principal, ResourceIdentifier.from(dto), AccessType.UPDATE);
+    authorizationManager.ensureHasAccess(principal, dto, AccessType.WRITE);
 
     alertCreater.createOnboardingTask(id, startTime, safeEndTime(endTime));
     return Response.ok().build();
@@ -251,7 +250,7 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
       @ApiParam(hidden = true) @Auth final ThirdEyePrincipal principal,
       @PathParam("id") final Long id) {
     final AlertDTO dto = get(id);
-    authorizationManager.ensureHasAccess(principal, ResourceIdentifier.from(dto), AccessType.UPDATE);
+    authorizationManager.ensureHasAccess(principal, dto, AccessType.WRITE);
     LOG.warn(String.format("Resetting alert id: %d by principal: %s", id, principal.getName()));
 
     alertDeleter.deleteAssociatedAnomalies(dto.getId());

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
@@ -29,10 +29,9 @@ import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.DaoFilterBuilder;
 import ai.startree.thirdeye.RequestCache;
-import ai.startree.thirdeye.auth.AccessType;
 import ai.startree.thirdeye.auth.AuthorizationManager;
-import ai.startree.thirdeye.auth.ResourceIdentifier;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
+import ai.startree.thirdeye.spi.accessControl.AccessType;
 import ai.startree.thirdeye.spi.api.CountApi;
 import ai.startree.thirdeye.spi.api.ThirdEyeCrudApi;
 import ai.startree.thirdeye.spi.datalayer.DaoFilter;
@@ -214,9 +213,7 @@ public abstract class CrudResource<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exte
 
     final RequestCache cache = createRequestCache();
     return respondOk(results.stream()
-        .filter(dto -> authorizationManager.hasAccess(principal,
-            ResourceIdentifier.from(dto),
-            AccessType.READ))
+        .filter(dto -> authorizationManager.hasAccess(principal, dto, AccessType.READ))
         .map(dto -> toApi(dto, cache)));
   }
 

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
@@ -23,11 +23,11 @@ import ai.startree.thirdeye.alert.AlertDeleter;
 import ai.startree.thirdeye.alert.AlertEvaluator;
 import ai.startree.thirdeye.alert.AlertInsightsProvider;
 import ai.startree.thirdeye.alert.AlertTemplateRenderer;
-import ai.startree.thirdeye.auth.AccessControl;
-import ai.startree.thirdeye.auth.AccessControlModule;
-import ai.startree.thirdeye.auth.AccessType;
+import ai.startree.thirdeye.spi.accessControl.AccessControl;
+import ai.startree.thirdeye.auth.AccessControlProvider;
+import ai.startree.thirdeye.spi.accessControl.AccessType;
 import ai.startree.thirdeye.auth.AuthorizationManager;
-import ai.startree.thirdeye.auth.ResourceIdentifier;
+import ai.startree.thirdeye.spi.accessControl.ResourceIdentifier;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
 import ai.startree.thirdeye.core.AppAnalyticsService;
 import ai.startree.thirdeye.spi.api.AlertApi;
@@ -108,7 +108,7 @@ public class AlertResourceTest {
     final AlertTemplateRenderer alertTemplateRenderer = new AlertTemplateRenderer(
         mock(AlertManager.class), alertTemplateManager);
 
-    final AccessControl accessControl = (ThirdEyePrincipal principal, ResourceIdentifier identifier, AccessType accessType)
+    final AccessControl accessControl = (String token, ResourceIdentifier identifier, AccessType accessType)
         -> identifier.name.equals("0");
 
     new AlertResource(
@@ -143,7 +143,7 @@ public class AlertResourceTest {
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
             alertTemplateRenderer,
-            AccessControlModule.alwaysDeny
+            AccessControlProvider.alwaysDeny
         )
     ).runTask(nobody(), 1L, 0L, 1L);
   }
@@ -159,7 +159,7 @@ public class AlertResourceTest {
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
             mock(AlertTemplateRenderer.class),
-            AccessControlModule.alwaysDeny
+            AccessControlProvider.alwaysDeny
         )
     ).validateMultiple(
         nobody(),
@@ -176,7 +176,7 @@ public class AlertResourceTest {
         .thenReturn(((AlertTemplateDTO) new AlertTemplateDTO().setId(1L)).setName("template1"));
     final AlertTemplateRenderer alertTemplateRenderer = new AlertTemplateRenderer(mock(AlertManager.class),alertTemplateManager);
 
-    final AccessControl accessControl = (ThirdEyePrincipal principal, ResourceIdentifier identifier, AccessType accessType)
+    final AccessControl accessControl = (String token, ResourceIdentifier identifier, AccessType accessType)
         -> identifier.name.equals("alert1");
 
     new AlertResource(
@@ -215,7 +215,7 @@ public class AlertResourceTest {
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
             alertTemplateRenderer,
-            AccessControlModule.alwaysDeny
+            AccessControlProvider.alwaysDeny
         )
     ).evaluate(nobody(),
         new AlertEvaluationApi()
@@ -240,7 +240,7 @@ public class AlertResourceTest {
         mock(AlertInsightsProvider.class),
         new AuthorizationManager(
             alertTemplateRenderer,
-            AccessControlModule.alwaysDeny
+            AccessControlProvider.alwaysDeny
         )
     ).reset(nobody(), 1L);
   }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/CrudResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/CrudResourceTest.java
@@ -64,7 +64,7 @@ public class CrudResourceTest {
     final ThirdEyePrincipal owner = getPrincipal(emails.get(0));
     final DummyApi api = new DummyApi().setData("testData");
 
-    final Timestamp before = getCurrentTime();
+    final Timestamp before = new Timestamp(1671476530000L);
     List<DummyApi> response = (List<DummyApi>) resource.createMultiple(owner, singletonList(api)).getEntity();
 
     assertThat(response).isNotNull();

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ai.startree.thirdeye.alert.AlertTemplateRenderer;
-import ai.startree.thirdeye.auth.AccessControlModule;
+import ai.startree.thirdeye.auth.AccessControlProvider;
 import ai.startree.thirdeye.auth.AuthorizationManager;
 import ai.startree.thirdeye.auth.ThirdEyePrincipal;
 import ai.startree.thirdeye.core.DataSourceOnboarder;
@@ -49,7 +49,7 @@ public class DataSourceResourceTest {
         mock(DataSourceOnboarder.class),
         new AuthorizationManager(
             mock(AlertTemplateRenderer.class),
-            AccessControlModule.alwaysAllow
+            AccessControlProvider.alwaysAllow
         )
         );
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
@@ -23,6 +23,7 @@ import ai.startree.thirdeye.spi.detection.postprocessing.AnomalyPostProcessorFac
 import ai.startree.thirdeye.spi.notification.NotificationServiceFactory;
 import ai.startree.thirdeye.spi.rca.ContributorsFinderFactory;
 import java.util.Collections;
+import java.util.Map;
 
 public interface Plugin {
 
@@ -58,7 +59,7 @@ public interface Plugin {
     return Collections.emptyList();
   }
 
-  default AccessControl getAccessControl() {
+  default AccessControl getAccessControl(Map<String,Object> config) {
     return null;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi;
 
+import ai.startree.thirdeye.spi.accessControl.AccessControl;
 import ai.startree.thirdeye.spi.bootstrap.BootstrapResourcesProviderFactory;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSourceFactory;
 import ai.startree.thirdeye.spi.detection.AnomalyDetectorFactory;
@@ -55,5 +56,9 @@ public interface Plugin {
 
   default Iterable<EnumeratorFactory> getEnumeratorFactories() {
     return Collections.emptyList();
+  }
+
+  default AccessControl getAccessControl() {
+    return null;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Plugin.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.spi;
 
 import ai.startree.thirdeye.spi.accessControl.AccessControl;
+import ai.startree.thirdeye.spi.accessControl.AccessControlConfiguration;
 import ai.startree.thirdeye.spi.bootstrap.BootstrapResourcesProviderFactory;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSourceFactory;
 import ai.startree.thirdeye.spi.detection.AnomalyDetectorFactory;
@@ -59,7 +60,7 @@ public interface Plugin {
     return Collections.emptyList();
   }
 
-  default AccessControl getAccessControl(Map<String,Object> config) {
+  default AccessControl getAccessControl(AccessControlConfiguration config) {
     return null;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControl.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControl.java
@@ -11,8 +11,13 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package ai.startree.thirdeye.auth;
+package ai.startree.thirdeye.spi.accessControl;
 
-public enum AccessType {
-  READ, UPDATE
+public interface AccessControl {
+
+  boolean hasAccess(
+      String token,
+      ResourceIdentifier identifier,
+      AccessType accessType
+  );
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package ai.startree.thirdeye.spi.accessControl;
+
+import java.util.Map;
+
+public class AccessControlConfiguration {
+  public boolean enabled;
+  public Map<String, Object> properties;
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
@@ -16,7 +16,18 @@ package ai.startree.thirdeye.spi.accessControl;
 
 import java.util.Map;
 
+/**
+ * Plugin specific configuration is provided as plugin name -> properties.
+ * Example server.yaml:
+ * ---
+ * accessControl:
+ *   enabled: true
+ *   plugins:
+ *     startree-platform-auth:
+ *       endpoint: https://platform-auth.service
+ * ...
+ */
 public class AccessControlConfiguration {
   public boolean enabled;
-  public Map<String, Object> plugins;
+  public Map<String, Map<String, Object>> plugins;
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
@@ -23,8 +23,8 @@ import java.util.Map;
  * accessControl:
  *   enabled: true
  *   plugins:
- *     startree-platform-auth:
- *       endpoint: https://platform-auth.service
+ *     my-plugin:
+ *       prop1: val1
  * ...
  */
 public class AccessControlConfiguration {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessControlConfiguration.java
@@ -18,5 +18,5 @@ import java.util.Map;
 
 public class AccessControlConfiguration {
   public boolean enabled;
-  public Map<String, Object> properties;
+  public Map<String, Object> plugins;
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessType.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/AccessType.java
@@ -11,13 +11,8 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package ai.startree.thirdeye.auth;
+package ai.startree.thirdeye.spi.accessControl;
 
-public interface AccessControl {
-
-  boolean hasAccess(
-      ThirdEyePrincipal principal,
-      ResourceIdentifier identifier,
-      AccessType accessType
-  );
+public enum AccessType {
+  READ, WRITE
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/ResourceIdentifier.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/ResourceIdentifier.java
@@ -15,6 +15,8 @@ package ai.startree.thirdeye.spi.accessControl;
 
 import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class ResourceIdentifier {
 
   static public final String DEFAULT_NAME = "0";
@@ -34,9 +36,9 @@ public class ResourceIdentifier {
   public static ResourceIdentifier from(final String name, final String namespace,
       final String entityType) {
     return new ResourceIdentifier(
-        optional(name).orElse("").length() > 0 ? name : DEFAULT_NAME,
-        optional(namespace).orElse("").length() > 0 ? name : DEFAULT_NAMESPACE,
-        optional(entityType).orElse("").length() > 0 ? name : DEFAULT_ENTITY_TYPE
+        optional(name).filter(StringUtils::isNotEmpty).orElse(DEFAULT_NAME),
+        optional(namespace).filter(StringUtils::isNotEmpty).orElse(DEFAULT_NAMESPACE),
+        optional(entityType).filter(StringUtils::isNotEmpty).orElse(DEFAULT_ENTITY_TYPE)
     );
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/ResourceIdentifier.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/accessControl/ResourceIdentifier.java
@@ -11,13 +11,9 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package ai.startree.thirdeye.auth;
+package ai.startree.thirdeye.spi.accessControl;
 
 import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
-
-import ai.startree.thirdeye.datalayer.dao.SubEntities;
-import ai.startree.thirdeye.spi.datalayer.dto.AbstractDTO;
-import java.util.Objects;
 
 public class ResourceIdentifier {
 
@@ -29,18 +25,18 @@ public class ResourceIdentifier {
   public final String namespace;
   public final String entityType;
 
-  public ResourceIdentifier(final String name, final String namespace, final String entityType) {
+  private ResourceIdentifier(final String name, final String namespace, final String entityType) {
     this.name = name;
     this.namespace = namespace;
     this.entityType = entityType;
   }
 
-  static public <T extends AbstractDTO> ResourceIdentifier from(final T dto) {
+  public static ResourceIdentifier from(final String name, final String namespace,
+      final String entityType) {
     return new ResourceIdentifier(
-        optional(dto.getId()).map(Objects::toString).orElse(DEFAULT_NAME),
-        optional(dto.getNamespace()).orElse(DEFAULT_NAMESPACE),
-        optional(SubEntities.BEAN_TYPE_MAP.get(dto.getClass()))
-            .map(Objects::toString).orElse(DEFAULT_ENTITY_TYPE)
+        optional(name).orElse("").length() > 0 ? name : DEFAULT_NAME,
+        optional(namespace).orElse("").length() > 0 ? name : DEFAULT_NAMESPACE,
+        optional(entityType).orElse("").length() > 0 ? name : DEFAULT_ENTITY_TYPE
     );
   }
 }


### PR DESCRIPTION
This pr add a method providing an AccessControl instance to the Plugin interface. 

There's a generic access control config that has a flag for enabled/disabled and a map of plugin specific properties. 

I moved the AccessControl interface and related resources into the spi package so Plugin can reference them.

A single AccessControlProvider class is bound to the AccessControl interface. The Pugin loader can store a new AccessControl instance in the AccessControlProvider, which is subsequently used by server resources. 

I verified that swapping in different access control instances from the plugin loader does work as expected. I also tested w/ https://github.com/startreedata/startree-thirdeye/pull/93 to make sure that the plugin loads and runs correctly.


