### PR TITLE
feat(ui): TE-1207 added exponential notation and Infinite label to very large anomaly deviations

### DIFF
--- a/thirdeye-ui/src/app/platform/utils/number/number.util.ts
+++ b/thirdeye-ui/src/app/platform/utils/number/number.util.ts
@@ -83,10 +83,12 @@ export const formatLargeNumberV1 = (
 // 0.1 -> 10%
 // 0.01234 -> 1.23%
 // 0.01237 -> 1.24%
+// 123456 -> 1e7% (if exponential = true)
 export const formatPercentageV1 = (
     num: number,
     mantissa: number = MANTISSA_DEFAULT,
-    optionalMantissa: boolean = OPTIONAL_MANTISSA_DEFAULT
+    optionalMantissa: boolean = OPTIONAL_MANTISSA_DEFAULT,
+    exponential = false // Show number in exponential notation
 ): string => {
     if (isNil(num)) {
         return "";
@@ -95,8 +97,9 @@ export const formatPercentageV1 = (
     return numbro(num).format({
         output: "percent",
         thousandSeparated: true,
-        mantissa: mantissa,
-        optionalMantissa: optionalMantissa,
+        mantissa,
+        optionalMantissa,
+        exponential,
     });
 };
 

--- a/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
+++ b/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
@@ -134,9 +134,20 @@ export const getUiAnomaly = (anomaly: Anomaly): UiAnomaly => {
         const deviation =
             (anomaly.avgCurrentVal - anomaly.avgBaselineVal) /
             Math.abs(anomaly.avgBaselineVal);
-        uiAnomaly.deviation = isNaN(deviation)
-            ? i18n.t("label.no-data-marker")
-            : formatPercentageV1(deviation);
+
+        if (isNaN(deviation)) {
+            uiAnomaly.deviation = i18n.t("label.no-data-marker");
+        } else if (deviation === Infinity) {
+            uiAnomaly.deviation = "Large(Infinite)";
+        } else {
+            uiAnomaly.deviation = formatPercentageV1(
+                deviation,
+                2,
+                true,
+                deviation > 10 ** 5
+            );
+        }
+
         uiAnomaly.deviationVal = deviation;
         uiAnomaly.negativeDeviation = deviation < 0;
     }


### PR DESCRIPTION
#### Issue(s)

[TE-1207](https://cortexdata.atlassian.net/browse/TE-1207)

#### Description

- For anomaly deviations that are extremely large (`> 10^5`), the scientific notation is used
- For anomaly deviations that are `<something> / 0`, the label of `Large (Infinite)` is shown instead of `Infinity%` ([link to discussion thread](https://cortexdata.atlassian.net/browse/TE-1207?focusedCommentId=16097)) 

#### Screenshots

![Screenshot_69](https://user-images.githubusercontent.com/20799363/214603802-49e804b6-24f4-4d49-b2c7-ccfe9cd35f8c.png)


[TE-1207]: https://cortexdata.atlassian.net/browse/TE-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ