### PR TITLE
feat(ui): TE-1284 added oidc "groups" claim to dex default scopes in platform code in thirdeye-ui

### DIFF
--- a/thirdeye-ui/src/app/platform/components/auth-provider-v1/auth-provider-v1.component.tsx
+++ b/thirdeye-ui/src/app/platform/components/auth-provider-v1/auth-provider-v1.component.tsx
@@ -560,7 +560,11 @@ export const AuthProviderV1: FunctionComponent<AuthProviderV1Props> = ({
                         name="redirect_uri"
                         value={location.origin}
                     />
-                    <input readOnly name="scope" value="openid email profile" />
+                    <input
+                        readOnly
+                        name="scope"
+                        value="openid email profile groups"
+                    />
                     {oidcIssuerAudiencePath && (
                         <input
                             readOnly


### PR DESCRIPTION
### Issue(s)

[TE-1284](https://cortexdata.atlassian.net/browse/TE-1284)

### Description

Updated auth claims in auth-provider to match platform-ui

### Links
- [platform-ui PR](https://github.com/startreedata/startree-ui/pull/1183)
- [Slack Thread](https://cortex-data.slack.com/archives/C04MVHLM8BX/p1675432779815489)

### Screenshots

> None

[TE-1284]: https://cortexdata.atlassian.net/browse/TE-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ