### PR TITLE
feat(ui): TE-1216 support timezone in alert details view pages

### DIFF
--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
@@ -85,6 +85,7 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
         right: 0,
     };
     tsData.xAxis = {
+        ...tsData.xAxis,
         tickFormatter: (d: string) => {
             return DateTime.fromJSDate(new Date(d), {
                 zone: timezone,
@@ -137,8 +138,12 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
                                     )
                                 }
                             >
-                                {!isExpanded && <span>View Details</span>}
-                                {isExpanded && <span>Hide Details</span>}
+                                {!isExpanded && (
+                                    <span>{t("label.view-details")}</span>
+                                )}
+                                {isExpanded && (
+                                    <span>{t("label.hide-details")}</span>
+                                )}
                             </Button>
                         </Grid>
                         <Grid item sm={2} xs={12}>

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
@@ -45,6 +45,7 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     expanded,
     onExpandChange,
     alertStats,
+    timezone,
 }) => {
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -65,7 +66,8 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
         detectionEvaluation,
         anomalies,
         t,
-        navigate
+        navigate,
+        timezone
     );
     const tsDataForExpanded = {
         ...tsData,

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
@@ -86,7 +86,9 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     };
     tsData.xAxis = {
         tickFormatter: (d: string) => {
-            return DateTime.fromJSDate(new Date(d)).toFormat("MMM dd");
+            return DateTime.fromJSDate(new Date(d), {
+                zone: timezone,
+            }).toFormat("MMM dd");
         },
     };
 

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.interfaces.ts
@@ -23,4 +23,5 @@ export interface EnumerationItemRowProps {
     expanded: string[];
     onExpandChange: (isOpen: boolean, name: string) => void;
     alertStats: AlertStats | null;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.component.tsx
@@ -47,6 +47,7 @@ export const EnumerationItemsTable: FunctionComponent<EnumerationItemsTableProps
         sortOrder,
         onSortOrderChange,
         alertsStats,
+        timezone,
     }) => {
         const [filteredDetectionEvaluations, setFilteredDetectionEvaluations] =
             useState(
@@ -257,6 +258,7 @@ export const EnumerationItemsTable: FunctionComponent<EnumerationItemsTableProps
                                         key={generateNameForDetectionResult(
                                             detectionEvaluation
                                         )}
+                                        timezone={timezone}
                                         onExpandChange={handleIsOpenChange}
                                     />
                                 );

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.interfaces.ts
@@ -26,4 +26,5 @@ export interface EnumerationItemsTableProps {
     onSearchTermChange: (newTerm: string) => void;
     onSortOrderChange: (newOrder: DataGridSortOrderV1) => void;
     alertsStats?: Record<number, AlertStats | null> | null;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../../platform/components";
 import { DialogType } from "../../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { Alert } from "../../../rest/dto/alert.interfaces";
+import { determineTimezoneFromAlert } from "../../../utils/alerts/alerts.util";
 import { TimeRangeButtonWithContext } from "../../time-range/time-range-button-with-context/time-range-button.component";
 import { AlertViewSubHeaderProps } from "./alert-sub-header.interfaces";
 
@@ -96,7 +97,10 @@ export const AlertViewSubHeader: FunctionComponent<AlertViewSubHeaderProps> = ({
                         </Button>
                     </Grid>
                     <Grid item>
-                        <TimeRangeButtonWithContext btnGroupColor="primary" />
+                        <TimeRangeButtonWithContext
+                            btnGroupColor="primary"
+                            timezone={determineTimezoneFromAlert(alert)}
+                        />
                     </Grid>
                 </Grid>
             </Grid>

--- a/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
@@ -23,12 +23,12 @@ import {
 } from "../../../platform/components";
 import { DialogType } from "../../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { Alert } from "../../../rest/dto/alert.interfaces";
-import { determineTimezoneFromAlert } from "../../../utils/alerts/alerts.util";
 import { TimeRangeButtonWithContext } from "../../time-range/time-range-button-with-context/time-range-button.component";
 import { AlertViewSubHeaderProps } from "./alert-sub-header.interfaces";
 
 export const AlertViewSubHeader: FunctionComponent<AlertViewSubHeaderProps> = ({
     alert,
+    timezone,
 }) => {
     const { showDialog, hideDialog } = useDialogProviderV1();
     const { t } = useTranslation();
@@ -99,7 +99,7 @@ export const AlertViewSubHeader: FunctionComponent<AlertViewSubHeaderProps> = ({
                     <Grid item>
                         <TimeRangeButtonWithContext
                             btnGroupColor="primary"
-                            timezone={determineTimezoneFromAlert(alert)}
+                            timezone={timezone}
                         />
                     </Grid>
                 </Grid>

--- a/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.interfaces.ts
@@ -16,4 +16,5 @@ import { Alert } from "../../../rest/dto/alert.interfaces";
 
 export interface AlertViewSubHeaderProps {
     alert: Alert;
+    timezone: string | undefined;
 }

--- a/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.component.tsx
@@ -30,7 +30,7 @@ import {
     DataGridV1,
     SkeletonV1,
 } from "../../platform/components";
-import { linkRendererV1 } from "../../platform/utils";
+import { formatDateAndTimeV1, linkRendererV1 } from "../../platform/utils";
 import { ActionStatus } from "../../rest/actions.interfaces";
 import { EnumerationItem } from "../../rest/dto/enumeration-item.interfaces";
 import type { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
@@ -52,6 +52,8 @@ export const AnomalyListV1: FunctionComponent<AnomalyListV1Props> = ({
     showEnumerationItem = false,
     enumerationItems = [],
     enumerationItemsStatus,
+    // If timezone is passed, override all datetime rendering to use this timezone
+    timezone,
 }) => {
     const [selectedAnomaly, setSelectedAnomaly] =
         useState<DataGridSelectionModelV1<UiAnomaly>>();
@@ -181,14 +183,19 @@ export const AnomalyListV1: FunctionComponent<AnomalyListV1Props> = ({
 
     const startTimeRenderer = useCallback(
         // use formatted value to display
-        (_, data: UiAnomaly) => addMutedStyle(data.startTime, data),
-        []
+        (_, data: UiAnomaly) =>
+            addMutedStyle(
+                formatDateAndTimeV1(data.startTimeVal, timezone),
+                data
+            ),
+        [timezone]
     );
 
     const endTimeRenderer = useCallback(
         // use formatted value to display
-        (_, data: UiAnomaly) => addMutedStyle(data.endTime, data),
-        []
+        (_, data: UiAnomaly) =>
+            addMutedStyle(formatDateAndTimeV1(data.endTimeVal, timezone), data),
+        [timezone]
     );
 
     const enumerationItemRender = useCallback(

--- a/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.interfaces.ts
+++ b/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.interfaces.ts
@@ -29,4 +29,5 @@ export interface AnomalyListV1Props extends Partial<EnumerationDataProps> {
     searchFilterValue?: string | null;
     onSearchFilterValueChange?: (value: string) => void;
     toolbar?: ReactNode;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.test.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-list-v1/anomaly-list-v1.test.tsx
@@ -44,6 +44,9 @@ jest.mock("../../platform/utils", () => ({
         .mockImplementation((value: string, id: number) => (
             <a href={`testHref${id}`}>{value}</a>
         )),
+    formatDateAndTimeV1: jest
+        .fn()
+        .mockImplementation((value: number) => (value ? value.toString() : "")),
 }));
 
 jest.mock("../anomaly-quick-filters/anomaly-quick-filters.component", () => ({

--- a/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filter.interface.ts
+++ b/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filter.interface.ts
@@ -20,4 +20,5 @@ export enum AnomalyFilterQueryStringKey {
 
 export interface AnomalyQuickFiltersProps {
     showTimeSelectorOnly?: boolean;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filters.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filters.component.tsx
@@ -52,7 +52,7 @@ function initializeSelected(
 }
 
 export const AnomalyQuickFilters: FunctionComponent<AnomalyQuickFiltersProps> =
-    ({ showTimeSelectorOnly }) => {
+    ({ showTimeSelectorOnly, timezone }) => {
         const {
             timeRangeDuration,
             recentCustomTimeRangeDurations,
@@ -238,6 +238,7 @@ export const AnomalyQuickFilters: FunctionComponent<AnomalyQuickFiltersProps> =
                             recentCustomTimeRangeDurations
                         }
                         timeRangeDuration={timeRangeDuration}
+                        timezone={timezone}
                         onChange={onHandleTimeRangeChange}
                         onRefresh={onHandleRefresh}
                     />

--- a/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
@@ -18,6 +18,7 @@ import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { PageContentsCardV1, SkeletonV1 } from "../../../platform/components";
 import { formatDateAndTimeV1 } from "../../../platform/utils";
+import { timezoneStringShort } from "../../../utils/time/time.util";
 import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
 import { AnomalySummaryCardDetail } from "../root-cause-analysis/anomaly-summary-card/anomaly-summary-card-deatil.component";
 import { AnomalyCardProps } from "./anomaly-card.interfaces";
@@ -45,7 +46,10 @@ export const AnomalyCard: FunctionComponent<AnomalyCardProps> = (
                         {/* Start */}
                         <Grid item lg={2} sm={6} xs={12}>
                             <AnomalySummaryCardDetail
-                                label={t("label.start")}
+                                label={
+                                    t("label.start") +
+                                    ` (${timezoneStringShort(props.timezone)})`
+                                }
                                 value={formatDateAndTimeV1(
                                     props.uiAnomaly.startTimeVal,
                                     props.timezone
@@ -56,7 +60,10 @@ export const AnomalyCard: FunctionComponent<AnomalyCardProps> = (
                         {/* End */}
                         <Grid item lg={2} sm={6} xs={12}>
                             <AnomalySummaryCardDetail
-                                label={t("label.end")}
+                                label={
+                                    t("label.end") +
+                                    ` (${timezoneStringShort(props.timezone)})`
+                                }
                                 value={formatDateAndTimeV1(
                                     props.uiAnomaly.endTimeVal,
                                     props.timezone

--- a/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
@@ -17,6 +17,7 @@ import classnames from "classnames";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { PageContentsCardV1, SkeletonV1 } from "../../../platform/components";
+import { formatDateAndTimeV1 } from "../../../platform/utils";
 import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
 import { AnomalySummaryCardDetail } from "../root-cause-analysis/anomaly-summary-card/anomaly-summary-card-deatil.component";
 import { AnomalyCardProps } from "./anomaly-card.interfaces";
@@ -45,7 +46,10 @@ export const AnomalyCard: FunctionComponent<AnomalyCardProps> = (
                         <Grid item lg={2} sm={6} xs={12}>
                             <AnomalySummaryCardDetail
                                 label={t("label.start")}
-                                value={props.uiAnomaly.startTime}
+                                value={formatDateAndTimeV1(
+                                    props.uiAnomaly.startTimeVal,
+                                    props.timezone
+                                )}
                             />
                         </Grid>
 
@@ -53,7 +57,10 @@ export const AnomalyCard: FunctionComponent<AnomalyCardProps> = (
                         <Grid item lg={2} sm={6} xs={12}>
                             <AnomalySummaryCardDetail
                                 label={t("label.end")}
-                                value={props.uiAnomaly.endTime}
+                                value={formatDateAndTimeV1(
+                                    props.uiAnomaly.endTimeVal,
+                                    props.timezone
+                                )}
                             />
                         </Grid>
 

--- a/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.interfaces.ts
@@ -19,4 +19,5 @@ export interface AnomalyCardProps {
     searchWords?: string[];
     className?: string;
     isLoading?: boolean;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
@@ -15,18 +15,16 @@
 import { Grid, Typography } from "@material-ui/core";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
 import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
-import React, { FunctionComponent, useEffect } from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import {
     PageContentsCardV1,
     SkeletonV1,
-    useNotificationProviderV1,
 } from "../../../../platform/components";
-import { ActionStatus } from "../../../../rest/actions.interfaces";
-import { useGetAlert } from "../../../../rest/alerts/alerts.actions";
+import { formatDateAndTimeV1 } from "../../../../platform/utils";
 import { useCommonStyles } from "../../../../utils/material-ui/common.styles";
-import { notifyIfErrors } from "../../../../utils/notifications/notifications.util";
 import { NoDataIndicator } from "../../../no-data-indicator/no-data-indicator.component";
+import { LoadingErrorStateSwitch } from "../../../page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { AnomalySummaryCardDetail } from "./anomaly-summary-card-deatil.component";
 import { AnomalySummaryCardProps } from "./anomaly-summary-card.interfaces";
 
@@ -34,29 +32,12 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = ({
     uiAnomaly,
     isLoading,
     className,
+    timezone,
+    alert,
 }) => {
-    const { alert, getAlert, status, errorMessages } = useGetAlert();
     const commonClasses = useCommonStyles();
     const { t } = useTranslation();
-    const { notify } = useNotificationProviderV1();
     let metricName;
-
-    useEffect(() => {
-        if (uiAnomaly && uiAnomaly.alertId) {
-            getAlert(uiAnomaly.alertId);
-        }
-    }, [uiAnomaly]);
-
-    useEffect(() => {
-        notifyIfErrors(
-            status,
-            errorMessages,
-            notify,
-            t("message.error-while-fetching", {
-                entity: t("label.alert"),
-            })
-        );
-    }, [status, errorMessages]);
 
     if (alert && alert.templateProperties) {
         if (
@@ -69,98 +50,97 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = ({
         }
     }
 
-    if (isLoading) {
-        return (
-            <PageContentsCardV1 className={className}>
-                <Typography variant="body1">
-                    <SkeletonV1 preventDelay />
-                    <SkeletonV1 preventDelay />
-                </Typography>
-            </PageContentsCardV1>
-        );
-    }
-
     return (
         <PageContentsCardV1 className={className}>
-            {uiAnomaly && (
-                <Grid container spacing={8}>
-                    {/* Metric */}
-                    <Grid item>
-                        <AnomalySummaryCardDetail
-                            label={`${t("label.metric")} ${
-                                status === ActionStatus.Done &&
-                                alert &&
-                                alert.templateProperties.dataset
-                            }`}
-                            value={
-                                status === ActionStatus.Working
-                                    ? "Loading ..."
-                                    : status === ActionStatus.Done && metricName
-                                    ? metricName
-                                    : t("label.no-data-marker")
-                            }
-                        />
-                    </Grid>
+            <LoadingErrorStateSwitch
+                errorState={<NoDataIndicator />}
+                isError={!uiAnomaly}
+                isLoading={!!isLoading}
+                loadingState={
+                    <Typography variant="body1">
+                        <SkeletonV1 preventDelay />
+                        <SkeletonV1 preventDelay />
+                    </Typography>
+                }
+            >
+                {uiAnomaly && (
+                    <Grid container spacing={8}>
+                        {/* Metric */}
+                        <Grid item>
+                            <AnomalySummaryCardDetail
+                                label={`${t("label.metric")} ${
+                                    alert && alert.templateProperties.dataset
+                                }`}
+                                value={
+                                    alert === null
+                                        ? "Loading ..."
+                                        : metricName
+                                        ? metricName
+                                        : t("label.no-data-marker")
+                                }
+                            />
+                        </Grid>
 
-                    {/* Current and Predicted */}
-                    <Grid item>
-                        <Grid container spacing={2}>
-                            <Grid item>
-                                <AnomalySummaryCardDetail
-                                    label={t("label.current")}
-                                    value={uiAnomaly.current}
-                                />
-                            </Grid>
-                            <Grid item>
-                                <Grid
-                                    container
-                                    className={
-                                        uiAnomaly.negativeDeviation
-                                            ? commonClasses.decreased
-                                            : commonClasses.increased
-                                    }
-                                    spacing={0}
-                                >
-                                    <Grid item>{uiAnomaly.deviation}</Grid>
-                                    <Grid item>
-                                        {uiAnomaly.negativeDeviation && (
-                                            <ArrowDownwardIcon fontSize="small" />
-                                        )}
-                                        {!uiAnomaly.negativeDeviation && (
-                                            <ArrowUpwardIcon fontSize="small" />
-                                        )}
+                        {/* Current and Predicted */}
+                        <Grid item>
+                            <Grid container spacing={2}>
+                                <Grid item>
+                                    <AnomalySummaryCardDetail
+                                        label={t("label.current")}
+                                        value={uiAnomaly.current}
+                                    />
+                                </Grid>
+                                <Grid item>
+                                    <Grid
+                                        container
+                                        className={
+                                            uiAnomaly.negativeDeviation
+                                                ? commonClasses.decreased
+                                                : commonClasses.increased
+                                        }
+                                        spacing={0}
+                                    >
+                                        <Grid item>{uiAnomaly.deviation}</Grid>
+                                        <Grid item>
+                                            {uiAnomaly.negativeDeviation && (
+                                                <ArrowDownwardIcon fontSize="small" />
+                                            )}
+                                            {!uiAnomaly.negativeDeviation && (
+                                                <ArrowUpwardIcon fontSize="small" />
+                                            )}
+                                        </Grid>
                                     </Grid>
                                 </Grid>
-                            </Grid>
-                            <Grid item>
-                                <AnomalySummaryCardDetail
-                                    label={t("label.baseline")}
-                                    value={uiAnomaly.predicted}
-                                />
+                                <Grid item>
+                                    <AnomalySummaryCardDetail
+                                        label={t("label.baseline")}
+                                        value={uiAnomaly.predicted}
+                                    />
+                                </Grid>
                             </Grid>
                         </Grid>
-                    </Grid>
 
-                    {/* Start */}
-                    <Grid item>
-                        <AnomalySummaryCardDetail
-                            label={t("label.start")}
-                            value={uiAnomaly.startTime}
-                        />
-                    </Grid>
+                        {/* Start */}
+                        <Grid item>
+                            <AnomalySummaryCardDetail
+                                label={t("label.start")}
+                                value={formatDateAndTimeV1(
+                                    uiAnomaly.startTimeVal,
+                                    timezone
+                                )}
+                            />
+                        </Grid>
 
-                    {/* Duration */}
-                    <Grid item>
-                        <AnomalySummaryCardDetail
-                            label={t("label.duration")}
-                            value={uiAnomaly.duration}
-                        />
+                        {/* Duration */}
+                        <Grid item>
+                            <AnomalySummaryCardDetail
+                                label={t("label.duration")}
+                                value={uiAnomaly.duration}
+                            />
+                        </Grid>
                     </Grid>
-                </Grid>
-            )}
-
-            {/* No data available */}
-            {!uiAnomaly && <NoDataIndicator />}
+                )}
+            </LoadingErrorStateSwitch>
         </PageContentsCardV1>
     );
 };

--- a/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../../../platform/components";
 import { formatDateAndTimeV1 } from "../../../../platform/utils";
 import { useCommonStyles } from "../../../../utils/material-ui/common.styles";
+import { timezoneStringShort } from "../../../../utils/time/time.util";
 import { NoDataIndicator } from "../../../no-data-indicator/no-data-indicator.component";
 import { LoadingErrorStateSwitch } from "../../../page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { AnomalySummaryCardDetail } from "./anomaly-summary-card-deatil.component";
@@ -123,7 +124,10 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = ({
                         {/* Start */}
                         <Grid item>
                             <AnomalySummaryCardDetail
-                                label={t("label.start")}
+                                label={
+                                    t("label.start") +
+                                    ` (${timezoneStringShort(timezone)})`
+                                }
                                 value={formatDateAndTimeV1(
                                     uiAnomaly.startTimeVal,
                                     timezone

--- a/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.interfaces.ts
@@ -12,10 +12,13 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import { Alert } from "../../../../rest/dto/alert.interfaces";
 import { UiAnomaly } from "../../../../rest/dto/ui-anomaly.interfaces";
 
 export interface AnomalySummaryCardProps {
     uiAnomaly: UiAnomaly | null;
     isLoading?: boolean;
     className?: string;
+    timezone?: string;
+    alert: Alert | null;
 }

--- a/thirdeye-ui/src/app/components/home-page/recent-anomalies/anomaly-row/anomaly-row.component.tsx
+++ b/thirdeye-ui/src/app/components/home-page/recent-anomalies/anomaly-row/anomaly-row.component.tsx
@@ -25,6 +25,7 @@ import { useGetEvaluation } from "../../../../rest/alerts/alerts.actions";
 import { UiAnomaly } from "../../../../rest/dto/ui-anomaly.interfaces";
 import {
     createAlertEvaluation,
+    determineTimezoneFromAlertInEvaluation,
     extractDetectionEvaluation,
 } from "../../../../utils/alerts/alerts.util";
 import { getUiAnomaly } from "../../../../utils/anomalies/anomalies.util";
@@ -95,7 +96,8 @@ export const AnomalyRow: FunctionComponent<AnomalyRowProps> = ({ anomaly }) => {
         const options = generateChartOptionsForMetricsReport(
             detectionEvalForAnomaly,
             [anomaly],
-            t
+            t,
+            determineTimezoneFromAlertInEvaluation(evaluation.alert)
         );
 
         options.zoom = true;

--- a/thirdeye-ui/src/app/components/metrics-report-list/metrics-report-list.interfaces.ts
+++ b/thirdeye-ui/src/app/components/metrics-report-list/metrics-report-list.interfaces.ts
@@ -22,7 +22,7 @@ export interface MetricsReportListProps {
 }
 
 export interface AnomaliesByAlert {
-    alert: Alert;
+    alert: Pick<Alert, "id" | "name">;
     anomalies: Anomaly[];
     metric: string;
     dataset: string;

--- a/thirdeye-ui/src/app/components/rca/analysis-tabs/analysis-tabs.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/analysis-tabs/analysis-tabs.component.tsx
@@ -66,6 +66,7 @@ export const AnalysisTabs: FunctionComponent<AnalysisTabsProps> = ({
     selectedEvents,
     onEventSelectionChange,
     isLoading,
+    timezone,
 }) => {
     const { notify } = useNotificationProviderV1();
     const [searchParams, setSearchParams] = useSearchParams();
@@ -227,9 +228,12 @@ export const AnalysisTabs: FunctionComponent<AnalysisTabsProps> = ({
                                 Data Date Range
                             </div>
                             <div>
-                                {formatDateAndTimeV1(anomaly.startTime)}
+                                {formatDateAndTimeV1(
+                                    anomaly.startTime,
+                                    timezone
+                                )}
                                 <strong> to </strong>
-                                {formatDateAndTimeV1(anomaly.endTime)}
+                                {formatDateAndTimeV1(anomaly.endTime, timezone)}
                             </div>
                         </Grid>
                         <Grid item xs={6}>
@@ -251,14 +255,16 @@ export const AnalysisTabs: FunctionComponent<AnalysisTabsProps> = ({
                                     anomaly.startTime -
                                         baselineOffsetToMilliseconds(
                                             comparisonOffset
-                                        )
+                                        ),
+                                    timezone
                                 )}
                                 <strong> to </strong>
                                 {formatDateAndTimeV1(
                                     anomaly.endTime -
                                         baselineOffsetToMilliseconds(
                                             comparisonOffset
-                                        )
+                                        ),
+                                    timezone
                                 )}
                             </div>
                         </Grid>
@@ -276,6 +282,7 @@ export const AnalysisTabs: FunctionComponent<AnalysisTabsProps> = ({
                         anomalyId={anomalyId}
                         chartTimeSeriesFilterSet={chartTimeSeriesFilterSet}
                         comparisonOffset={comparisonOffset}
+                        timezone={timezone}
                         onCheckClick={onAddFilterSetClick}
                     />
                 </Box>
@@ -286,6 +293,7 @@ export const AnalysisTabs: FunctionComponent<AnalysisTabsProps> = ({
                         anomalyId={anomalyId}
                         chartTimeSeriesFilterSet={chartTimeSeriesFilterSet}
                         comparisonOffset={comparisonOffset}
+                        timezone={timezone}
                         onAddFilterSetClick={onAddFilterSetClick}
                     />
                 </Box>
@@ -296,6 +304,7 @@ export const AnalysisTabs: FunctionComponent<AnalysisTabsProps> = ({
                         anomalyId={anomalyId}
                         searchValue={eventsSearchValue}
                         selectedEvents={selectedEvents}
+                        timezone={timezone}
                         triggerUpdate={triggerUpdateEvents}
                         onCheckClick={onEventSelectionChange}
                     />

--- a/thirdeye-ui/src/app/components/rca/analysis-tabs/analysis-tabs.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/analysis-tabs/analysis-tabs.component.tsx
@@ -293,7 +293,6 @@ export const AnalysisTabs: FunctionComponent<AnalysisTabsProps> = ({
                         anomalyId={anomalyId}
                         chartTimeSeriesFilterSet={chartTimeSeriesFilterSet}
                         comparisonOffset={comparisonOffset}
-                        timezone={timezone}
                         onAddFilterSetClick={onAddFilterSetClick}
                     />
                 </Box>

--- a/thirdeye-ui/src/app/components/rca/analysis-tabs/analysis-tabs.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/analysis-tabs/analysis-tabs.interfaces.ts
@@ -24,4 +24,5 @@ export interface AnalysisTabsProps {
     selectedEvents: Event[];
     onEventSelectionChange: (events: Event[]) => void;
     isLoading: boolean;
+    timezone: string | undefined;
 }

--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-row-expanded.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-row-expanded.component.tsx
@@ -45,6 +45,7 @@ export const AlgorithmRowExpanded: FunctionComponent<AlgorithmRowExpandedProps> 
         alertId,
         dimensionColumns,
         comparisonOffset,
+        timezone,
     }) => {
         const commonClasses = useCommonStyles();
         const {
@@ -88,7 +89,8 @@ export const AlgorithmRowExpanded: FunctionComponent<AlgorithmRowExpandedProps> 
                             startTime,
                             endTime,
                             comparisonOffset,
-                            t
+                            t,
+                            timezone
                         )
                     );
                 }

--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-row.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-row.component.tsx
@@ -66,6 +66,7 @@ export const AlgorithmRow: FunctionComponent<AlgorithmRowProps> = ({
     comparisonOffset,
     checked,
     onCheckClick,
+    timezone,
 }) => {
     const { t } = useTranslation();
     const [open, setOpen] = useState(false);
@@ -158,6 +159,7 @@ export const AlgorithmRow: FunctionComponent<AlgorithmRowProps> = ({
                                 endTime={endTime}
                                 row={row}
                                 startTime={startTime}
+                                timezone={timezone}
                             />
                         )}
                     </Collapse>

--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-table.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-table.component.tsx
@@ -34,6 +34,7 @@ export const AnomalyDimensionAnalysisTable: FunctionComponent<AlgorithmTableProp
         comparisonOffset,
         chartTimeSeriesFilterSet,
         onCheckClick,
+        timezone,
     }) => {
         const { t } = useTranslation();
         const totalSum = anomalyDimensionAnalysisData.responseRows.reduce(
@@ -120,6 +121,7 @@ export const AnomalyDimensionAnalysisTable: FunctionComponent<AlgorithmTableProp
                                     }
                                     row={row}
                                     startTime={anomaly.startTime}
+                                    timezone={timezone}
                                     totalSum={totalSum}
                                     onCheckClick={onCheckClick}
                                 />

--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-table.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-table.interfaces.ts
@@ -25,6 +25,7 @@ export interface AlgorithmTableProps {
     comparisonOffset: string;
     onCheckClick?: (filters: AnomalyFilterOption[]) => void;
     chartTimeSeriesFilterSet: AnomalyFilterOption[][];
+    timezone: string | undefined;
 }
 
 export interface AlgorithmRowProps {
@@ -39,6 +40,7 @@ export interface AlgorithmRowProps {
     dimensionColumns: string[];
     checked: boolean;
     onCheckClick?: (filters: AnomalyFilterOption[]) => void;
+    timezone: string | undefined;
 }
 
 export interface AlgorithmRowExpandedProps {
@@ -48,4 +50,5 @@ export interface AlgorithmRowExpandedProps {
     row: AnomalyDimensionAnalysisMetricRow;
     dimensionColumns: string[];
     comparisonOffset: string;
+    timezone: string | undefined;
 }

--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/anomaly-dimension-analysis.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/anomaly-dimension-analysis.component.tsx
@@ -36,6 +36,7 @@ export const AnomalyDimensionAnalysis: FunctionComponent<AnomalyDimensionAnalysi
         comparisonOffset,
         chartTimeSeriesFilterSet,
         onCheckClick,
+        timezone,
     }) => {
         const { notify } = useNotificationProviderV1();
         const { t } = useTranslation();
@@ -102,6 +103,7 @@ export const AnomalyDimensionAnalysis: FunctionComponent<AnomalyDimensionAnalysi
                                     chartTimeSeriesFilterSet
                                 }
                                 comparisonOffset={comparisonOffset}
+                                timezone={timezone}
                                 onCheckClick={onCheckClick}
                             />
                         )}

--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/anomaly-dimension-analysis.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/anomaly-dimension-analysis.interfaces.ts
@@ -24,6 +24,7 @@ export interface AnomalyDimensionAnalysisProps {
     anomaly: Anomaly;
     chartTimeSeriesFilterSet: AnomalyFilterOption[][];
     onCheckClick: (filters: AnomalyFilterOption[]) => void;
+    timezone: string | undefined;
 }
 export interface AnomalyDimensionAnalysisTableProps {
     anomalyDimensionAnalysisData: AnomalyDimensionAnalysisData;

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
@@ -83,6 +83,7 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
         onEventSelectionChange,
         getEnumerationItemRequest,
         enumerationItem,
+        timezone,
     }) => {
         const [searchParams, setSearchParams] = useSearchParams();
         const { t } = useTranslation();
@@ -246,7 +247,8 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
                     detectionEvalForAnomaly,
                     anomaly,
                     filteredAlertEvaluation,
-                    t
+                    t,
+                    timezone
                 )
             );
         }, [
@@ -254,6 +256,7 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
             anomaly,
             filteredAlertEvaluation,
             enumerationItem,
+            timezone,
         ]);
 
         const handleChartHeightChange = (height: number): void => {
@@ -339,7 +342,9 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
                             {/** Use flex to align the button group */}
                             <Box display="flex">
                                 <Box>
-                                    <TimeRangeButtonWithContext />
+                                    <TimeRangeButtonWithContext
+                                        timezone={timezone}
+                                    />
                                 </Box>
                                 <Box marginLeft={1}>
                                     <TooltipV1

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
@@ -44,6 +44,7 @@ import { AlertEvaluation } from "../../../rest/dto/alert.interfaces";
 import { DetectionEvaluation } from "../../../rest/dto/detection.interfaces";
 import {
     DEFAULT_FEEDBACK,
+    determineTimezoneFromAlertInEvaluation,
     extractDetectionEvaluation,
 } from "../../../utils/alerts/alerts.util";
 import { createAlertEvaluation } from "../../../utils/anomalies/anomalies.util";
@@ -83,7 +84,7 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
         onEventSelectionChange,
         getEnumerationItemRequest,
         enumerationItem,
-        timezone,
+        onAlertEvaluationDidFetch,
     }) => {
         const [searchParams, setSearchParams] = useSearchParams();
         const { t } = useTranslation();
@@ -126,10 +127,12 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
 
             getEvaluation(
                 createAlertEvaluation(anomaly.alert.id, startTime, endTime)
-            ).then(
-                (fetchedEvaluation) =>
-                    fetchedEvaluation && setAlertEvaluation(fetchedEvaluation)
-            );
+            ).then((fetchedEvaluation) => {
+                fetchedEvaluation && setAlertEvaluation(fetchedEvaluation);
+                fetchedEvaluation &&
+                    onAlertEvaluationDidFetch &&
+                    onAlertEvaluationDidFetch(fetchedEvaluation);
+            });
         };
 
         const fetchFilteredAlertEvaluations = (): void => {
@@ -248,7 +251,9 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
                     anomaly,
                     filteredAlertEvaluation,
                     t,
-                    timezone
+                    determineTimezoneFromAlertInEvaluation(
+                        alertEvaluation.alert
+                    )
                 )
             );
         }, [
@@ -256,7 +261,6 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
             anomaly,
             filteredAlertEvaluation,
             enumerationItem,
-            timezone,
         ]);
 
         const handleChartHeightChange = (height: number): void => {
@@ -343,7 +347,9 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
                             <Box display="flex">
                                 <Box>
                                     <TimeRangeButtonWithContext
-                                        timezone={timezone}
+                                        timezone={determineTimezoneFromAlertInEvaluation(
+                                            alertEvaluation?.alert
+                                        )}
                                     />
                                 </Box>
                                 <Box marginLeft={1}>

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.interfaces.ts
@@ -27,4 +27,5 @@ export interface AnomalyTimeSeriesCardProps {
     onEventSelectionChange: (events: Event[]) => void;
     getEnumerationItemRequest: ActionStatus;
     enumerationItem: EnumerationItem | null;
+    timezone: string | undefined;
 }

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.interfaces.ts
@@ -13,6 +13,7 @@
  * the License.
  */
 import { ActionStatus } from "../../../rest/actions.interfaces";
+import { AlertEvaluation } from "../../../rest/dto/alert.interfaces";
 import { Anomaly } from "../../../rest/dto/anomaly.interfaces";
 import { EnumerationItem } from "../../../rest/dto/enumeration-item.interfaces";
 import { Event } from "../../../rest/dto/event.interfaces";
@@ -27,5 +28,5 @@ export interface AnomalyTimeSeriesCardProps {
     onEventSelectionChange: (events: Event[]) => void;
     getEnumerationItemRequest: ActionStatus;
     enumerationItem: EnumerationItem | null;
-    timezone: string | undefined;
+    onAlertEvaluationDidFetch: (evaluation: AlertEvaluation) => void;
 }

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.utils.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.utils.tsx
@@ -213,7 +213,8 @@ export const generateChartOptions = (
     detectionEvaluation: DetectionEvaluation,
     anomaly: Anomaly,
     filteredAlertEvaluation: [AlertEvaluation, AnomalyFilterOption[]][],
-    translation: (id: string) => string
+    translation: (id: string) => string,
+    timezone?: string
 ): TimeSeriesChartProps => {
     let series: Series[] = [];
 
@@ -230,12 +231,14 @@ export const generateChartOptions = (
                 [anomaly],
                 translation,
                 timeseriesData.timestamp,
-                timeseriesData.current
+                timeseriesData.current,
+                undefined,
+                timezone
             )
         );
     }
 
-    return {
+    const chartOptions: TimeSeriesChartProps = {
         series,
         yAxis: {
             position: Orientation.right,
@@ -245,6 +248,14 @@ export const generateChartOptions = (
         zoom: true,
         tooltip: true,
     };
+
+    if (timezone) {
+        chartOptions.xAxis = {
+            timezone,
+        };
+    }
+
+    return chartOptions;
 };
 
 export const generateSeriesForAnomalies = (
@@ -252,7 +263,8 @@ export const generateSeriesForAnomalies = (
     translation: (id: string) => string,
     timestamps: number[],
     valuesToTrackAgainst: number[],
-    navigate?: NavigateFunction
+    navigate?: NavigateFunction,
+    timezone?: string
 ): Series => {
     const granularityBestGuess = determineGranularity(timestamps);
 
@@ -294,7 +306,7 @@ export const generateSeriesForAnomalies = (
     return {
         name: translation("label.anomalies"),
         /**
-         * We need the points in data so it shows up in the legend
+         * We need the points in data, so it shows up in the legend
          * and in the filtered chart
          */
         data: flatten(
@@ -339,7 +351,8 @@ export const generateSeriesForAnomalies = (
                                 <td>{translation("label.start")}</td>
                                 <td align="right">
                                     {formatDateAndTimeV1(
-                                        dataPoint.extraData.startTime
+                                        dataPoint.extraData.startTime,
+                                        timezone
                                     )}
                                 </td>
                             </tr>
@@ -347,7 +360,8 @@ export const generateSeriesForAnomalies = (
                                 <td>{translation("label.end")}</td>
                                 <td align="right">
                                     {formatDateAndTimeV1(
-                                        dataPoint.extraData.endTime
+                                        dataPoint.extraData.endTime,
+                                        timezone
                                     )}
                                 </td>
                             </tr>
@@ -470,7 +484,8 @@ export const generateChartOptionsForAlert = (
     detectionEvaluation: DetectionEvaluation,
     anomalies: Anomaly[],
     translation: (id: string) => string,
-    navigate?: NavigateFunction
+    navigate?: NavigateFunction,
+    timezone?: string
 ): TimeSeriesChartProps => {
     let series: Series[] = [];
 
@@ -489,12 +504,13 @@ export const generateChartOptionsForAlert = (
                 translation,
                 detectionEvaluation.data.timestamp,
                 detectionEvaluation.data.current,
-                navigate
+                navigate,
+                timezone
             )
         );
     }
 
-    return {
+    const chartOptions: TimeSeriesChartProps = {
         series,
         legend: true,
         brush: true,
@@ -504,12 +520,21 @@ export const generateChartOptionsForAlert = (
             position: Orientation.right,
         },
     };
+
+    if (timezone) {
+        chartOptions.xAxis = {
+            timezone,
+        };
+    }
+
+    return chartOptions;
 };
 
 export const generateChartOptionsForMetricsReport = (
     detectionEvaluation: DetectionEvaluation,
     anomalies: Anomaly[],
-    translation: (id: string) => string
+    translation: (id: string) => string,
+    timezone?: string
 ): TimeSeriesChartProps => {
     let series: Series[] = [];
 
@@ -535,7 +560,7 @@ export const generateChartOptionsForMetricsReport = (
         );
     }
 
-    return {
+    const chartOptions: TimeSeriesChartProps = {
         series,
         legend: false,
         brush: false,
@@ -543,6 +568,14 @@ export const generateChartOptionsForMetricsReport = (
         tooltip: false,
         yAxis: { enabled: false },
     };
+
+    if (timezone) {
+        chartOptions.xAxis = {
+            timezone,
+        };
+    }
+
+    return chartOptions;
 };
 
 export const determineInitialZoom = (

--- a/thirdeye-ui/src/app/components/rca/events-tab/event-tab.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/events-tab/event-tab.component.tsx
@@ -48,6 +48,7 @@ export const EventsTab: FunctionComponent<EventsTabProps> = ({
     onCheckClick,
     searchValue,
     triggerUpdate,
+    timezone,
 }: EventsTabProps) => {
     const { t } = useTranslation();
     const { getEventsForAnomaly, errorMessages, status, events } =
@@ -118,14 +119,14 @@ export const EventsTab: FunctionComponent<EventsTabProps> = ({
 
     const startTimeRenderer = useCallback(
         (_: Record<string, unknown>, data: Event): ReactNode =>
-            formatDateAndTimeV1(data.startTime),
-        []
+            formatDateAndTimeV1(data.startTime, timezone),
+        [timezone]
     );
 
     const endTimeRenderer = useCallback(
         (_: Record<string, unknown>, data: Event): ReactNode =>
-            formatDateAndTimeV1(data.endTime),
-        []
+            formatDateAndTimeV1(data.endTime, timezone),
+        [timezone]
     );
 
     const metadataRenderer = useCallback(

--- a/thirdeye-ui/src/app/components/rca/events-tab/event-tab.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/events-tab/event-tab.interfaces.ts
@@ -20,4 +20,5 @@ export interface EventsTabProps {
     selectedEvents: Event[];
     searchValue: string;
     triggerUpdate: boolean;
+    timezone: string | undefined;
 }

--- a/thirdeye-ui/src/app/components/time-range/time-range-button/time-range-button.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/time-range-button/time-range-button.component.tsx
@@ -13,14 +13,16 @@
  * the License.
  */
 import { Button, ButtonGroup, Popover } from "@material-ui/core";
-import CalendarTodayIcon from "@material-ui/icons/CalendarToday";
 import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft";
 import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight";
 import React, { FunctionComponent, MouseEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TooltipV1 } from "../../../platform/components";
 import { formatTimeRangeDuration } from "../../../utils/time-range/time-range.util";
-import { WEEK_IN_MILLISECONDS } from "../../../utils/time/time.util";
+import {
+    timezoneStringShort,
+    WEEK_IN_MILLISECONDS,
+} from "../../../utils/time/time.util";
 import { TimeRangeSelectorPopoverContent } from "../time-range-selector-popover-content/time-range-selector-popover-content.component";
 import { TimeRangeButtonProps } from "./time-range-button.interfaces";
 
@@ -101,11 +103,11 @@ export const TimeRangeButton: FunctionComponent<TimeRangeButtonProps> = ({
 
                 <Button
                     color={btnGroupColor}
-                    startIcon={<CalendarTodayIcon />}
                     variant="outlined"
                     onClick={handleTimeRangeSelectorClick}
                 >
-                    {formatTimeRangeDuration(timeRangeDuration, timezone)}
+                    {formatTimeRangeDuration(timeRangeDuration, timezone)} (
+                    {timezoneStringShort(timezone)})
                 </Button>
                 {!hideQuickExtend && (
                     <Button

--- a/thirdeye-ui/src/app/components/time-range/time-range-selector/time-range-selector/time-range-selector.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/time-range-selector/time-range-selector/time-range-selector.component.tsx
@@ -20,6 +20,7 @@ import {
     formatTimeRange,
     formatTimeRangeDuration,
 } from "../../../../utils/time-range/time-range.util";
+import { timezoneStringShort } from "../../../../utils/time/time.util";
 import { SafariMuiGridFix } from "../../../safari-mui-grid-fix/safari-mui-grid-fix.component";
 import { TimeRangeSelectorPopoverContent } from "../../time-range-selector-popover-content/time-range-selector-popover-content.component";
 import { TimeRangeSelectorProps } from "./time-range-selector.interfaces";
@@ -61,7 +62,8 @@ export const TimeRangeSelector: FunctionComponent<TimeRangeSelectorProps> = ({
 
                     {/* Time range duration */}
                     <Typography variant="body2">
-                        {formatTimeRangeDuration(timeRangeDuration, timezone)}
+                        {formatTimeRangeDuration(timeRangeDuration, timezone)} (
+                        {timezoneStringShort(timezone)})
                     </Typography>
                 </Grid>
             )}

--- a/thirdeye-ui/src/app/components/time-range/time-range-selector/time-range-selector/time-range-selector.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/time-range-selector/time-range-selector/time-range-selector.component.tsx
@@ -33,6 +33,7 @@ export const TimeRangeSelector: FunctionComponent<TimeRangeSelectorProps> = ({
     recentCustomTimeRangeDurations,
     onRefresh,
     onChange,
+    timezone,
 }) => {
     const timeRangeSelectorClasses = useTimeRangeSelectorStyles();
     const [timeRangeSelectorAnchorElement, setTimeRangeSelectorAnchorElement] =
@@ -60,7 +61,7 @@ export const TimeRangeSelector: FunctionComponent<TimeRangeSelectorProps> = ({
 
                     {/* Time range duration */}
                     <Typography variant="body2">
-                        {formatTimeRangeDuration(timeRangeDuration)}
+                        {formatTimeRangeDuration(timeRangeDuration, timezone)}
                     </Typography>
                 </Grid>
             )}
@@ -90,6 +91,7 @@ export const TimeRangeSelector: FunctionComponent<TimeRangeSelectorProps> = ({
                                 recentCustomTimeRangeDurations
                             }
                             timeRangeDuration={timeRangeDuration}
+                            timezone={timezone}
                             onChange={onChange}
                             onClose={handleTimeRangeSelectorClose}
                         />

--- a/thirdeye-ui/src/app/components/time-range/time-range-selector/time-range-selector/time-range-selector.interfaces.ts
+++ b/thirdeye-ui/src/app/components/time-range/time-range-selector/time-range-selector/time-range-selector.interfaces.ts
@@ -22,4 +22,5 @@ export interface TimeRangeSelectorProps {
     recentCustomTimeRangeDurations?: TimeRangeDuration[];
     onChange?: (timeRangeDuration: TimeRangeDuration) => void;
     onRefresh?: () => void;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/alert-evaluation-time-series-card.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/alert-evaluation-time-series-card.component.tsx
@@ -31,6 +31,7 @@ export const AlertEvaluationTimeSeriesCard: FunctionComponent<AlertEvaluationTim
         onRefresh,
         anomalies,
         disableNavigation,
+        timezone,
     }) => {
         const navigate = useNavigate();
         const { t } = useTranslation();
@@ -52,6 +53,7 @@ export const AlertEvaluationTimeSeriesCard: FunctionComponent<AlertEvaluationTim
                             <Grid container>
                                 <Grid item>
                                     <TimeRangeButtonWithContext
+                                        timezone={timezone}
                                         onTimeRangeChange={(
                                             start: number,
                                             end: number
@@ -71,7 +73,8 @@ export const AlertEvaluationTimeSeriesCard: FunctionComponent<AlertEvaluationTim
                                 detectionEvaluation,
                                 anomalies,
                                 t,
-                                disableNavigation ? undefined : navigate
+                                disableNavigation ? undefined : navigate,
+                                timezone
                             )}
                         />
                     )}

--- a/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/alert-evaluation-time-series-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/alert-evaluation-time-series-card.interfaces.ts
@@ -23,11 +23,13 @@ export interface AlertEvaluationTimeSeriesCardProps {
     header?: React.ReactElement;
     anomalies: Anomaly[];
     disableNavigation?: boolean;
+    timezone?: string;
 }
 
 export interface ViewAnomalyHeaderProps {
     anomaly: Anomaly | null;
     onRefresh?: (start?: number, end?: number) => void;
+    timezone?: string;
 }
 
 export interface CreateAlertHeaderProps {

--- a/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/headers/view-anomaly-header.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/headers/view-anomaly-header.component.tsx
@@ -22,6 +22,7 @@ import { ViewAnomalyHeaderProps } from "../alert-evaluation-time-series-card.int
 export const ViewAnomalyHeader: FunctionComponent<ViewAnomalyHeaderProps> = ({
     anomaly,
     onRefresh,
+    timezone,
 }) => {
     return (
         <CardContent>
@@ -48,6 +49,7 @@ export const ViewAnomalyHeader: FunctionComponent<ViewAnomalyHeaderProps> = ({
                     xs={12}
                 >
                     <TimeRangeButtonWithContext
+                        timezone={timezone}
                         onTimeRangeChange={(start: number, end: number) =>
                             onRefresh && onRefresh(start, end)
                         }

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/chart-core/tick-calculator/chart-time-axis.utils.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/chart-core/tick-calculator/chart-time-axis.utils.ts
@@ -51,11 +51,16 @@ export const tickFormat = (dateLuxon: DateTime): string => {
     } else if (timeMinute(dateLuxon) < dateLuxon) {
         return dateLuxon.toLocaleString({ second: "2-digit" });
     } else if (timeHour(dateLuxon) < dateLuxon) {
-        return dateLuxon.toLocaleString({ hour: "2-digit", minute: "2-digit" });
+        return dateLuxon.toLocaleString({
+            hour: "2-digit",
+            minute: "2-digit",
+            timeZoneName: "short",
+        });
     } else if (timeDay(dateLuxon) < dateLuxon) {
         return dateLuxon.toLocaleString({
             hour: "2-digit",
             hour12: true,
+            timeZoneName: "short",
         });
     } else if (timeMonth(dateLuxon) < dateLuxon) {
         if (timeWeekday(0)(dateLuxon) < dateLuxon) {

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -388,15 +388,18 @@ export const TimeSeriesChartInternal: FunctionComponent<TimeSeriesChartInternalP
 
         return (
             <div style={{ position: "relative" }}>
-                <Box paddingLeft={5} position="absolute">
-                    <Typography color="textSecondary" variant="caption">
-                        {t("message.times-displayed-in-timezone", {
-                            timezone:
-                                xAxis?.timezone ??
-                                (Settings.defaultZone as Zone).name,
-                        })}
-                    </Typography>
-                </Box>
+                {height > 200 && (
+                    <Box paddingLeft={5} position="absolute">
+                        <Typography color="textSecondary" variant="caption">
+                            {t("message.times-displayed-in-timezone", {
+                                timezone:
+                                    xAxis?.timezone ??
+                                    (Settings.defaultZone as Zone).name,
+                            })}
+                        </Typography>
+                    </Box>
+                )}
+
                 {events && events.length > 0 && (
                     <EventsChart
                         events={processedEvents}

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -16,7 +16,7 @@ import { Box, Button, Typography } from "@material-ui/core";
 import { ParentSize } from "@visx/responsive";
 import { scaleOrdinal, scaleTime } from "@visx/scale";
 import { TooltipWithBounds, useTooltip } from "@visx/tooltip";
-import { Settings } from "luxon";
+import { Settings, Zone } from "luxon";
 import React, {
     FunctionComponent,
     MouseEvent,
@@ -388,17 +388,15 @@ export const TimeSeriesChartInternal: FunctionComponent<TimeSeriesChartInternalP
 
         return (
             <div style={{ position: "relative" }}>
-                {!!xAxis?.timezone &&
-                    Settings.defaultZone !== xAxis.timezone &&
-                    height > 200 && (
-                        <Box paddingLeft={5} position="absolute">
-                            <Typography color="textSecondary" variant="caption">
-                                {t("message.times-displayed-in-timezone", {
-                                    timezone: xAxis.timezone,
-                                })}
-                            </Typography>
-                        </Box>
-                    )}
+                <Box paddingLeft={5} position="absolute">
+                    <Typography color="textSecondary" variant="caption">
+                        {t("message.times-displayed-in-timezone", {
+                            timezone:
+                                xAxis?.timezone ??
+                                (Settings.defaultZone as Zone).name,
+                        })}
+                    </Typography>
+                </Box>
                 {events && events.length > 0 && (
                     <EventsChart
                         events={processedEvents}

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -12,11 +12,10 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { Box, Button, Typography } from "@material-ui/core";
+import { Box, Button } from "@material-ui/core";
 import { ParentSize } from "@visx/responsive";
 import { scaleOrdinal, scaleTime } from "@visx/scale";
 import { TooltipWithBounds, useTooltip } from "@visx/tooltip";
-import { Settings, Zone } from "luxon";
 import React, {
     FunctionComponent,
     MouseEvent,
@@ -388,18 +387,6 @@ export const TimeSeriesChartInternal: FunctionComponent<TimeSeriesChartInternalP
 
         return (
             <div style={{ position: "relative" }}>
-                {height > 200 && (
-                    <Box paddingLeft={5} position="absolute">
-                        <Typography color="textSecondary" variant="caption">
-                            {t("message.times-displayed-in-timezone", {
-                                timezone:
-                                    xAxis?.timezone ??
-                                    (Settings.defaultZone as Zone).name,
-                            })}
-                        </Typography>
-                    </Box>
-                )}
-
                 {events && events.length > 0 && (
                     <EventsChart
                         events={processedEvents}

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-popover.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/tooltip/tooltip-popover.component.tsx
@@ -15,6 +15,7 @@
 import { Grid, Typography } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
 import { formatDateAndTimeV1 } from "../../../../platform/utils";
+import { timezoneStringShort } from "../../../../utils/time/time.util";
 import { DataPoint, NormalizedSeries } from "../time-series-chart.interfaces";
 import { TooltipPopoverProps } from "./tooltip.interfaces";
 import { useTooltipStyles } from "./tooltip.styles";
@@ -42,7 +43,8 @@ export const TooltipPopover: FunctionComponent<TooltipPopoverProps> = ({
                 >
                     <Grid item>
                         <Typography variant="overline">
-                            {formatDateAndTimeV1(xValue, timezoneOverride)}
+                            {formatDateAndTimeV1(xValue, timezoneOverride)}{" "}
+                            {`(${timezoneStringShort(timezoneOverride)})`}
                         </Typography>
                     </Grid>
                 </Grid>

--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -175,6 +175,7 @@
         "heatmap-data": "Heatmap Data",
         "help": "Help",
         "hide-count-default-properties": "Hide {{count}} default properties",
+        "hide-details": "Hide Details",
         "hide-preview": "Hide preview",
         "high": "High",
         "holt-winters-rule": "Holt-Winters Rule",

--- a/thirdeye-ui/src/app/pages/alerts-anomalies-page/alerts-anomalies-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-anomalies-page/alerts-anomalies-page.component.tsx
@@ -33,7 +33,6 @@ import { deleteAnomaly } from "../../rest/anomalies/anomalies.rest";
 import { useGetAnomalies } from "../../rest/anomalies/anomaly.actions";
 import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
 import { useGetEnumerationItem } from "../../rest/enumeration-items/enumeration-items.actions";
-import { determineTimezoneFromAlert } from "../../utils/alerts/alerts.util";
 import {
     filterAnomaliesByFunctions,
     getUiAnomalies,
@@ -238,11 +237,13 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
                                 // This prop is set to null every time the API is called again to
                                 // trigger a UI loading state, since otherwise the new data just
                                 // replaces the old one abruptly
-                                anomaliesRequestStatus === ActionStatus.Working
+                                anomaliesRequestStatus ===
+                                    ActionStatus.Working ||
+                                anomaliesRequestStatus === ActionStatus.Initial
                                     ? null
                                     : uiAnomalies
                             }
-                            timezone={determineTimezoneFromAlert(alert)}
+                            // timezone={determineTimezoneFromAlert(alert)}
                             toolbar={
                                 <>
                                     <Box width="100%">
@@ -262,9 +263,9 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
                                     </Box>
                                     <AnomalyQuickFilters
                                         showTimeSelectorOnly
-                                        timezone={determineTimezoneFromAlert(
-                                            alert
-                                        )}
+                                        // timezone={determineTimezoneFromAlert(
+                                        //     alert
+                                        // )}
                                     />
                                 </>
                             }

--- a/thirdeye-ui/src/app/pages/alerts-anomalies-page/alerts-anomalies-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-anomalies-page/alerts-anomalies-page.component.tsx
@@ -33,6 +33,7 @@ import { deleteAnomaly } from "../../rest/anomalies/anomalies.rest";
 import { useGetAnomalies } from "../../rest/anomalies/anomaly.actions";
 import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
 import { useGetEnumerationItem } from "../../rest/enumeration-items/enumeration-items.actions";
+import { determineTimezoneFromAlert } from "../../utils/alerts/alerts.util";
 import {
     filterAnomaliesByFunctions,
     getUiAnomalies,
@@ -241,6 +242,7 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
                                     ? null
                                     : uiAnomalies
                             }
+                            timezone={determineTimezoneFromAlert(alert)}
                             toolbar={
                                 <>
                                     <Box width="100%">
@@ -258,7 +260,12 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
                                             label={t("message.show-ignored")}
                                         />
                                     </Box>
-                                    <AnomalyQuickFilters showTimeSelectorOnly />
+                                    <AnomalyQuickFilters
+                                        showTimeSelectorOnly
+                                        timezone={determineTimezoneFromAlert(
+                                            alert
+                                        )}
+                                    />
                                 </>
                             }
                             onDelete={handleAnomalyDelete}

--- a/thirdeye-ui/src/app/pages/alerts-anomalies-page/alerts-anomalies-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-anomalies-page/alerts-anomalies-page.component.tsx
@@ -28,11 +28,15 @@ import {
     useNotificationProviderV1,
 } from "../../platform/components";
 import { ActionStatus } from "../../rest/actions.interfaces";
-import { useGetAlert } from "../../rest/alerts/alerts.actions";
+import {
+    useGetAlert,
+    useGetAlertInsight,
+} from "../../rest/alerts/alerts.actions";
 import { deleteAnomaly } from "../../rest/anomalies/anomalies.rest";
 import { useGetAnomalies } from "../../rest/anomalies/anomaly.actions";
 import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
 import { useGetEnumerationItem } from "../../rest/enumeration-items/enumeration-items.actions";
+import { determineTimezoneFromAlertInEvaluation } from "../../utils/alerts/alerts.util";
 import {
     filterAnomaliesByFunctions,
     getUiAnomalies,
@@ -59,6 +63,8 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
     const { showDialog } = useDialogProviderV1();
     const { notify } = useNotificationProviderV1();
     const { id: alertId } = useParams<AlertsAnomaliesParams>();
+    // Insights is used here to get timezone information
+    const { alertInsight, getAlertInsight } = useGetAlertInsight();
     const {
         alert,
         getAlert,
@@ -139,6 +145,7 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
 
     useEffect(() => {
         getAlert(Number(alertId));
+        getAlertInsight({ alertId: Number(alertId) });
     }, [alertId]);
 
     useEffect(() => {
@@ -243,7 +250,9 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
                                     ? null
                                     : uiAnomalies
                             }
-                            // timezone={determineTimezoneFromAlert(alert)}
+                            timezone={determineTimezoneFromAlertInEvaluation(
+                                alertInsight?.templateWithProperties
+                            )}
                             toolbar={
                                 <>
                                     <Box width="100%">
@@ -263,9 +272,9 @@ export const AlertsAnomaliesPage: FunctionComponent = () => {
                                     </Box>
                                     <AnomalyQuickFilters
                                         showTimeSelectorOnly
-                                        // timezone={determineTimezoneFromAlert(
-                                        //     alert
-                                        // )}
+                                        timezone={determineTimezoneFromAlertInEvaluation(
+                                            alertInsight?.templateWithProperties
+                                        )}
                                     />
                                 </>
                             }

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -64,10 +64,14 @@ import {
     updateAlert,
 } from "../../rest/alerts/alerts.rest";
 import { useGetAnomalies } from "../../rest/anomalies/anomaly.actions";
-import { Alert, AlertStats } from "../../rest/dto/alert.interfaces";
+import {
+    Alert,
+    AlertInEvaluation,
+    AlertStats,
+} from "../../rest/dto/alert.interfaces";
 import {
     createAlertEvaluation,
-    determineTimezoneFromAlert,
+    determineTimezoneFromAlertInEvaluation,
     extractDetectionEvaluation,
 } from "../../utils/alerts/alerts.util";
 import { generateNameForDetectionResult } from "../../utils/enumeration-items/enumeration-items.util";
@@ -547,7 +551,15 @@ export const AlertsViewPage: FunctionComponent = () => {
                         }
                         loadingState={<SkeletonV1 />}
                     >
-                        <AlertViewSubHeader alert={alert as Alert} />
+                        <AlertViewSubHeader
+                            alert={alert as Alert}
+                            timezone={determineTimezoneFromAlertInEvaluation(
+                                evaluation?.alert.template as Pick<
+                                    AlertInEvaluation,
+                                    "metadata"
+                                >
+                            )}
+                        />
                     </LoadingErrorStateSwitch>
                 </Grid>
 
@@ -608,8 +620,12 @@ export const AlertsViewPage: FunctionComponent = () => {
                                             expanded={expanded}
                                             initialSearchTerm={searchTerm || ""}
                                             sortOrder={sortOrder}
-                                            timezone={determineTimezoneFromAlert(
-                                                alert
+                                            timezone={determineTimezoneFromAlertInEvaluation(
+                                                evaluation?.alert
+                                                    ?.template as Pick<
+                                                    AlertInEvaluation,
+                                                    "metadata"
+                                                >
                                             )}
                                             onExpandedChange={
                                                 handleExpandedChange

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -67,6 +67,7 @@ import { useGetAnomalies } from "../../rest/anomalies/anomaly.actions";
 import { Alert, AlertStats } from "../../rest/dto/alert.interfaces";
 import {
     createAlertEvaluation,
+    determineTimezoneFromAlert,
     extractDetectionEvaluation,
 } from "../../utils/alerts/alerts.util";
 import { generateNameForDetectionResult } from "../../utils/enumeration-items/enumeration-items.util";
@@ -538,11 +539,16 @@ export const AlertsViewPage: FunctionComponent = () => {
             <PageContentsGridV1>
                 {/* Alert sub header */}
                 <Grid item xs={12}>
-                    {getAlertStatus === ActionStatus.Working ? (
-                        <SkeletonV1 />
-                    ) : (
-                        alert && <AlertViewSubHeader alert={alert} />
-                    )}
+                    <LoadingErrorStateSwitch
+                        isError={getAlertStatus === ActionStatus.Error}
+                        isLoading={
+                            getAlertStatus === ActionStatus.Initial ||
+                            getAlertStatus === ActionStatus.Working
+                        }
+                        loadingState={<SkeletonV1 />}
+                    >
+                        <AlertViewSubHeader alert={alert as Alert} />
+                    </LoadingErrorStateSwitch>
                 </Grid>
 
                 {/* Alert evaluation time series */}
@@ -602,6 +608,9 @@ export const AlertsViewPage: FunctionComponent = () => {
                                             expanded={expanded}
                                             initialSearchTerm={searchTerm || ""}
                                             sortOrder={sortOrder}
+                                            timezone={determineTimezoneFromAlert(
+                                                alert
+                                            )}
                                             onExpandedChange={
                                                 handleExpandedChange
                                             }

--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-page.component.tsx
@@ -39,10 +39,7 @@ import {
 } from "../../platform/components";
 import { DialogType } from "../../platform/components/dialog-provider-v1/dialog-provider-v1.interfaces";
 import { ActionStatus } from "../../rest/actions.interfaces";
-import {
-    useGetAlert,
-    useGetEvaluation,
-} from "../../rest/alerts/alerts.actions";
+import { useGetEvaluation } from "../../rest/alerts/alerts.actions";
 import { deleteAnomaly } from "../../rest/anomalies/anomalies.rest";
 import { useGetAnomaly } from "../../rest/anomalies/anomaly.actions";
 import { Anomaly } from "../../rest/dto/anomaly.interfaces";
@@ -51,7 +48,7 @@ import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
 import { useGetEnumerationItem } from "../../rest/enumeration-items/enumeration-items.actions";
 import { useGetInvestigations } from "../../rest/rca/rca.actions";
 import {
-    determineTimezoneFromAlert,
+    determineTimezoneFromAlertInEvaluation,
     extractDetectionEvaluation,
 } from "../../utils/alerts/alerts.util";
 import {
@@ -74,7 +71,6 @@ import { AnomaliesViewPageParams } from "./anomalies-view-page.interfaces";
 import { useAnomaliesViewPageStyles } from "./anomalies-view-page.styles";
 
 export const AnomaliesViewPage: FunctionComponent = () => {
-    const { alert, getAlert } = useGetAlert();
     const {
         enumerationItem,
         getEnumerationItem,
@@ -142,7 +138,6 @@ export const AnomaliesViewPage: FunctionComponent = () => {
     useEffect(() => {
         // Fetched alert or time range changed, fetch alert evaluation
         fetchAlertEvaluation();
-        anomaly && getAlert(anomaly.alert.id);
     }, [anomaly, searchParams]);
 
     useEffect(() => {
@@ -364,7 +359,9 @@ export const AnomaliesViewPage: FunctionComponent = () => {
                         isLoading={
                             anomalyRequestStatus === ActionStatus.Working
                         }
-                        timezone={determineTimezoneFromAlert(alert)}
+                        timezone={determineTimezoneFromAlertInEvaluation(
+                            evaluation?.alert
+                        )}
                         uiAnomaly={uiAnomaly}
                     />
                 </Grid>
@@ -387,7 +384,9 @@ export const AnomaliesViewPage: FunctionComponent = () => {
                             header={
                                 <ViewAnomalyHeader
                                     anomaly={anomaly}
-                                    timezone={determineTimezoneFromAlert(alert)}
+                                    timezone={determineTimezoneFromAlertInEvaluation(
+                                        evaluation?.alert
+                                    )}
                                     onRefresh={fetchAlertEvaluation}
                                 />
                             }
@@ -395,7 +394,9 @@ export const AnomaliesViewPage: FunctionComponent = () => {
                                 getEvaluationRequestStatus ===
                                 ActionStatus.Working
                             }
-                            timezone={determineTimezoneFromAlert(alert)}
+                            timezone={determineTimezoneFromAlertInEvaluation(
+                                evaluation?.alert
+                            )}
                         />
                     )}
                 </Grid>

--- a/thirdeye-ui/src/app/pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.component.tsx
@@ -32,6 +32,7 @@ import { ActionStatus } from "../../rest/actions.interfaces";
 import { Event } from "../../rest/dto/event.interfaces";
 import { Investigation, SavedStateKeys } from "../../rest/dto/rca.interfaces";
 import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
+import { determineTimezoneFromAlert } from "../../utils/alerts/alerts.util";
 import { getUiAnomaly } from "../../utils/anomalies/anomalies.util";
 import { getFromSavedInvestigationOrDefault } from "../../utils/investigation/investigation.util";
 import { notifyIfErrors } from "../../utils/notifications/notifications.util";
@@ -52,6 +53,7 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
         anomaly,
         getAnomalyRequestStatus,
         anomalyRequestErrors,
+        alert,
     } = useOutletContext<InvestigationContext>();
     const [uiAnomaly, setUiAnomaly] = useState<UiAnomaly | null>(null);
     const [chartTimeSeriesFilterSet, setChartTimeSeriesFilterSet] = useState<
@@ -126,6 +128,8 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
         );
     }, [getAnomalyRequestStatus, anomalyRequestErrors]);
 
+    const timezone = determineTimezoneFromAlert(alert);
+
     const handleAddFilterSetClick = (filters: AnomalyFilterOption[]): void => {
         const serializedFilters = serializeKeyValuePair(filters);
         const existingIndex = chartTimeSeriesFilterSet.findIndex(
@@ -163,10 +167,12 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
                 >
                     <Grid item lg={12} md={12} sm={12} xs={12}>
                         <AnomalySummaryCard
+                            alert={alert}
                             className={style.fullHeight}
                             isLoading={
                                 getAnomalyRequestStatus === ActionStatus.Working
                             }
+                            timezone={timezone}
                             uiAnomaly={uiAnomaly}
                         />
                     </Grid>
@@ -184,8 +190,8 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
             <Grid item xs={12}>
                 <AnomalyTimeSeriesCard
                     anomaly={anomaly}
-                    // Selected events should be shown on the graph
                     enumerationItem={enumerationItem}
+                    // Selected events should be shown on the graph
                     events={selectedEvents}
                     getEnumerationItemRequest={getEnumerationItemRequest}
                     isLoading={
@@ -193,6 +199,7 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
                         getAnomalyRequestStatus === ActionStatus.Initial
                     }
                     timeSeriesFiltersSet={chartTimeSeriesFilterSet}
+                    timezone={timezone}
                     onEventSelectionChange={handleEventSelectionChange}
                     onRemoveBtnClick={handleRemoveBtnClick}
                 />
@@ -206,6 +213,7 @@ export const RootCauseAnalysisForAnomalyPage: FunctionComponent = () => {
                     chartTimeSeriesFilterSet={chartTimeSeriesFilterSet}
                     isLoading={getAnomalyRequestStatus === ActionStatus.Working}
                     selectedEvents={selectedEvents}
+                    timezone={timezone}
                     onAddFilterSetClick={handleAddFilterSetClick}
                     onEventSelectionChange={handleEventSelectionChange}
                 />

--- a/thirdeye-ui/src/app/pages/root-cause-analysis-investigation-state-tracker/investigation-state-tracker.component.tsx
+++ b/thirdeye-ui/src/app/pages/root-cause-analysis-investigation-state-tracker/investigation-state-tracker.component.tsx
@@ -18,6 +18,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Outlet, useParams, useSearchParams } from "react-router-dom";
 import { PageHeader } from "../../components/page-header/page-header.component";
+import { LoadingErrorStateSwitch } from "../../components/page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { InvestigationOptions } from "../../components/rca/investigation-options/investigation-options.component";
 import {
     AppLoadingIndicatorV1,
@@ -30,6 +31,7 @@ import {
     useNotificationProviderV1,
 } from "../../platform/components";
 import { ActionStatus } from "../../rest/actions.interfaces";
+import { useGetAlert } from "../../rest/alerts/alerts.actions";
 import { useGetAnomaly } from "../../rest/anomalies/anomaly.actions";
 import { Investigation, SavedStateKeys } from "../../rest/dto/rca.interfaces";
 import { useGetEnumerationItem } from "../../rest/enumeration-items/enumeration-items.actions";
@@ -61,8 +63,14 @@ export const InvestigationStateTracker: FunctionComponent = () => {
         useState<Investigation | null>(null);
     const { id: anomalyId } =
         useParams<RootCauseAnalysisForAnomalyPageParams>();
-    const { anomaly, getAnomaly, status, errorMessages } = useGetAnomaly();
 
+    const {
+        anomaly,
+        getAnomaly,
+        status: getAnomalyStatus,
+        errorMessages,
+    } = useGetAnomaly();
+    const { alert, getAlert, status: getAlertStatus } = useGetAlert();
     const {
         enumerationItem,
         getEnumerationItem,
@@ -75,7 +83,11 @@ export const InvestigationStateTracker: FunctionComponent = () => {
     } = useGetInvestigation();
 
     useEffect(() => {
-        getAnomaly(Number(anomalyId));
+        getAnomaly(Number(anomalyId)).then((anomaly) => {
+            if (anomaly) {
+                getAlert(anomaly.alert.id);
+            }
+        });
     }, [anomalyId]);
 
     useEffect(() => {
@@ -114,7 +126,7 @@ export const InvestigationStateTracker: FunctionComponent = () => {
     }, [searchParams]);
 
     /**
-     * Inform users there was issues when retrieving the investigation for the
+     * Inform users there were issues when retrieving the investigation for the
      * associated investigation id
      */
     useEffect(() => {
@@ -129,6 +141,21 @@ export const InvestigationStateTracker: FunctionComponent = () => {
                 : notify(NotificationTypeV1.Error, genericMsg);
         }
     }, [getInvestigationRequestStatus, getInvestigationRequestErrors]);
+
+    /**
+     * Inform users there were issues fetching alert so we will have to default
+     * to UTC
+     */
+    useEffect(() => {
+        if (getAlertStatus === ActionStatus.Error) {
+            notify(
+                NotificationTypeV1.Error,
+                t(
+                    "message.experienced-issue-fetching-alert-information-for-anomaly"
+                )
+            );
+        }
+    }, [getAlertStatus]);
 
     useEffect(() => {
         if (investigationId) {
@@ -151,24 +178,6 @@ export const InvestigationStateTracker: FunctionComponent = () => {
             setInvestigationFromServer(null);
         }
     }, [investigationId]);
-
-    // Ensure localInvestigation is always so the children views can access a valid object
-    if (
-        localInvestigation === null ||
-        getInvestigationRequestStatus === ActionStatus.Working
-    ) {
-        return (
-            <PageV1>
-                <Card variant="outlined">
-                    <CardContent>
-                        <Box padding={20}>
-                            <AppLoadingIndicatorV1 />
-                        </Box>
-                    </CardContent>
-                </Card>
-            </PageV1>
-        );
-    }
 
     const handleInvestigationChange = (
         modifiedInvestigation: Investigation
@@ -197,101 +206,127 @@ export const InvestigationStateTracker: FunctionComponent = () => {
 
     return (
         <PageV1>
-            <PageHeader
-                breadcrumbs={[
-                    {
-                        link: anomaly
-                            ? enumerationItem
-                                ? getAlertsAlertPath(
-                                      anomaly.alert.id,
-                                      new URLSearchParams([
-                                          [
-                                              QUERY_PARAM_KEY_FOR_EXPANDED,
-                                              generateNameForEnumerationItem(
-                                                  enumerationItem
-                                              ),
-                                          ],
-                                      ])
-                                  )
-                                : getAlertsAlertPath(anomaly.alert.id)
-                            : undefined,
-                        label: anomaly
-                            ? enumerationItem
-                                ? `${
-                                      anomaly.alert.name
-                                  } (${generateNameForEnumerationItem(
-                                      enumerationItem
-                                  )})`
-                                : anomaly.alert.name
-                            : "",
-                    },
-                    {
-                        label: anomalyId,
-                        link: getAnomaliesAnomalyViewPath(Number(anomalyId)),
-                    },
-                    {
-                        label: t("label.investigate"),
-                    },
-                ]}
-                customActions={
-                    <PageHeaderActionsV1>
-                        <InvestigationOptions
-                            investigationId={investigationId}
-                            localInvestigation={localInvestigation}
-                            serverInvestigation={investigationFromServer}
-                            onRemoveInvestigationAssociation={
-                                handleRemoveInvestigationAssociation
-                            }
-                            onSuccessfulUpdate={
-                                handleServerUpdatedInvestigation
-                            }
-                        />
-                    </PageHeaderActionsV1>
+            <LoadingErrorStateSwitch
+                isError={false}
+                /**
+                 * Ensure localInvestigation is always so the children
+                 * views can access a valid object
+                 */
+                isLoading={
+                    localInvestigation === null ||
+                    getInvestigationRequestStatus === ActionStatus.Working
                 }
-                subtitle={
-                    investigationId ? (
-                        <>
-                            Viewing saved investigation (#
-                            {investigationId}):{" "}
-                            {investigationFromServer &&
-                                investigationFromServer.name}
-                        </>
-                    ) : undefined
+                loadingState={
+                    <Card variant="outlined">
+                        <CardContent>
+                            <Box padding={20}>
+                                <AppLoadingIndicatorV1 />
+                            </Box>
+                        </CardContent>
+                    </Card>
                 }
             >
-                <PageHeaderTextV1>
-                    {t("label.investigate")}
-                    <TooltipV1
-                        placement="top"
-                        title={
-                            t(
-                                "label.how-to-perform-root-cause-analysis-doc"
-                            ) as string
-                        }
-                    >
-                        <span>
-                            <HelpLinkIconV1
-                                displayInline
-                                enablePadding
-                                externalLink
-                                href={`${THIRDEYE_DOC_LINK}/how-tos/perform-root-cause-analysis`}
+                <PageHeader
+                    breadcrumbs={[
+                        {
+                            link: anomaly
+                                ? enumerationItem
+                                    ? getAlertsAlertPath(
+                                          anomaly.alert.id,
+                                          new URLSearchParams([
+                                              [
+                                                  QUERY_PARAM_KEY_FOR_EXPANDED,
+                                                  generateNameForEnumerationItem(
+                                                      enumerationItem
+                                                  ),
+                                              ],
+                                          ])
+                                      )
+                                    : getAlertsAlertPath(anomaly.alert.id)
+                                : undefined,
+                            label: anomaly
+                                ? enumerationItem
+                                    ? `${
+                                          anomaly.alert.name
+                                      } (${generateNameForEnumerationItem(
+                                          enumerationItem
+                                      )})`
+                                    : anomaly.alert.name
+                                : "",
+                        },
+                        {
+                            label: anomalyId,
+                            link: getAnomaliesAnomalyViewPath(
+                                Number(anomalyId)
+                            ),
+                        },
+                        {
+                            label: t("label.investigate"),
+                        },
+                    ]}
+                    customActions={
+                        <PageHeaderActionsV1>
+                            <InvestigationOptions
+                                investigationId={investigationId}
+                                localInvestigation={
+                                    localInvestigation as Investigation
+                                }
+                                serverInvestigation={investigationFromServer}
+                                onRemoveInvestigationAssociation={
+                                    handleRemoveInvestigationAssociation
+                                }
+                                onSuccessfulUpdate={
+                                    handleServerUpdatedInvestigation
+                                }
                             />
-                        </span>
-                    </TooltipV1>
-                </PageHeaderTextV1>
-            </PageHeader>
+                        </PageHeaderActionsV1>
+                    }
+                    subtitle={
+                        investigationId ? (
+                            <>
+                                {t("message.viewing-saved-investigation-id", {
+                                    investigationId: investigationId,
+                                    name: investigationFromServer?.name ?? "",
+                                })}
+                            </>
+                        ) : undefined
+                    }
+                >
+                    <PageHeaderTextV1>
+                        {t("label.investigate")}
+                        <TooltipV1
+                            placement="top"
+                            title={
+                                t(
+                                    "label.how-to-perform-root-cause-analysis-doc"
+                                ) as string
+                            }
+                        >
+                            <span>
+                                <HelpLinkIconV1
+                                    displayInline
+                                    enablePadding
+                                    externalLink
+                                    href={`${THIRDEYE_DOC_LINK}/how-tos/perform-root-cause-analysis`}
+                                />
+                            </span>
+                        </TooltipV1>
+                    </PageHeaderTextV1>
+                </PageHeader>
 
-            <Outlet
-                context={{
-                    investigation: localInvestigation,
-                    investigationHasChanged: handleInvestigationChange,
-                    getEnumerationItemRequest,
-                    enumerationItem,
-                    anomaly,
-                    getAnomalyRequestStatus: status,
-                    anomalyRequestErrors: errorMessages,
-                }}
-            />
+                <Outlet
+                    context={{
+                        investigation: localInvestigation,
+                        investigationHasChanged: handleInvestigationChange,
+                        getEnumerationItemRequest,
+                        enumerationItem,
+                        anomaly,
+                        getAnomalyRequestStatus: getAnomalyStatus,
+                        anomalyRequestErrors: errorMessages,
+                        alert,
+                    }}
+                />
+            </LoadingErrorStateSwitch>
         </PageV1>
     );
 };

--- a/thirdeye-ui/src/app/pages/root-cause-analysis-investigation-state-tracker/investigation-state-tracker.interfaces.ts
+++ b/thirdeye-ui/src/app/pages/root-cause-analysis-investigation-state-tracker/investigation-state-tracker.interfaces.ts
@@ -13,6 +13,7 @@
  * the License.
  */
 import { ActionStatus } from "../../rest/actions.interfaces";
+import { Alert } from "../../rest/dto/alert.interfaces";
 import { Anomaly } from "../../rest/dto/anomaly.interfaces";
 import { EnumerationItem } from "../../rest/dto/enumeration-item.interfaces";
 import { Investigation } from "../../rest/dto/rca.interfaces";
@@ -25,4 +26,5 @@ export type InvestigationContext = {
     anomaly: Anomaly;
     getAnomalyRequestStatus: ActionStatus;
     anomalyRequestErrors: string[];
+    alert: Alert | null;
 };

--- a/thirdeye-ui/src/app/rest/dto/alert.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/alert.interfaces.ts
@@ -63,6 +63,7 @@ export interface AlertInsight {
     datasetEndTime: number;
     defaultStartTime: number;
     defaultEndTime: number;
+    templateWithProperties: Pick<AlertInEvaluation, "metadata">;
 }
 
 export interface AlertDataFetcherNode {
@@ -119,8 +120,14 @@ export enum AlertNodeType {
     DATA_FETCHER = "DataFetcher",
 }
 
+export interface AlertInEvaluation extends Alert {
+    metadata: {
+        timezone?: string;
+    };
+}
+
 export interface AlertEvaluation {
-    alert: Alert;
+    alert: AlertInEvaluation;
     detectionEvaluations: { [index: string]: DetectionEvaluation };
     start: number;
     end: number;

--- a/thirdeye-ui/src/app/utils/alerts/alerts.util.test.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts.util.test.ts
@@ -16,6 +16,7 @@ import { cloneDeep } from "lodash";
 import {
     Alert,
     AlertEvaluation,
+    AlertInEvaluation,
     AlertNodeType,
 } from "../../rest/dto/alert.interfaces";
 import { DetectionEvaluation } from "../../rest/dto/detection.interfaces";
@@ -27,7 +28,7 @@ import {
     createEmptyUiAlert,
     createEmptyUiAlertDatasetAndMetric,
     createEmptyUiAlertSubscriptionGroup,
-    determineTimezoneFromAlert,
+    determineTimezoneFromAlertInEvaluation,
     extractDetectionEvaluation,
     filterAlerts,
     generateGenericNameForAlert,
@@ -223,34 +224,17 @@ describe("Alerts Util", () => {
         ).toEqual("hello-world");
     });
 
-    it("determineTimezoneFromAlert should return expected results given the inputs", () => {
+    it("determineTimezoneFromAlertInEvaluation should return expected results given the inputs", () => {
         expect(
-            determineTimezoneFromAlert({
-                templateProperties: {
+            determineTimezoneFromAlertInEvaluation({
+                metadata: {
                     timezone: "America/Los_Angeles",
                 },
             })
         ).toEqual("America/Los_Angeles");
         expect(
-            determineTimezoneFromAlert({
-                templateProperties: {
-                    timezone: "America/Los_Angeles",
-                    monitoringGranularity: "P1H",
-                },
-            })
-        ).toEqual("America/Los_Angeles");
-        expect(
-            determineTimezoneFromAlert({
-                templateProperties: {
-                    monitoringGranularity: "P1H",
-                },
-            })
-        ).toBeUndefined();
-        expect(
-            determineTimezoneFromAlert({
-                templateProperties: {
-                    monitoringGranularity: "P1D",
-                },
+            determineTimezoneFromAlertInEvaluation({
+                metadata: {},
             })
         ).toEqual("UTC");
     });
@@ -534,7 +518,7 @@ const mockDetectionEvaluations = [
 ];
 
 const mockAlertEvaluation = {
-    alert: {} as Alert,
+    alert: {} as AlertInEvaluation,
     detectionEvaluations: {
         detectionEvaluation1:
             mockDetectionEvaluations[0] as DetectionEvaluation,

--- a/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
@@ -18,6 +18,7 @@ import {
     Alert,
     AlertAnomalyDetectorNode,
     AlertEvaluation,
+    AlertInEvaluation,
     AlertNodeType,
     AlertStats,
     EditableAlert,
@@ -452,28 +453,16 @@ export const getAlertAccuracyData = (
     return { accuracy, colorScheme, noAnomalyData };
 };
 
-export const determineTimezoneFromAlert = (
-    alert: Pick<Alert, "templateProperties"> | undefined | null
+export const determineTimezoneFromAlertInEvaluation = (
+    alert: Pick<AlertInEvaluation, "metadata"> | undefined | null
 ): string | undefined => {
     if (alert === undefined || alert === null) {
         return undefined;
     }
 
-    if (alert.templateProperties.timezone) {
-        return alert.templateProperties.timezone as string;
+    if (alert.metadata?.timezone) {
+        return alert.metadata.timezone as string;
     }
 
-    /**
-     * If no explicit timezone is set, check if monitoring is a
-     * daily granularity order to assume to use UTC
-     */
-    if (alert.templateProperties.monitoringGranularity) {
-        return (
-            alert.templateProperties.monitoringGranularity as string
-        ).endsWith("D")
-            ? "UTC"
-            : undefined;
-    }
-
-    return undefined;
+    return "UTC";
 };

--- a/thirdeye-ui/src/app/utils/time/time.util.ts
+++ b/thirdeye-ui/src/app/utils/time/time.util.ts
@@ -12,6 +12,8 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import { DateTime } from "luxon";
+
 export const SECOND_IN_MILLISECONDS = 1000;
 export const MINUTE_IN_MILLISECONDS = SECOND_IN_MILLISECONDS * 60;
 export const HOUR_IN_MILLISECONDS = MINUTE_IN_MILLISECONDS * 60;
@@ -25,4 +27,8 @@ export const OFFSET_TO_MILLISECONDS: { [key: string]: number } = {
     W: WEEK_IN_MILLISECONDS,
     M: MONTH_IN_MILLISECONDS,
     Y: YEAR_IN_MILLISECONDS,
+};
+
+export const timezoneStringShort = (timezone: string | undefined): string => {
+    return DateTime.now().setZone(timezone).offsetNameShort;
 };


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1216

#### Description

Adding support for determining timezone to use from the alert in the alert details and alert anomalies pages

#### Screenshots

Alert DX
![image](https://user-images.githubusercontent.com/2080348/215472571-faf168be-8d57-4a9b-9d4b-fe2e36118b62.png)

Alert DX Anomalies
![image](https://user-images.githubusercontent.com/2080348/215472700-c27b6ce6-cd53-4b38-9cf0-bde0f460861b.png)

Normal Alert
![image](https://user-images.githubusercontent.com/2080348/215472596-291b2212-d2ad-4db7-9af2-0ae43c79220a.png)

Anomalies for particular alert
![image](https://user-images.githubusercontent.com/2080348/215472638-29dda668-4022-4d42-a7d2-d931a5c92a2f.png)

