### PR TITLE
feat(ui): TE-1231 have the chart timeframe adapt to the baseline offset

### DIFF
--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-row-expanded.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-row-expanded.component.tsx
@@ -26,6 +26,7 @@ import { formatLargeNumberV1 } from "../../../../platform/utils";
 import { ActionStatus } from "../../../../rest/actions.interfaces";
 import { useGetEvaluation } from "../../../../rest/alerts/alerts.actions";
 import { createAlertEvaluation } from "../../../../utils/anomalies/anomalies.util";
+import { baselineOffsetToMilliseconds } from "../../../../utils/anomaly-breakdown/anomaly-breakdown.util";
 import { useCommonStyles } from "../../../../utils/material-ui/common.styles";
 import { NoDataIndicator } from "../../../no-data-indicator/no-data-indicator.component";
 import { TimeRangeQueryStringKey } from "../../../time-range/time-range-provider/time-range-provider.interfaces";
@@ -144,12 +145,16 @@ export const AlgorithmRowExpanded: FunctionComponent<AlgorithmRowExpandedProps> 
                 row.otherDimensionValues
             );
 
+            const startTimestamp =
+                Number(start) - baselineOffsetToMilliseconds(comparisonOffset);
+            const endTimestamp = Number(end);
+
             getNonFilteredEvaluation(
-                createAlertEvaluation(alertId, Number(start), Number(end))
+                createAlertEvaluation(alertId, startTimestamp, endTimestamp)
             );
 
             getFilteredEvaluation(
-                createAlertEvaluation(alertId, Number(start), Number(end)),
+                createAlertEvaluation(alertId, startTimestamp, endTimestamp),
                 filters
             );
         };

--- a/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-table.utils.tsx
+++ b/thirdeye-ui/src/app/components/rca/anomaly-dimension-analysis/algorithm-table/algorithm-table.utils.tsx
@@ -156,6 +156,7 @@ export const generateComparisonChartOptions = (
     const chartOptions: TimeSeriesChartProps = {
         brush: true,
         height: 400,
+        zoom: true,
         series,
         xAxis: {
             plotBands: [


### PR DESCRIPTION
### Issue(s)

[TE-1231](https://cortexdata.atlassian.net/browse/TE-1231)

### Description

- Baseline offset is being taken into account for the start datetime for alert evaluation data series
- Enabled zoom for the Top Contributors chart to allow better usability since the chart gets zoomed out for large baseline offsets

### Screenshots

![Screenshot_94](https://user-images.githubusercontent.com/20799363/216341100-43d75783-a789-4a9c-8785-5a17f40dfabf.png)


[TE-1231]: https://cortexdata.atlassian.net/browse/TE-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ