### PR TITLE
feat(ui): TE-1240 using total anomaly count to calculate alert accuracy

### DIFF
--- a/thirdeye-ui/src/app/components/alert-list-v1/alert-list-v1.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-list-v1/alert-list-v1.component.tsx
@@ -88,7 +88,9 @@ export const AlertListV1: FunctionComponent<AlertListV1Props> = ({
         <AlertAccuracyColored
             alertStats={data.accuracyStatistics ?? null}
             renderCustomText={({ accuracy, noAnomalyData }) =>
-                noAnomalyData ? t("message.no-data") : `${100 * accuracy}%`
+                noAnomalyData
+                    ? t("message.no-data")
+                    : `${(100 * accuracy).toFixed(2)}%`
             }
             typographyProps={{ variant: "body2" }}
         />

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -475,7 +475,7 @@ export const AlertsViewPage: FunctionComponent = () => {
                                       )
                                     : `${t("label.overall-entity", {
                                           entity: t("label.accuracy"),
-                                      })}: ${100 * accuracy}%`
+                                      })}: ${(100 * accuracy).toFixed(2)}%`
                             )
                         }
                     />

--- a/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
@@ -433,13 +433,12 @@ export const getAlertAccuracyData = (
 
     // There's no point of calculating the accuracy if there is no feedback reported.
     // In which case, just return the default value of accuracy=100%
-    if (alertStat.countWithFeedback && alertStat.countWithFeedback > 0) {
+    if (alertStat.totalCount && alertStat.totalCount > 0) {
         // Returns a decimal value with four digits of precision
         accuracy = Number(
             (
                 1 -
-                alertStat.feedbackStats.NOT_ANOMALY /
-                    alertStat.countWithFeedback
+                alertStat.feedbackStats.NOT_ANOMALY / alertStat.totalCount
             ).toFixed(4)
         );
 


### PR DESCRIPTION
#### Issue(s)

[TE-1240](https://cortexdata.atlassian.net/browse/TE-1240)

#### Description

- Alert accuracy uses total anomaly count instead of anomalies with feedback count for denominator
- Added appropriate rounding off to prevent floating point calculation issues

#### Screenshots

![Screenshot_54](https://user-images.githubusercontent.com/20799363/213166363-470b3c1d-90a5-433a-b370-ff88beb7a1ad.png)

![Screenshot_55](https://user-images.githubusercontent.com/20799363/213166588-293b3942-cd4a-4012-a9fc-9ddbdf0eccfa.png)


[TE-1240]: https://cortexdata.atlassian.net/browse/TE-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ