### PR TITLE
Add AuthorizationConfiguration container for namespace

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AlertMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AlertMapper.java
@@ -36,7 +36,6 @@ public interface AlertMapper {
     return new AlertApi()
         .setId(dto.getId())
         .setName(dto.getName())
-        .setNamespace(dto.getNamespace())
         .setDescription(dto.getDescription())
         .setActive(dto.isActive())
         .setCron(dto.getCron())
@@ -49,14 +48,14 @@ public interface AlertMapper {
             .setPrincipal(dto.getCreatedBy()))
         .setCreated(dto.getCreateTime())
         .setUpdated(dto.getUpdateTime())
-        ;
+        .setAuthorization(optional(dto.getAuthorization())
+            .map(ApiBeanMapper::toApi).orElse(null));
   }
 
   default AlertDTO toAlertDTO(final AlertApi api) {
     final AlertDTO dto = new AlertDTO();
 
     dto.setName(api.getName());
-    dto.setNamespace(api.getNamespace());
     dto.setDescription(api.getDescription());
     dto.setActive(optional(api.getActive()).orElse(true));
     dto.setCron(api.getCron());
@@ -77,6 +76,9 @@ public interface AlertMapper {
         .map(UserApi::getPrincipal)
         .ifPresent(dto::setCreatedBy);
 
+    optional(api.getAuthorization())
+        .map(ApiBeanMapper::toAuthorizationConfigurationDTO)
+        .ifPresent(dto::setAuthorization);
     return dto;
   }
 }

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AlertMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AlertMapper.java
@@ -48,7 +48,7 @@ public interface AlertMapper {
             .setPrincipal(dto.getCreatedBy()))
         .setCreated(dto.getCreateTime())
         .setUpdated(dto.getUpdateTime())
-        .setAuthorization(optional(dto.getAuthorization())
+        .setAuth(optional(dto.getAuth())
             .map(ApiBeanMapper::toApi).orElse(null));
   }
 
@@ -76,9 +76,9 @@ public interface AlertMapper {
         .map(UserApi::getPrincipal)
         .ifPresent(dto::setCreatedBy);
 
-    optional(api.getAuthorization())
+    optional(api.getAuth())
         .map(ApiBeanMapper::toAuthorizationConfigurationDTO)
-        .ifPresent(dto::setAuthorization);
+        .ifPresent(dto::setAuth);
     return dto;
   }
 }

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AnomalyMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AnomalyMapper.java
@@ -93,7 +93,9 @@ public interface AnomalyMapper {
             .setDataset(datasetApi)
         )
         .setEnumerationItem(EnumerationItemMapper.INSTANCE.toApi(dto.getEnumerationItem()))
-        .setFeedback(toAnomalyFeedbackApi(dto));
+        .setFeedback(toAnomalyFeedbackApi(dto))
+        .setAuthorization(optional(dto.getAuthorization())
+            .map(ApiBeanMapper::toApi).orElse(null));
 
     if (dto.getMetricUrn() != null) {
       anomalyApi

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AnomalyMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AnomalyMapper.java
@@ -94,7 +94,7 @@ public interface AnomalyMapper {
         )
         .setEnumerationItem(EnumerationItemMapper.INSTANCE.toApi(dto.getEnumerationItem()))
         .setFeedback(toAnomalyFeedbackApi(dto))
-        .setAuthorization(optional(dto.getAuthorization())
+        .setAuth(optional(dto.getAuth())
             .map(ApiBeanMapper::toApi).orElse(null));
 
     if (dto.getMetricUrn() != null) {

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/ApiBeanMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/ApiBeanMapper.java
@@ -20,6 +20,7 @@ import ai.startree.thirdeye.spi.api.AlertTemplateApi;
 import ai.startree.thirdeye.spi.api.AnomalyApi;
 import ai.startree.thirdeye.spi.api.AnomalyFeedbackApi;
 import ai.startree.thirdeye.spi.api.AnomalyLabelApi;
+import ai.startree.thirdeye.spi.api.AuthorizationConfigurationApi;
 import ai.startree.thirdeye.spi.api.DataSourceApi;
 import ai.startree.thirdeye.spi.api.DatasetApi;
 import ai.startree.thirdeye.spi.api.EnumerationItemApi;
@@ -35,6 +36,7 @@ import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AnomalyDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AnomalyFeedbackDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AnomalyLabelDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AuthorizationConfigurationDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DataSourceDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.EnumerationItemDTO;
@@ -167,5 +169,14 @@ public abstract class ApiBeanMapper {
 
   public static EnumerationItemApi toApi(final EnumerationItemDTO dto) {
     return EnumerationItemMapper.INSTANCE.toApi(dto);
+  }
+
+  public static AuthorizationConfigurationDTO toAuthorizationConfigurationDTO(
+      final AuthorizationConfigurationApi api) {
+    return AuthorizationConfigurationMapper.INSTANCE.toDto(api);
+  }
+
+  public static AuthorizationConfigurationApi toApi(final AuthorizationConfigurationDTO dto) {
+    return AuthorizationConfigurationMapper.INSTANCE.toApi(dto);
   }
 }

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AuthorizationConfigurationMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/AuthorizationConfigurationMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.mapper;
+
+import ai.startree.thirdeye.spi.api.AuthorizationConfigurationApi;
+import ai.startree.thirdeye.spi.datalayer.dto.AuthorizationConfigurationDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface AuthorizationConfigurationMapper {
+
+  AuthorizationConfigurationMapper INSTANCE = Mappers.getMapper(AuthorizationConfigurationMapper.class);
+
+  AuthorizationConfigurationDTO toDto(AuthorizationConfigurationApi api);
+
+  AuthorizationConfigurationApi toApi(AuthorizationConfigurationDTO dto);
+}

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DataSourceMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DataSourceMapper.java
@@ -42,8 +42,8 @@ public interface DataSourceMapper {
                 .collect(Collectors.toList()))
             .orElse(null));
     dto.setId(api.getId());
-    optional(api.getAuthorization()).map(ApiBeanMapper::toAuthorizationConfigurationDTO)
-        .ifPresent(dto::setAuthorization);
+    optional(api.getAuth()).map(ApiBeanMapper::toAuthorizationConfigurationDTO)
+        .ifPresent(dto::setAuth);
     return dto;
   }
 
@@ -59,7 +59,7 @@ public interface DataSourceMapper {
         .setMetaList(optional(dto.getMetaList()).filter(l -> !l.isEmpty())
             .map(l -> l.stream().map(DataSourceMapper::toApi).collect(Collectors.toList()))
             .orElse(null))
-        .setAuthorization(optional(dto.getAuthorization())
+        .setAuth(optional(dto.getAuth())
             .map(ApiBeanMapper::toApi).orElse(null));
   }
 

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DataSourceMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DataSourceMapper.java
@@ -42,7 +42,8 @@ public interface DataSourceMapper {
                 .collect(Collectors.toList()))
             .orElse(null));
     dto.setId(api.getId());
-    dto.setNamespace(api.getNamespace());
+    optional(api.getAuthorization()).map(ApiBeanMapper::toAuthorizationConfigurationDTO)
+        .ifPresent(dto::setAuthorization);
     return dto;
   }
 
@@ -53,12 +54,13 @@ public interface DataSourceMapper {
     return new DataSourceApi()
         .setId(dto.getId())
         .setName(dto.getName())
-        .setNamespace(dto.getNamespace())
         .setType(dto.getType())
         .setProperties(optional(dto.getProperties()).filter(p -> !p.isEmpty()).orElse(null))
         .setMetaList(optional(dto.getMetaList()).filter(l -> !l.isEmpty())
             .map(l -> l.stream().map(DataSourceMapper::toApi).collect(Collectors.toList()))
-            .orElse(null));
+            .orElse(null))
+        .setAuthorization(optional(dto.getAuthorization())
+            .map(ApiBeanMapper::toApi).orElse(null));
   }
 
   private static DataSourceMetaApi toApi(final DataSourceMetaBean metaBean) {

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DatasetMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DatasetMapper.java
@@ -48,9 +48,9 @@ public interface DatasetMapper {
       optional(timeColumn.getFormat()).ifPresent(dto::setTimeFormat);
       optional(timeColumn.getTimezone()).ifPresent(dto::setTimezone);
     });
-    optional(api.getAuthorization())
+    optional(api.getAuth())
         .map(ApiBeanMapper::toAuthorizationConfigurationDTO)
-        .ifPresent(dto::setAuthorization);
+        .ifPresent(dto::setAuth);
     return dto;
   }
 
@@ -67,7 +67,7 @@ public interface DatasetMapper {
             .map(datasourceName -> new DataSourceApi().setName(datasourceName))
             .orElse(null))
         .setCompletenessDelay(optional(dto.getCompletenessDelay()).orElse(null))
-        .setAuthorization(optional(dto.getAuthorization())
+        .setAuth(optional(dto.getAuth())
             .map(ApiBeanMapper::toApi).orElse(null));
     optional(dto.getRcaExcludedDimensions()).ifPresent(datasetApi::setRcaExcludedDimensions);
     optional(dto.getTimeColumn()).ifPresent(timeColumn -> datasetApi.setTimeColumn(

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DatasetMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/DatasetMapper.java
@@ -42,14 +42,15 @@ public interface DatasetMapper {
         .setDimensions(api.getDimensions())
         .setRcaExcludedDimensions(api.getRcaExcludedDimensions())
         ;
-    dto.setNamespace(api.getNamespace());
     optional(api.getTimeColumn()).ifPresent(timeColumn -> {
       dto.setTimeColumn(timeColumn.getName());
       updateTimeGranularityOnDataset(dto, timeColumn);
       optional(timeColumn.getFormat()).ifPresent(dto::setTimeFormat);
       optional(timeColumn.getTimezone()).ifPresent(dto::setTimezone);
     });
-
+    optional(api.getAuthorization())
+        .map(ApiBeanMapper::toAuthorizationConfigurationDTO)
+        .ifPresent(dto::setAuthorization);
     return dto;
   }
 
@@ -62,11 +63,12 @@ public interface DatasetMapper {
         .setActive(dto.getActive())
         .setDimensions(dto.getDimensions())
         .setName(dto.getDataset())
-        .setNamespace(dto.getNamespace())
         .setDataSource(optional(dto.getDataSource())
             .map(datasourceName -> new DataSourceApi().setName(datasourceName))
             .orElse(null))
-        .setCompletenessDelay(optional(dto.getCompletenessDelay()).orElse(null));
+        .setCompletenessDelay(optional(dto.getCompletenessDelay()).orElse(null))
+        .setAuthorization(optional(dto.getAuthorization())
+            .map(ApiBeanMapper::toApi).orElse(null));
     optional(dto.getRcaExcludedDimensions()).ifPresent(datasetApi::setRcaExcludedDimensions);
     optional(dto.getTimeColumn()).ifPresent(timeColumn -> datasetApi.setTimeColumn(
         new TimeColumnApi()

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/mapper/ApiBeanMapperTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/mapper/ApiBeanMapperTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.mapper;
+
+import static org.testng.Assert.*;
+
+import ai.startree.thirdeye.spi.api.AlertApi;
+import ai.startree.thirdeye.spi.api.AlertTemplateApi;
+import ai.startree.thirdeye.spi.api.AuthorizationConfigurationApi;
+import ai.startree.thirdeye.spi.api.DataSourceApi;
+import ai.startree.thirdeye.spi.api.DatasetApi;
+import ai.startree.thirdeye.spi.api.EnumerationItemApi;
+import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AuthorizationConfigurationDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.DataSourceDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.EnumerationItemDTO;
+import org.testng.annotations.Test;
+
+// This test validates the mapping between api <-> dto objects.
+// If tests fail, you may need to delete thirdeye-core/target before rerunning.
+public class ApiBeanMapperTest {
+
+  @Test
+  public void testToDataSourceApi() {
+    final DataSourceDTO dto = new DataSourceDTO();
+    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+
+    final DataSourceApi gotApi = ApiBeanMapper.toApi(dto);
+    assertNotNull(gotApi.getAuthorization());
+    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToDataSourceDto() {
+    final DataSourceApi api = new DataSourceApi()
+        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+
+    final DataSourceDTO gotDto = ApiBeanMapper.toDataSourceDto(api);
+    assertNotNull(gotDto.getAuthorization());
+    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToDatasetApi() {
+    final DatasetConfigDTO dto = new DatasetConfigDTO();
+    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+
+    final DatasetApi gotApi = ApiBeanMapper.toApi(dto);
+    assertNotNull(gotApi.getAuthorization());
+    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToDatasetDto() {
+    final DatasetApi api = new DatasetApi()
+        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+
+    final DatasetConfigDTO gotDto = ApiBeanMapper.toDatasetConfigDto(api);
+    assertNotNull(gotDto.getAuthorization());
+    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToAlertTemplateApi() {
+    final AlertTemplateDTO dto = new AlertTemplateDTO();
+    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+
+    final AlertTemplateApi gotApi = ApiBeanMapper.toAlertTemplateApi(dto);
+    assertNotNull(gotApi.getAuthorization());
+    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToAlertTemplateDto() {
+    final AlertTemplateApi api = new AlertTemplateApi()
+        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+
+    final AlertTemplateDTO gotDto = ApiBeanMapper.toAlertTemplateDto(api);
+    assertNotNull(gotDto.getAuthorization());
+    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToAlertApi() {
+    final AlertDTO dto = new AlertDTO();
+    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+
+    final AlertApi gotApi = ApiBeanMapper.toApi(dto);
+    assertNotNull(gotApi.getAuthorization());
+    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToAlertDto() {
+    final AlertApi api = new AlertApi()
+        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+
+    final AlertDTO gotDto = ApiBeanMapper.toAlertDto(api);
+    assertNotNull(gotDto.getAuthorization());
+    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToEnumerationItemApi() {
+    final EnumerationItemDTO dto = new EnumerationItemDTO();
+    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+
+    final EnumerationItemApi gotApi = ApiBeanMapper.toApi(dto);
+    assertNotNull(gotApi.getAuthorization());
+    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToEnumerationItemDTO() {
+    final EnumerationItemApi api = new EnumerationItemApi()
+        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+
+    final EnumerationItemDTO gotDto = ApiBeanMapper.toEnumerationItemDTO(api);
+    assertNotNull(gotDto.getAuthorization());
+    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToAuthorizationConfigurationApi() {
+    final AuthorizationConfigurationDTO dto = new AuthorizationConfigurationDTO();
+    dto.setNamespace("my-namespace");
+
+    final AuthorizationConfigurationApi gotApi = ApiBeanMapper.toApi(dto);
+    assertEquals(gotApi.getNamespace(), "my-namespace");
+  }
+
+  @Test
+  public void testToAuthorizationConfigurationDTO() {
+    final AuthorizationConfigurationApi api = new AuthorizationConfigurationApi()
+        .setNamespace("my-namespace");
+
+    final AuthorizationConfigurationDTO gotDto = ApiBeanMapper.toAuthorizationConfigurationDTO(api);
+    assertEquals(gotDto.getNamespace(), "my-namespace");
+  }
+
+}

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/mapper/ApiBeanMapperTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/mapper/ApiBeanMapperTest.java
@@ -36,101 +36,101 @@ public class ApiBeanMapperTest {
   @Test
   public void testToDataSourceApi() {
     final DataSourceDTO dto = new DataSourceDTO();
-    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+    dto.setAuth(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
 
     final DataSourceApi gotApi = ApiBeanMapper.toApi(dto);
-    assertNotNull(gotApi.getAuthorization());
-    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotApi.getAuth());
+    assertEquals(gotApi.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToDataSourceDto() {
     final DataSourceApi api = new DataSourceApi()
-        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+        .setAuth(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
 
     final DataSourceDTO gotDto = ApiBeanMapper.toDataSourceDto(api);
-    assertNotNull(gotDto.getAuthorization());
-    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotDto.getAuth());
+    assertEquals(gotDto.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToDatasetApi() {
     final DatasetConfigDTO dto = new DatasetConfigDTO();
-    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+    dto.setAuth(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
 
     final DatasetApi gotApi = ApiBeanMapper.toApi(dto);
-    assertNotNull(gotApi.getAuthorization());
-    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotApi.getAuth());
+    assertEquals(gotApi.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToDatasetDto() {
     final DatasetApi api = new DatasetApi()
-        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+        .setAuth(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
 
     final DatasetConfigDTO gotDto = ApiBeanMapper.toDatasetConfigDto(api);
-    assertNotNull(gotDto.getAuthorization());
-    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotDto.getAuth());
+    assertEquals(gotDto.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToAlertTemplateApi() {
     final AlertTemplateDTO dto = new AlertTemplateDTO();
-    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+    dto.setAuth(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
 
     final AlertTemplateApi gotApi = ApiBeanMapper.toAlertTemplateApi(dto);
-    assertNotNull(gotApi.getAuthorization());
-    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotApi.getAuth());
+    assertEquals(gotApi.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToAlertTemplateDto() {
     final AlertTemplateApi api = new AlertTemplateApi()
-        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+        .setAuth(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
 
     final AlertTemplateDTO gotDto = ApiBeanMapper.toAlertTemplateDto(api);
-    assertNotNull(gotDto.getAuthorization());
-    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotDto.getAuth());
+    assertEquals(gotDto.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToAlertApi() {
     final AlertDTO dto = new AlertDTO();
-    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+    dto.setAuth(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
 
     final AlertApi gotApi = ApiBeanMapper.toApi(dto);
-    assertNotNull(gotApi.getAuthorization());
-    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotApi.getAuth());
+    assertEquals(gotApi.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToAlertDto() {
     final AlertApi api = new AlertApi()
-        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+        .setAuth(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
 
     final AlertDTO gotDto = ApiBeanMapper.toAlertDto(api);
-    assertNotNull(gotDto.getAuthorization());
-    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotDto.getAuth());
+    assertEquals(gotDto.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToEnumerationItemApi() {
     final EnumerationItemDTO dto = new EnumerationItemDTO();
-    dto.setAuthorization(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
+    dto.setAuth(new AuthorizationConfigurationDTO().setNamespace("my-namespace"));
 
     final EnumerationItemApi gotApi = ApiBeanMapper.toApi(dto);
-    assertNotNull(gotApi.getAuthorization());
-    assertEquals(gotApi.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotApi.getAuth());
+    assertEquals(gotApi.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test
   public void testToEnumerationItemDTO() {
     final EnumerationItemApi api = new EnumerationItemApi()
-        .setAuthorization(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
+        .setAuth(new AuthorizationConfigurationApi().setNamespace("my-namespace"));
 
     final EnumerationItemDTO gotDto = ApiBeanMapper.toEnumerationItemDTO(api);
-    assertNotNull(gotDto.getAuthorization());
-    assertEquals(gotDto.getAuthorization().getNamespace(), "my-namespace");
+    assertNotNull(gotDto.getAuth());
+    assertEquals(gotDto.getAuth().getNamespace(), "my-namespace");
   }
 
   @Test

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -26,6 +26,7 @@ import ai.startree.thirdeye.spi.accessControl.ResourceIdentifier;
 import ai.startree.thirdeye.spi.datalayer.dto.AbstractDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AuthorizationConfigurationDTO;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -107,7 +108,8 @@ public class AuthorizationManager {
   static public <T extends AbstractDTO> ResourceIdentifier resourceId(final T dto) {
     return ResourceIdentifier.from(
         optional(dto.getId()).map(Objects::toString).orElse(DEFAULT_NAME),
-        optional(dto.getNamespace()).orElse(DEFAULT_NAMESPACE),
+        optional(dto.getAuthorization())
+            .map(AuthorizationConfigurationDTO::getNamespace).orElse(DEFAULT_NAMESPACE),
         optional(SubEntities.BEAN_TYPE_MAP.get(dto.getClass()))
             .map(Objects::toString).orElse(DEFAULT_ENTITY_TYPE));
   }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -108,7 +108,7 @@ public class AuthorizationManager {
   static public <T extends AbstractDTO> ResourceIdentifier resourceId(final T dto) {
     return ResourceIdentifier.from(
         optional(dto.getId()).map(Objects::toString).orElse(DEFAULT_NAME),
-        optional(dto.getAuthorization())
+        optional(dto.getAuth())
             .map(AuthorizationConfigurationDTO::getNamespace).orElse(DEFAULT_NAMESPACE),
         optional(SubEntities.BEAN_TYPE_MAP.get(dto.getClass()))
             .map(Objects::toString).orElse(DEFAULT_ENTITY_TYPE));

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertApi.java
@@ -21,7 +21,6 @@ public class AlertApi implements ThirdEyeCrudApi<AlertApi> {
 
   private Long id;
   private String name;
-  private String namespace;
   private String description;
   private AlertTemplateApi template;
   private Map<String, Object> templateProperties;
@@ -32,6 +31,7 @@ public class AlertApi implements ThirdEyeCrudApi<AlertApi> {
   private Date updated;
   private UserApi owner;
   private List<SubscriptionGroupApi> subscriptionGroups;
+  private AuthorizationConfigurationApi authorization;
 
 
   public Long getId() {
@@ -49,15 +49,6 @@ public class AlertApi implements ThirdEyeCrudApi<AlertApi> {
 
   public AlertApi setName(final String name) {
     this.name = name;
-    return this;
-  }
-
-  public String getNamespace() {
-    return namespace;
-  }
-
-  public AlertApi setNamespace(final String namespace) {
-    this.namespace = namespace;
     return this;
   }
 
@@ -150,6 +141,15 @@ public class AlertApi implements ThirdEyeCrudApi<AlertApi> {
   public AlertApi setSubscriptionGroups(
       final List<SubscriptionGroupApi> subscriptionGroups) {
     this.subscriptionGroups = subscriptionGroups;
+    return this;
+  }
+
+  public AuthorizationConfigurationApi getAuthorization() {
+    return authorization;
+  }
+
+  public AlertApi setAuthorization(final AuthorizationConfigurationApi authorization) {
+    this.authorization = authorization;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertApi.java
@@ -31,7 +31,7 @@ public class AlertApi implements ThirdEyeCrudApi<AlertApi> {
   private Date updated;
   private UserApi owner;
   private List<SubscriptionGroupApi> subscriptionGroups;
-  private AuthorizationConfigurationApi authorization;
+  private AuthorizationConfigurationApi auth;
 
 
   public Long getId() {
@@ -144,12 +144,12 @@ public class AlertApi implements ThirdEyeCrudApi<AlertApi> {
     return this;
   }
 
-  public AuthorizationConfigurationApi getAuthorization() {
-    return authorization;
+  public AuthorizationConfigurationApi getAuth() {
+    return auth;
   }
 
-  public AlertApi setAuthorization(final AuthorizationConfigurationApi authorization) {
-    this.authorization = authorization;
+  public AlertApi setAuth(final AuthorizationConfigurationApi auth) {
+    this.auth = auth;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
@@ -23,7 +23,6 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
 
   private Long id;
   private String name;
-  private String namespace;
   private String description;
   private String cron;
   private Date created;
@@ -36,6 +35,7 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
   @Deprecated // use propertiesMetadata
   private Map<String, @Nullable Object> defaultProperties;
   private List<TemplatePropertyMetadata> properties;
+  private AuthorizationConfigurationApi authorization;
 
   public Long getId() {
     return id;
@@ -52,15 +52,6 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
 
   public AlertTemplateApi setName(final String name) {
     this.name = name;
-    return this;
-  }
-
-  public String getNamespace() {
-    return namespace;
-  }
-
-  public AlertTemplateApi setNamespace(final String namespace) {
-    this.namespace = namespace;
     return this;
   }
 
@@ -158,6 +149,15 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
   public AlertTemplateApi setProperties(
       final List<TemplatePropertyMetadata> properties) {
     this.properties = properties;
+    return this;
+  }
+
+  public AuthorizationConfigurationApi getAuthorization() {
+    return authorization;
+  }
+
+  public AlertTemplateApi setAuthorization(final AuthorizationConfigurationApi authorization) {
+    this.authorization = authorization;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertTemplateApi.java
@@ -35,7 +35,7 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
   @Deprecated // use propertiesMetadata
   private Map<String, @Nullable Object> defaultProperties;
   private List<TemplatePropertyMetadata> properties;
-  private AuthorizationConfigurationApi authorization;
+  private AuthorizationConfigurationApi auth;
 
   public Long getId() {
     return id;
@@ -152,12 +152,12 @@ public class AlertTemplateApi implements ThirdEyeCrudApi<AlertTemplateApi> {
     return this;
   }
 
-  public AuthorizationConfigurationApi getAuthorization() {
-    return authorization;
+  public AuthorizationConfigurationApi getAuth() {
+    return auth;
   }
 
-  public AlertTemplateApi setAuthorization(final AuthorizationConfigurationApi authorization) {
-    this.authorization = authorization;
+  public AlertTemplateApi setAuth(final AuthorizationConfigurationApi auth) {
+    this.auth = auth;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AnomalyApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AnomalyApi.java
@@ -59,7 +59,7 @@ public class AnomalyApi implements ThirdEyeCrudApi<AnomalyApi> {
 
   private EnumerationItemApi enumerationItem;
   private List<AnomalyLabelApi> anomalyLabels;
-  private AuthorizationConfigurationApi authorization;
+  private AuthorizationConfigurationApi auth;
 
   public Long getId() {
     return id;
@@ -275,12 +275,12 @@ public class AnomalyApi implements ThirdEyeCrudApi<AnomalyApi> {
     return this;
   }
 
-  public AuthorizationConfigurationApi getAuthorization() {
-    return authorization;
+  public AuthorizationConfigurationApi getAuth() {
+    return auth;
   }
 
-  public AnomalyApi setAuthorization(final AuthorizationConfigurationApi authorization) {
-    this.authorization = authorization;
+  public AnomalyApi setAuth(final AuthorizationConfigurationApi auth) {
+    this.auth = auth;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AnomalyApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AnomalyApi.java
@@ -59,6 +59,7 @@ public class AnomalyApi implements ThirdEyeCrudApi<AnomalyApi> {
 
   private EnumerationItemApi enumerationItem;
   private List<AnomalyLabelApi> anomalyLabels;
+  private AuthorizationConfigurationApi authorization;
 
   public Long getId() {
     return id;
@@ -271,6 +272,15 @@ public class AnomalyApi implements ThirdEyeCrudApi<AnomalyApi> {
   public AnomalyApi setAnomalyLabels(
       final List<AnomalyLabelApi> anomalyLabels) {
     this.anomalyLabels = anomalyLabels;
+    return this;
+  }
+
+  public AuthorizationConfigurationApi getAuthorization() {
+    return authorization;
+  }
+
+  public AnomalyApi setAuthorization(final AuthorizationConfigurationApi authorization) {
+    this.authorization = authorization;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AuthorizationConfigurationApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AuthorizationConfigurationApi.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.spi.api;
+
+public class AuthorizationConfigurationApi {
+
+  private String namespace;
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public AuthorizationConfigurationApi setNamespace(final String namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DataSourceApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DataSourceApi.java
@@ -28,7 +28,7 @@ public class DataSourceApi implements ThirdEyeCrudApi<DataSourceApi> {
   private String type;
   private Map<String, Object> properties;
   private List<DataSourceMetaApi> metaList;
-  private AuthorizationConfigurationApi authorization;
+  private AuthorizationConfigurationApi auth;
 
   @Override
   public Long getId() {
@@ -79,12 +79,12 @@ public class DataSourceApi implements ThirdEyeCrudApi<DataSourceApi> {
     return this;
   }
 
-  public AuthorizationConfigurationApi getAuthorization() {
-    return authorization;
+  public AuthorizationConfigurationApi getAuth() {
+    return auth;
   }
 
-  public DataSourceApi setAuthorization(final AuthorizationConfigurationApi authorization) {
-    this.authorization = authorization;
+  public DataSourceApi setAuth(final AuthorizationConfigurationApi auth) {
+    this.auth = auth;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DataSourceApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DataSourceApi.java
@@ -25,10 +25,10 @@ public class DataSourceApi implements ThirdEyeCrudApi<DataSourceApi> {
 
   private Long id;
   private String name;
-  private String namespace;
   private String type;
   private Map<String, Object> properties;
   private List<DataSourceMetaApi> metaList;
+  private AuthorizationConfigurationApi authorization;
 
   @Override
   public Long getId() {
@@ -47,15 +47,6 @@ public class DataSourceApi implements ThirdEyeCrudApi<DataSourceApi> {
 
   public DataSourceApi setName(final String name) {
     this.name = name;
-    return this;
-  }
-
-  public String getNamespace() {
-    return namespace;
-  }
-
-  public DataSourceApi setNamespace(final String namespace) {
-    this.namespace = namespace;
     return this;
   }
 
@@ -85,6 +76,15 @@ public class DataSourceApi implements ThirdEyeCrudApi<DataSourceApi> {
   public DataSourceApi setMetaList(
       final List<DataSourceMetaApi> metaList) {
     this.metaList = metaList;
+    return this;
+  }
+
+  public AuthorizationConfigurationApi getAuthorization() {
+    return authorization;
+  }
+
+  public DataSourceApi setAuthorization(final AuthorizationConfigurationApi authorization) {
+    this.authorization = authorization;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
@@ -40,7 +40,7 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
    * Dimensions to exclude from RCA algorithm runs.
    */
   private Templatable<List<String>> rcaExcludedDimensions;
-  private AuthorizationConfigurationApi authorization;
+  private AuthorizationConfigurationApi auth;
 
   public Long getId() {
     return id;
@@ -144,12 +144,12 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
     return this;
   }
 
-  public AuthorizationConfigurationApi getAuthorization() {
-    return authorization;
+  public AuthorizationConfigurationApi getAuth() {
+    return auth;
   }
 
-  public DatasetApi setAuthorization(final AuthorizationConfigurationApi authorization) {
-    this.authorization = authorization;
+  public DatasetApi setAuth(final AuthorizationConfigurationApi auth) {
+    this.auth = auth;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
@@ -40,6 +40,7 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
    * Dimensions to exclude from RCA algorithm runs.
    */
   private Templatable<List<String>> rcaExcludedDimensions;
+  private AuthorizationConfigurationApi authorization;
 
   public Long getId() {
     return id;
@@ -140,6 +141,15 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
   public DatasetApi setRcaExcludedDimensions(
       final Templatable<List<String>> rcaExcludedDimensions) {
     this.rcaExcludedDimensions = rcaExcludedDimensions;
+    return this;
+  }
+
+  public AuthorizationConfigurationApi getAuthorization() {
+    return authorization;
+  }
+
+  public DatasetApi setAuthorization(final AuthorizationConfigurationApi authorization) {
+    this.authorization = authorization;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/EnumerationItemApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/EnumerationItemApi.java
@@ -26,7 +26,7 @@ public class EnumerationItemApi implements ThirdEyeCrudApi<EnumerationItemApi> {
   private String description;
   private Map<String, Object> params;
   private List<AlertApi> alerts;
-  private AuthorizationConfigurationApi authorization;
+  private AuthorizationConfigurationApi auth;
 
   @Override
   public Long getId() {
@@ -75,12 +75,12 @@ public class EnumerationItemApi implements ThirdEyeCrudApi<EnumerationItemApi> {
     return this;
   }
 
-  public AuthorizationConfigurationApi getAuthorization() {
-    return authorization;
+  public AuthorizationConfigurationApi getAuth() {
+    return auth;
   }
 
-  public EnumerationItemApi setAuthorization(final AuthorizationConfigurationApi authorization) {
-    this.authorization = authorization;
+  public EnumerationItemApi setAuth(final AuthorizationConfigurationApi auth) {
+    this.auth = auth;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/EnumerationItemApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/EnumerationItemApi.java
@@ -26,6 +26,7 @@ public class EnumerationItemApi implements ThirdEyeCrudApi<EnumerationItemApi> {
   private String description;
   private Map<String, Object> params;
   private List<AlertApi> alerts;
+  private AuthorizationConfigurationApi authorization;
 
   @Override
   public Long getId() {
@@ -71,6 +72,15 @@ public class EnumerationItemApi implements ThirdEyeCrudApi<EnumerationItemApi> {
 
   public EnumerationItemApi setAlerts(final List<AlertApi> alerts) {
     this.alerts = alerts;
+    return this;
+  }
+
+  public AuthorizationConfigurationApi getAuthorization() {
+    return authorization;
+  }
+
+  public EnumerationItemApi setAuthorization(final AuthorizationConfigurationApi authorization) {
+    this.authorization = authorization;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AbstractDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AbstractDTO.java
@@ -30,7 +30,7 @@ public abstract class AbstractDTO implements Serializable {
   private String createdBy;
   private Timestamp updateTime;
   private String updatedBy;
-  private AuthorizationConfigurationDTO authorization;
+  private AuthorizationConfigurationDTO auth;
 
   public Long getId() {
     return id;
@@ -86,12 +86,12 @@ public abstract class AbstractDTO implements Serializable {
     return this;
   }
 
-  public AuthorizationConfigurationDTO getAuthorization() {
-    return authorization;
+  public AuthorizationConfigurationDTO getAuth() {
+    return auth;
   }
 
-  public AbstractDTO setAuthorization(AuthorizationConfigurationDTO authorization) {
-    this.authorization = authorization;
+  public AbstractDTO setAuth(AuthorizationConfigurationDTO auth) {
+    this.auth = auth;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AbstractDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AbstractDTO.java
@@ -25,12 +25,12 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public abstract class AbstractDTO implements Serializable {
 
   private Long id;
-  private String namespace;
   private int version;
   private Timestamp createTime;
   private String createdBy;
   private Timestamp updateTime;
   private String updatedBy;
+  private AuthorizationConfigurationDTO authorization;
 
   public Long getId() {
     return id;
@@ -38,15 +38,6 @@ public abstract class AbstractDTO implements Serializable {
 
   public AbstractDTO setId(final Long id) {
     this.id = id;
-    return this;
-  }
-
-  public String getNamespace() {
-    return namespace;
-  }
-
-  public AbstractDTO setNamespace(final String namespace) {
-    this.namespace = namespace;
     return this;
   }
 
@@ -92,6 +83,15 @@ public abstract class AbstractDTO implements Serializable {
 
   public AbstractDTO setUpdatedBy(final String updatedBy) {
     this.updatedBy = updatedBy;
+    return this;
+  }
+
+  public AuthorizationConfigurationDTO getAuthorization() {
+    return authorization;
+  }
+
+  public AbstractDTO setAuthorization(AuthorizationConfigurationDTO authorization) {
+    this.authorization = authorization;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AuthorizationConfigurationDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AuthorizationConfigurationDTO.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.spi.datalayer.dto;
+
+
+public class AuthorizationConfigurationDTO {
+
+  private String namespace;
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public AuthorizationConfigurationDTO setNamespace(final String namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+}


### PR DESCRIPTION
This change adds a container AuthorizationConfiguration to store the namespace and any future fields relating to authorization.

Api resources that support AuthorizationConfiguration:
 - DataSource
 - Dataset
 - AlertTemplate
 - Alert
 - EnumerationItem
 - Anomaly