### PR TITLE
chore(ui): TE-1238 remove duplicated api calls to metrics, datasets, and alerts in all anomalies page

### DIFF
--- a/thirdeye-ui/src/app/pages/alerts-update-page/alerts-update-base-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-update-page/alerts-update-base-page.component.tsx
@@ -296,7 +296,7 @@ export const AlertsUpdateBasePage: FunctionComponent = () => {
 
     return (
         <LoadingErrorStateSwitch
-            isError={!originalAlert}
+            isError={getAlertStatus === ActionStatus.Error}
             isLoading={loading}
             loadingState={<AppLoadingIndicatorV1 />}
         >

--- a/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
@@ -47,6 +47,7 @@ export const AnomaliesAllPage: FunctionComponent = () => {
     // Use state so we can remove anomalies locally without having to fetch again
     const [anomalies, setAnomalies] = useState<Anomaly[]>([]);
     const {
+        anomalies: anomaliesRequestDataResponse,
         getAnomalies,
         status: getAnomaliesRequestStatus,
         errorMessages: anomaliesRequestErrors,
@@ -170,7 +171,8 @@ export const AnomaliesAllPage: FunctionComponent = () => {
                     wrapInGrid
                     isError={getAnomaliesRequestStatus === ActionStatus.Error}
                     isLoading={
-                        getAnomaliesRequestStatus === ActionStatus.Working
+                        getAnomaliesRequestStatus === ActionStatus.Working ||
+                        getAnomaliesRequestStatus === ActionStatus.Initial
                     }
                 >
                     <EmptyStateSwitch
@@ -220,7 +222,7 @@ export const AnomaliesAllPage: FunctionComponent = () => {
                                 </PageContentsCardV1>
                             </Grid>
                         }
-                        isEmpty={anomalies.length === 0}
+                        isEmpty={anomaliesRequestDataResponse?.length === 0}
                     >
                         <Outlet
                             context={{


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1238

#### Description

Describe the changes being introduced.

#### Screenshots

No UI changes

Before:
<img width="1778" alt="Screen Shot 2023-01-20 at 2 34 53 PM" src="https://user-images.githubusercontent.com/2080348/213641697-260dbc95-459a-41eb-acff-6ba927d276af.png">

After:
<img width="1778" alt="Screen Shot 2023-01-20 at 2 33 39 PM" src="https://user-images.githubusercontent.com/2080348/213641545-2d655ef6-30e2-4aea-8bd6-1d1b935c5737.png">

