### PR TITLE
[postprocessors] remove child generation when merging anomalies

### DIFF
--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
@@ -288,7 +288,7 @@ public class HappyPathTest {
     Response response = request("api/anomalies/count").get();
     assertThat(response.getStatus()).isEqualTo(200);
     Long anomalyCount = response.readEntity(CountApi.class).getCount();
-    assertThat(anomalyCount).isEqualTo(22);
+    assertThat(anomalyCount).isEqualTo(6);
 
     // there are only 5 parent anomalies
     response = request("api/anomalies/count?isChild=false").get();

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
@@ -191,7 +191,6 @@ public class SchedulingTest {
 
   @Test(dependsOnMethods = "testAfterDetectionCronLastTimestamp", timeOut = 60000L)
   public void testSecondAnomalyIsMerged() throws InterruptedException {
-    List<AnomalyApi> anomalies = getAnomalies();
 
     // advance detection time to March 23, 2020, 00:00:00 UTC
     // this should trigger the cron - and a new anomaly is expected on [March 22 - March 23]
@@ -211,6 +210,7 @@ public class SchedulingTest {
     // check that lastTimestamp after detection is the runTime of the cron
     assertThat(alertLastTimestamp).isEqualTo(MARCH_23_2020_00H00);
 
+    final List<AnomalyApi> anomalies = getAnomalies();
     // find anomalies starting on MARCH 21 - there should be 2
     final List<AnomalyApi> march21Anomalies = anomalies.stream()
         .filter(a -> a.getStartTime().getTime() == MARCH_21_2020_00H00)

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AnomalyDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AnomalyDTO.java
@@ -61,7 +61,9 @@ public class AnomalyDTO extends AbstractDTO implements Comparable<AnomalyDTO>, S
   @JsonIgnore
   private String metricUrn;
   private Long detectionConfigId;
+  @Deprecated
   private Set<Long> childIds; // ids of the anomalies this anomaly merged from
+  @Deprecated
   private boolean isChild;
   @Deprecated
   @JsonIgnore
@@ -84,19 +86,23 @@ public class AnomalyDTO extends AbstractDTO implements Comparable<AnomalyDTO>, S
   private EnumerationItemDTO enumerationItem;
   private List<AnomalyLabelDTO> anomalyLabels;
 
+  @Deprecated
   public Set<Long> getChildIds() {
     return childIds;
   }
 
+  @Deprecated
   public AnomalyDTO setChildIds(Set<Long> childIds) {
     this.childIds = childIds;
     return this;
   }
 
+  @Deprecated
   public boolean isChild() {
     return isChild;
   }
 
+  @Deprecated
   public AnomalyDTO setChild(boolean child) {
     isChild = child;
     return this;
@@ -390,10 +396,12 @@ public class AnomalyDTO extends AbstractDTO implements Comparable<AnomalyDTO>, S
     this.anomalyFunction = anomalyFunction;
   }
 
+  @Deprecated
   public Set<AnomalyDTO> getChildren() {
     return children;
   }
 
+  @Deprecated
   public void setChildren(Set<AnomalyDTO> children) {
     this.children = children;
   }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/model/AnomalySlice.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/model/AnomalySlice.java
@@ -13,11 +13,9 @@
  */
 package ai.startree.thirdeye.spi.detection.model;
 
-import ai.startree.thirdeye.spi.datalayer.dto.AnomalyDTO;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -105,50 +103,6 @@ public class AnomalySlice {
     }
 
     return true;
-  }
-
-  public boolean match(AnomalyDTO anomaly) {
-    if (anomaly == null) {
-      return false;
-    }
-
-    if (this.detectionId >= 0 &&
-        (anomaly.getDetectionConfigId() == null
-            || anomaly.getDetectionConfigId() != this.detectionId)) {
-      return false;
-    }
-
-    if (this.start >= 0 && anomaly.getEndTime() <= this.start) {
-      return false;
-    }
-    if (this.end >= 0 && anomaly.getStartTime() >= this.end) {
-      return false;
-    }
-
-    // Matches anomalies on the specified dimension filters
-    //
-    // Let's assume you have anomalies say, A1 on overall pageviews, A2 on pageviews(country=US),
-    // A3 on pageviews(country=US,FR) and A4 on pageviews(country=US, device=Android).
-    //
-    // Now, if you want to fetch all the anomalies in US (country=US), then this matching will
-    // return A2 (country=US) and A4 (country=US, device=Android)
-    for (String dimName : this.filters.keySet()) {
-      if (anomaly.getDimensionMap().containsKey(dimName)) {
-        Collection<String> dimValue = anomaly.getDimensionMap().get(dimName);
-        if (!this.filters.get(dimName).equals(dimValue)) {
-          return false;
-        }
-      } else {
-        return false;
-      }
-    }
-
-    // deprecated logic
-    if (!this.detectionComponentNames.isEmpty()) {
-      return false;
-    } else {
-      return isTaggedAsChild == anomaly.isChild();
-    }
   }
 
   @Override


### PR DESCRIPTION
- don't generate child anomalies anymore
- all code manipulating child anomalies, and child ids is unchanged for the moment to keep backward compatibility.
- anomaly `avgCurrentValue` is not the average of anomalies when anomalies are merged, it is the value of the first anomaly. This is the current behaviour so this is not changed.
