### PR TITLE
update mappers to support namespace field

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AlertMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AlertMapper.java
@@ -36,6 +36,7 @@ public interface AlertMapper {
     return new AlertApi()
         .setId(dto.getId())
         .setName(dto.getName())
+        .setNamespace(dto.getNamespace())
         .setDescription(dto.getDescription())
         .setActive(dto.isActive())
         .setCron(dto.getCron())
@@ -55,6 +56,7 @@ public interface AlertMapper {
     final AlertDTO dto = new AlertDTO();
 
     dto.setName(api.getName());
+    dto.setNamespace(api.getNamespace());
     dto.setDescription(api.getDescription());
     dto.setActive(optional(api.getActive()).orElse(true));
     dto.setCron(api.getCron());

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DataSourceMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DataSourceMapper.java
@@ -42,6 +42,7 @@ public interface DataSourceMapper {
                 .collect(Collectors.toList()))
             .orElse(null));
     dto.setId(api.getId());
+    dto.setNamespace(api.getNamespace());
     return dto;
   }
 
@@ -52,6 +53,7 @@ public interface DataSourceMapper {
     return new DataSourceApi()
         .setId(dto.getId())
         .setName(dto.getName())
+        .setNamespace(dto.getNamespace())
         .setType(dto.getType())
         .setProperties(optional(dto.getProperties()).filter(p -> !p.isEmpty()).orElse(null))
         .setMetaList(optional(dto.getMetaList()).filter(l -> !l.isEmpty())

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DatasetMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DatasetMapper.java
@@ -42,6 +42,7 @@ public interface DatasetMapper {
         .setDimensions(api.getDimensions())
         .setRcaExcludedDimensions(api.getRcaExcludedDimensions())
         ;
+    dto.setNamespace(api.getNamespace());
     optional(api.getTimeColumn()).ifPresent(timeColumn -> {
       dto.setTimeColumn(timeColumn.getName());
       updateTimeGranularityOnDataset(dto, timeColumn);
@@ -61,6 +62,7 @@ public interface DatasetMapper {
         .setActive(dto.getActive())
         .setDimensions(dto.getDimensions())
         .setName(dto.getDataset())
+        .setNamespace(dto.getNamespace())
         .setDataSource(optional(dto.getDataSource())
             .map(datasourceName -> new DataSourceApi().setName(datasourceName))
             .orElse(null))

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DataSourceApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DataSourceApi.java
@@ -25,6 +25,7 @@ public class DataSourceApi implements ThirdEyeCrudApi<DataSourceApi> {
 
   private Long id;
   private String name;
+  private String namespace;
   private String type;
   private Map<String, Object> properties;
   private List<DataSourceMetaApi> metaList;
@@ -46,6 +47,15 @@ public class DataSourceApi implements ThirdEyeCrudApi<DataSourceApi> {
 
   public DataSourceApi setName(final String name) {
     this.name = name;
+    return this;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public DataSourceApi setNamespace(final String namespace) {
+    this.namespace = namespace;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
@@ -24,6 +24,7 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
 
   private Long id;
   private String name;
+  private String namespace;
   private Boolean active;
   private Boolean additive;
   private Templatable<List<String>> dimensions;
@@ -55,6 +56,15 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
 
   public DatasetApi setName(final String name) {
     this.name = name;
+    return this;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public DatasetApi setNamespace(final String namespace) {
+    this.namespace = namespace;
     return this;
   }
 
@@ -127,7 +137,8 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
     return rcaExcludedDimensions;
   }
 
-  public DatasetApi setRcaExcludedDimensions(final Templatable<List<String>> rcaExcludedDimensions) {
+  public DatasetApi setRcaExcludedDimensions(
+      final Templatable<List<String>> rcaExcludedDimensions) {
     this.rcaExcludedDimensions = rcaExcludedDimensions;
     return this;
   }


### PR DESCRIPTION
In previous prs, I added the namespace field to the AbstractDTO class and the AlertAPI and AlertTemplateAPI classes. I didn't update the mappers, so the namespace never made it to the database 🤦

Update api<->dto mappers to support namespace field in Alerts, Datasets, Data sources.

Tested by adding namespace field to the resources.
