### PR TITLE
feat(ui): TE-1216 support timezone in anomalies details page

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filter.interface.ts
+++ b/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filter.interface.ts
@@ -20,4 +20,5 @@ export enum AnomalyFilterQueryStringKey {
 
 export interface AnomalyQuickFiltersProps {
     showTimeSelectorOnly?: boolean;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filters.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-quick-filters/anomaly-quick-filters.component.tsx
@@ -52,7 +52,7 @@ function initializeSelected(
 }
 
 export const AnomalyQuickFilters: FunctionComponent<AnomalyQuickFiltersProps> =
-    ({ showTimeSelectorOnly }) => {
+    ({ showTimeSelectorOnly, timezone }) => {
         const {
             timeRangeDuration,
             recentCustomTimeRangeDurations,
@@ -238,6 +238,7 @@ export const AnomalyQuickFilters: FunctionComponent<AnomalyQuickFiltersProps> =
                             recentCustomTimeRangeDurations
                         }
                         timeRangeDuration={timeRangeDuration}
+                        timezone={timezone}
                         onChange={onHandleTimeRangeChange}
                         onRefresh={onHandleRefresh}
                     />

--- a/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.component.tsx
@@ -17,6 +17,7 @@ import classnames from "classnames";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { PageContentsCardV1, SkeletonV1 } from "../../../platform/components";
+import { formatDateAndTimeV1 } from "../../../platform/utils";
 import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
 import { AnomalySummaryCardDetail } from "../root-cause-analysis/anomaly-summary-card/anomaly-summary-card-deatil.component";
 import { AnomalyCardProps } from "./anomaly-card.interfaces";
@@ -45,7 +46,10 @@ export const AnomalyCard: FunctionComponent<AnomalyCardProps> = (
                         <Grid item lg={2} sm={6} xs={12}>
                             <AnomalySummaryCardDetail
                                 label={t("label.start")}
-                                value={props.uiAnomaly.startTime}
+                                value={formatDateAndTimeV1(
+                                    props.uiAnomaly.startTimeVal,
+                                    props.timezone
+                                )}
                             />
                         </Grid>
 
@@ -53,7 +57,10 @@ export const AnomalyCard: FunctionComponent<AnomalyCardProps> = (
                         <Grid item lg={2} sm={6} xs={12}>
                             <AnomalySummaryCardDetail
                                 label={t("label.end")}
-                                value={props.uiAnomaly.endTime}
+                                value={formatDateAndTimeV1(
+                                    props.uiAnomaly.endTimeVal,
+                                    props.timezone
+                                )}
                             />
                         </Grid>
 

--- a/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/entity-cards/anomaly-card/anomaly-card.interfaces.ts
@@ -19,4 +19,5 @@ export interface AnomalyCardProps {
     searchWords?: string[];
     className?: string;
     isLoading?: boolean;
+    timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
+++ b/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.component.tsx
@@ -15,18 +15,16 @@
 import { Grid, Typography } from "@material-ui/core";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
 import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
-import React, { FunctionComponent, useEffect } from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import {
     PageContentsCardV1,
     SkeletonV1,
-    useNotificationProviderV1,
 } from "../../../../platform/components";
-import { ActionStatus } from "../../../../rest/actions.interfaces";
-import { useGetAlert } from "../../../../rest/alerts/alerts.actions";
+import { formatDateAndTimeV1 } from "../../../../platform/utils";
 import { useCommonStyles } from "../../../../utils/material-ui/common.styles";
-import { notifyIfErrors } from "../../../../utils/notifications/notifications.util";
 import { NoDataIndicator } from "../../../no-data-indicator/no-data-indicator.component";
+import { LoadingErrorStateSwitch } from "../../../page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { AnomalySummaryCardDetail } from "./anomaly-summary-card-deatil.component";
 import { AnomalySummaryCardProps } from "./anomaly-summary-card.interfaces";
 
@@ -34,29 +32,12 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = ({
     uiAnomaly,
     isLoading,
     className,
+    timezone,
+    alert,
 }) => {
-    const { alert, getAlert, status, errorMessages } = useGetAlert();
     const commonClasses = useCommonStyles();
     const { t } = useTranslation();
-    const { notify } = useNotificationProviderV1();
     let metricName;
-
-    useEffect(() => {
-        if (uiAnomaly && uiAnomaly.alertId) {
-            getAlert(uiAnomaly.alertId);
-        }
-    }, [uiAnomaly]);
-
-    useEffect(() => {
-        notifyIfErrors(
-            status,
-            errorMessages,
-            notify,
-            t("message.error-while-fetching", {
-                entity: t("label.alert"),
-            })
-        );
-    }, [status, errorMessages]);
 
     if (alert && alert.templateProperties) {
         if (
@@ -69,98 +50,97 @@ export const AnomalySummaryCard: FunctionComponent<AnomalySummaryCardProps> = ({
         }
     }
 
-    if (isLoading) {
-        return (
-            <PageContentsCardV1 className={className}>
-                <Typography variant="body1">
-                    <SkeletonV1 preventDelay />
-                    <SkeletonV1 preventDelay />
-                </Typography>
-            </PageContentsCardV1>
-        );
-    }
-
     return (
         <PageContentsCardV1 className={className}>
-            {uiAnomaly && (
-                <Grid container spacing={8}>
-                    {/* Metric */}
-                    <Grid item>
-                        <AnomalySummaryCardDetail
-                            label={`${t("label.metric")} ${
-                                status === ActionStatus.Done &&
-                                alert &&
-                                alert.templateProperties.dataset
-                            }`}
-                            value={
-                                status === ActionStatus.Working
-                                    ? "Loading ..."
-                                    : status === ActionStatus.Done && metricName
-                                    ? metricName
-                                    : t("label.no-data-marker")
-                            }
-                        />
-                    </Grid>
+            <LoadingErrorStateSwitch
+                errorState={<NoDataIndicator />}
+                isError={!uiAnomaly}
+                isLoading={!!isLoading}
+                loadingState={
+                    <Typography variant="body1">
+                        <SkeletonV1 preventDelay />
+                        <SkeletonV1 preventDelay />
+                    </Typography>
+                }
+            >
+                {uiAnomaly && (
+                    <Grid container spacing={8}>
+                        {/* Metric */}
+                        <Grid item>
+                            <AnomalySummaryCardDetail
+                                label={`${t("label.metric")} ${
+                                    alert && alert.templateProperties.dataset
+                                }`}
+                                value={
+                                    alert === null
+                                        ? "Loading ..."
+                                        : metricName
+                                        ? metricName
+                                        : t("label.no-data-marker")
+                                }
+                            />
+                        </Grid>
 
-                    {/* Current and Predicted */}
-                    <Grid item>
-                        <Grid container spacing={2}>
-                            <Grid item>
-                                <AnomalySummaryCardDetail
-                                    label={t("label.current")}
-                                    value={uiAnomaly.current}
-                                />
-                            </Grid>
-                            <Grid item>
-                                <Grid
-                                    container
-                                    className={
-                                        uiAnomaly.negativeDeviation
-                                            ? commonClasses.decreased
-                                            : commonClasses.increased
-                                    }
-                                    spacing={0}
-                                >
-                                    <Grid item>{uiAnomaly.deviation}</Grid>
-                                    <Grid item>
-                                        {uiAnomaly.negativeDeviation && (
-                                            <ArrowDownwardIcon fontSize="small" />
-                                        )}
-                                        {!uiAnomaly.negativeDeviation && (
-                                            <ArrowUpwardIcon fontSize="small" />
-                                        )}
+                        {/* Current and Predicted */}
+                        <Grid item>
+                            <Grid container spacing={2}>
+                                <Grid item>
+                                    <AnomalySummaryCardDetail
+                                        label={t("label.current")}
+                                        value={uiAnomaly.current}
+                                    />
+                                </Grid>
+                                <Grid item>
+                                    <Grid
+                                        container
+                                        className={
+                                            uiAnomaly.negativeDeviation
+                                                ? commonClasses.decreased
+                                                : commonClasses.increased
+                                        }
+                                        spacing={0}
+                                    >
+                                        <Grid item>{uiAnomaly.deviation}</Grid>
+                                        <Grid item>
+                                            {uiAnomaly.negativeDeviation && (
+                                                <ArrowDownwardIcon fontSize="small" />
+                                            )}
+                                            {!uiAnomaly.negativeDeviation && (
+                                                <ArrowUpwardIcon fontSize="small" />
+                                            )}
+                                        </Grid>
                                     </Grid>
                                 </Grid>
-                            </Grid>
-                            <Grid item>
-                                <AnomalySummaryCardDetail
-                                    label={t("label.baseline")}
-                                    value={uiAnomaly.predicted}
-                                />
+                                <Grid item>
+                                    <AnomalySummaryCardDetail
+                                        label={t("label.baseline")}
+                                        value={uiAnomaly.predicted}
+                                    />
+                                </Grid>
                             </Grid>
                         </Grid>
-                    </Grid>
 
-                    {/* Start */}
-                    <Grid item>
-                        <AnomalySummaryCardDetail
-                            label={t("label.start")}
-                            value={uiAnomaly.startTime}
-                        />
-                    </Grid>
+                        {/* Start */}
+                        <Grid item>
+                            <AnomalySummaryCardDetail
+                                label={t("label.start")}
+                                value={formatDateAndTimeV1(
+                                    uiAnomaly.startTimeVal,
+                                    timezone
+                                )}
+                            />
+                        </Grid>
 
-                    {/* Duration */}
-                    <Grid item>
-                        <AnomalySummaryCardDetail
-                            label={t("label.duration")}
-                            value={uiAnomaly.duration}
-                        />
+                        {/* Duration */}
+                        <Grid item>
+                            <AnomalySummaryCardDetail
+                                label={t("label.duration")}
+                                value={uiAnomaly.duration}
+                            />
+                        </Grid>
                     </Grid>
-                </Grid>
-            )}
-
-            {/* No data available */}
-            {!uiAnomaly && <NoDataIndicator />}
+                )}
+            </LoadingErrorStateSwitch>
         </PageContentsCardV1>
     );
 };

--- a/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/entity-cards/root-cause-analysis/anomaly-summary-card/anomaly-summary-card.interfaces.ts
@@ -12,10 +12,13 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import { Alert } from "../../../../rest/dto/alert.interfaces";
 import { UiAnomaly } from "../../../../rest/dto/ui-anomaly.interfaces";
 
 export interface AnomalySummaryCardProps {
     uiAnomaly: UiAnomaly | null;
     isLoading?: boolean;
     className?: string;
+    timezone?: string;
+    alert: Alert | null;
 }

--- a/thirdeye-ui/src/app/components/metrics-report-list/metrics-report-list.interfaces.ts
+++ b/thirdeye-ui/src/app/components/metrics-report-list/metrics-report-list.interfaces.ts
@@ -22,7 +22,7 @@ export interface MetricsReportListProps {
 }
 
 export interface AnomaliesByAlert {
-    alert: Alert;
+    alert: Pick<Alert, "id" | "name">;
     anomalies: Anomaly[];
     metric: string;
     dataset: string;

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.component.tsx
@@ -83,6 +83,7 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
         onEventSelectionChange,
         getEnumerationItemRequest,
         enumerationItem,
+        timezone,
     }) => {
         const [searchParams, setSearchParams] = useSearchParams();
         const { t } = useTranslation();
@@ -246,7 +247,8 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
                     detectionEvalForAnomaly,
                     anomaly,
                     filteredAlertEvaluation,
-                    t
+                    t,
+                    timezone
                 )
             );
         }, [
@@ -254,6 +256,7 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
             anomaly,
             filteredAlertEvaluation,
             enumerationItem,
+            timezone,
         ]);
 
         const handleChartHeightChange = (height: number): void => {
@@ -339,7 +342,9 @@ export const AnomalyTimeSeriesCard: FunctionComponent<AnomalyTimeSeriesCardProps
                             {/** Use flex to align the button group */}
                             <Box display="flex">
                                 <Box>
-                                    <TimeRangeButtonWithContext />
+                                    <TimeRangeButtonWithContext
+                                        timezone={timezone}
+                                    />
                                 </Box>
                                 <Box marginLeft={1}>
                                     <TooltipV1

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.interfaces.ts
@@ -27,4 +27,5 @@ export interface AnomalyTimeSeriesCardProps {
     onEventSelectionChange: (events: Event[]) => void;
     getEnumerationItemRequest: ActionStatus;
     enumerationItem: EnumerationItem | null;
+    timezone: string | undefined;
 }

--- a/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.utils.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-time-series-card/anomaly-time-series-card.utils.tsx
@@ -213,7 +213,8 @@ export const generateChartOptions = (
     detectionEvaluation: DetectionEvaluation,
     anomaly: Anomaly,
     filteredAlertEvaluation: [AlertEvaluation, AnomalyFilterOption[]][],
-    translation: (id: string) => string
+    translation: (id: string) => string,
+    timezone?: string
 ): TimeSeriesChartProps => {
     let series: Series[] = [];
 
@@ -230,12 +231,14 @@ export const generateChartOptions = (
                 [anomaly],
                 translation,
                 timeseriesData.timestamp,
-                timeseriesData.current
+                timeseriesData.current,
+                undefined,
+                timezone
             )
         );
     }
 
-    return {
+    const chartOptions: TimeSeriesChartProps = {
         series,
         yAxis: {
             position: Orientation.right,
@@ -245,6 +248,14 @@ export const generateChartOptions = (
         zoom: true,
         tooltip: true,
     };
+
+    if (timezone) {
+        chartOptions.xAxis = {
+            timezone,
+        };
+    }
+
+    return chartOptions;
 };
 
 export const generateSeriesForAnomalies = (
@@ -252,7 +263,8 @@ export const generateSeriesForAnomalies = (
     translation: (id: string) => string,
     timestamps: number[],
     valuesToTrackAgainst: number[],
-    navigate?: NavigateFunction
+    navigate?: NavigateFunction,
+    timezone?: string
 ): Series => {
     const granularityBestGuess = determineGranularity(timestamps);
 
@@ -294,7 +306,7 @@ export const generateSeriesForAnomalies = (
     return {
         name: translation("label.anomalies"),
         /**
-         * We need the points in data so it shows up in the legend
+         * We need the points in data, so it shows up in the legend
          * and in the filtered chart
          */
         data: flatten(
@@ -339,7 +351,8 @@ export const generateSeriesForAnomalies = (
                                 <td>{translation("label.start")}</td>
                                 <td align="right">
                                     {formatDateAndTimeV1(
-                                        dataPoint.extraData.startTime
+                                        dataPoint.extraData.startTime,
+                                        timezone
                                     )}
                                 </td>
                             </tr>
@@ -347,7 +360,8 @@ export const generateSeriesForAnomalies = (
                                 <td>{translation("label.end")}</td>
                                 <td align="right">
                                     {formatDateAndTimeV1(
-                                        dataPoint.extraData.endTime
+                                        dataPoint.extraData.endTime,
+                                        timezone
                                     )}
                                 </td>
                             </tr>
@@ -470,7 +484,8 @@ export const generateChartOptionsForAlert = (
     detectionEvaluation: DetectionEvaluation,
     anomalies: Anomaly[],
     translation: (id: string) => string,
-    navigate?: NavigateFunction
+    navigate?: NavigateFunction,
+    timezone?: string
 ): TimeSeriesChartProps => {
     let series: Series[] = [];
 
@@ -489,12 +504,13 @@ export const generateChartOptionsForAlert = (
                 translation,
                 detectionEvaluation.data.timestamp,
                 detectionEvaluation.data.current,
-                navigate
+                navigate,
+                timezone
             )
         );
     }
 
-    return {
+    const chartOptions: TimeSeriesChartProps = {
         series,
         legend: true,
         brush: true,
@@ -504,12 +520,21 @@ export const generateChartOptionsForAlert = (
             position: Orientation.right,
         },
     };
+
+    if (timezone) {
+        chartOptions.xAxis = {
+            timezone,
+        };
+    }
+
+    return chartOptions;
 };
 
 export const generateChartOptionsForMetricsReport = (
     detectionEvaluation: DetectionEvaluation,
     anomalies: Anomaly[],
-    translation: (id: string) => string
+    translation: (id: string) => string,
+    timezone?: string
 ): TimeSeriesChartProps => {
     let series: Series[] = [];
 
@@ -535,7 +560,7 @@ export const generateChartOptionsForMetricsReport = (
         );
     }
 
-    return {
+    const chartOptions: TimeSeriesChartProps = {
         series,
         legend: false,
         brush: false,
@@ -543,6 +568,14 @@ export const generateChartOptionsForMetricsReport = (
         tooltip: false,
         yAxis: { enabled: false },
     };
+
+    if (timezone) {
+        chartOptions.xAxis = {
+            timezone,
+        };
+    }
+
+    return chartOptions;
 };
 
 export const determineInitialZoom = (

--- a/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/headers/view-anomaly-header.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/alert-evaluation-time-series-card/headers/view-anomaly-header.component.tsx
@@ -22,6 +22,7 @@ import { ViewAnomalyHeaderProps } from "../alert-evaluation-time-series-card.int
 export const ViewAnomalyHeader: FunctionComponent<ViewAnomalyHeaderProps> = ({
     anomaly,
     onRefresh,
+    timezone,
 }) => {
     return (
         <CardContent>
@@ -48,6 +49,7 @@ export const ViewAnomalyHeader: FunctionComponent<ViewAnomalyHeaderProps> = ({
                     xs={12}
                 >
                     <TimeRangeButtonWithContext
+                        timezone={timezone}
                         onTimeRangeChange={(start: number, end: number) =>
                             onRefresh && onRefresh(start, end)
                         }


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1216

#### Description

Adding support for determining timezone to use from the anomalies details page which now requires fetching the alert details

#### Screenshots

![image](https://user-images.githubusercontent.com/2080348/215474089-e2d88222-7174-46d7-9446-207225ffc447.png)

