### PR TITLE
feat(ui): TE-1209 improved contrast on link in markdown tooltip

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/alert-template-form-field.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/alert-template-form-field.component.tsx
@@ -12,15 +12,53 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { Box, TextField, Tooltip, Typography } from "@material-ui/core";
+import {
+    Box,
+    TextField,
+    Tooltip,
+    Typography,
+    useTheme,
+} from "@material-ui/core";
 import InfoIconOutlined from "@material-ui/icons/InfoOutlined";
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useMemo } from "react";
+import { LinkV1 } from "../../../../platform/components";
 import { InputSection } from "../../../form-basics/input-section/input-section.component";
 import { ParseMarkdown } from "../../../parse-markdown/parse-markdown.component";
+import { ParseMarkdownProps } from "../../../parse-markdown/parse-markdown.interfaces";
 import { AlertTemplateFormFieldProps } from "./alert-template-form-field.interfaces";
 
 export const AlertTemplateFormField: FunctionComponent<AlertTemplateFormFieldProps> =
     ({ item, textFieldProps, tooltipText }) => {
+        const theme = useTheme();
+
+        const parseMarkdownProps = useMemo<
+            Omit<ParseMarkdownProps, "children">
+        >(
+            () => ({
+                customOptions: {
+                    components: {
+                        a: ({ children, ...props }) => (
+                            <LinkV1
+                                {...props}
+                                externalLink
+                                color="primary"
+                                style={{
+                                    // Using the light color to improve contrast
+                                    // against the dark tooltip background
+                                    color: theme.palette.primary.light,
+                                }}
+                                target="_blank"
+                                variant="caption"
+                            >
+                                {children}
+                            </LinkV1>
+                        ),
+                    },
+                },
+            }),
+            []
+        );
+
         return (
             <InputSection
                 gridContainerProps={{ alignItems: "flex-start" }}
@@ -49,7 +87,7 @@ export const AlertTemplateFormField: FunctionComponent<AlertTemplateFormFieldPro
                                 placement="top"
                                 title={
                                     <Typography variant="caption">
-                                        <ParseMarkdown>
+                                        <ParseMarkdown {...parseMarkdownProps}>
                                             {tooltipText}
                                         </ParseMarkdown>
                                     </Typography>

--- a/thirdeye-ui/src/app/components/parse-markdown/parse-markdown.component.tsx
+++ b/thirdeye-ui/src/app/components/parse-markdown/parse-markdown.component.tsx
@@ -25,6 +25,7 @@ export const ParseMarkdown: FunctionComponent<ParseMarkdownProps> = ({
     customOptions,
 }) => {
     const options: ReactMarkdownOptions = {
+        ...customOptions,
         components: {
             h1: ({ children }) => (
                 <Typography variant="h1">{children}</Typography>
@@ -51,7 +52,7 @@ export const ParseMarkdown: FunctionComponent<ParseMarkdownProps> = ({
                     color="primary"
                     href={href}
                     target="_blank"
-                    variant="body2"
+                    variant="caption"
                 >
                     {children}
                 </LinkV1>
@@ -61,9 +62,9 @@ export const ParseMarkdown: FunctionComponent<ParseMarkdownProps> = ({
                     {children}
                 </Box>
             ),
+            ...customOptions?.components,
         },
         children,
-        ...customOptions,
     };
 
     return <ReactMarkdown {...options} />;

--- a/thirdeye-ui/src/app/platform/components/link-v1/link-v1.interfaces.ts
+++ b/thirdeye-ui/src/app/platform/components/link-v1/link-v1.interfaces.ts
@@ -12,8 +12,13 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { Variant } from "@material-ui/core/styles/createTypography";
-import { HTMLAttributeAnchorTarget, MouseEventHandler, ReactNode } from "react";
+import type { Variant } from "@material-ui/core/styles/createTypography";
+import type {
+    CSSProperties,
+    HTMLAttributeAnchorTarget,
+    MouseEventHandler,
+    ReactNode,
+} from "react";
 
 export interface LinkV1Props {
     href?: string;
@@ -33,4 +38,5 @@ export interface LinkV1Props {
     className?: string;
     onClick?: MouseEventHandler;
     children?: ReactNode;
+    style?: CSSProperties;
 }


### PR DESCRIPTION
#### Issue(s)

[TE-1209](https://cortexdata.atlassian.net/browse/TE-1209)

#### Description

- Implemented `palette.primary.light` color for links in the tooltip markdown
- Improved the code to override markdown components so it can merge with default components

#### Screenshots

Before:
![image](https://user-images.githubusercontent.com/20799363/215080653-6608746f-9949-48a5-b5af-40abf6d2416f.png)

After:
![Screenshot_73](https://user-images.githubusercontent.com/20799363/215080374-cd414abd-bc65-402e-ad8b-573af369a861.png)



[TE-1209]: https://cortexdata.atlassian.net/browse/TE-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ