### PR TITLE
[core] add mutabilityPeriod to detectionIntervalCalculator

### DIFF
--- a/thirdeye-core/pom.xml
+++ b/thirdeye-core/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Swagger -->
     <dependency>

--- a/thirdeye-core/src/test/java/ai/startree/thirdeye/alert/AlertDetectionIntervalCalculatorTest.java
+++ b/thirdeye-core/src/test/java/ai/startree/thirdeye/alert/AlertDetectionIntervalCalculatorTest.java
@@ -13,16 +13,21 @@
  */
 package ai.startree.thirdeye.alert;
 
-import static ai.startree.thirdeye.alert.AlertDetectionIntervalCalculator.getCorrectedInterval;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertMetadataDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
+import java.io.IOException;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class AlertDetectionIntervalCalculatorTest {
@@ -33,54 +38,66 @@ public class AlertDetectionIntervalCalculatorTest {
   private static final long ALERT_ID = 0;
   private static final String DATASET_NAME = "my_dataset";
 
+  private AlertDetectionIntervalCalculator intervalCalculator;
+
+  @BeforeMethod
+  public void setUp() throws IOException, ClassNotFoundException {
+    final AlertTemplateRenderer alertTemplateRenderer = mock(AlertTemplateRenderer.class);
+    when(alertTemplateRenderer.renderAlert(any(AlertDTO.class), any())).then(
+        i -> ((AlertDTO) i.getArguments()[0]).getTemplate());
+    intervalCalculator = new AlertDetectionIntervalCalculator(alertTemplateRenderer);
+  }
+
   @Test
-  public void testGetCorrectedIntervalNoMetadata() {
+  public void testGetCorrectedIntervalNoMetadata() throws IOException, ClassNotFoundException {
     // test that timeframe is unchanged when there is no metadata
-    DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
-    DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
-    AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO();
-    Interval output = getCorrectedInterval(ALERT_ID,
-        inputTaskStart.getMillis(),
-        inputTaskEnd.getMillis(),
-        inputAlertTemplate);
-    Interval expected = new Interval(inputTaskStart, inputTaskEnd);
+    final DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
+    final DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
+    final AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO();
+    final AlertDTO inputAlertDto = (AlertDTO) new AlertDTO().setTemplate(inputAlertTemplate)
+        .setId(ALERT_ID);
+    final Interval output = intervalCalculator.getCorrectedInterval(inputAlertDto,
+        inputTaskStart.getMillis(), inputTaskEnd.getMillis());
+    final Interval expected = new Interval(inputTaskStart, inputTaskEnd);
 
     assertThat(output).isEqualTo(expected);
   }
 
   @Test
-  public void testGetCorrectedIntervalNoDelayNorGranularity() {
+  public void testGetCorrectedIntervalNoDelayNorGranularity()
+      throws IOException, ClassNotFoundException {
     // test that timeframe is unchanged when there is no completenessDelay nor granularity
-    DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
-    DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
-    DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO().setDataset(DATASET_NAME);
-    AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO().setMetadata(new AlertMetadataDTO().setDataset(
-        datasetConfigDTO));
-    Interval output = getCorrectedInterval(ALERT_ID,
-        inputTaskStart.getMillis(),
-        inputTaskEnd.getMillis(),
-        inputAlertTemplate);
+    final DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
+    final DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
+    final DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO().setDataset(DATASET_NAME);
+    final AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO().setMetadata(
+        new AlertMetadataDTO().setDataset(
+            datasetConfigDTO));
+    final AlertDTO inputAlertDto = (AlertDTO) new AlertDTO().setTemplate(inputAlertTemplate)
+        .setId(ALERT_ID);
+    final Interval output = intervalCalculator.getCorrectedInterval(inputAlertDto,
+        inputTaskStart.getMillis(), inputTaskEnd.getMillis());
     Interval expected = new Interval(inputTaskStart, inputTaskEnd);
 
     assertThat(output).isEqualTo(expected);
   }
 
   @Test
-  public void testGetCorrectedIntervalWithDelay() {
+  public void testGetCorrectedIntervalWithDelay() throws IOException, ClassNotFoundException {
     // test that endtime is changed when there is a delay
-    DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
-    DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
-    DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO()
+    final DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
+    final DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
+    final DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO()
         .setDataset(DATASET_NAME)
         .setCompletenessDelay("P1D"); // delay of 1 day
-    AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
+    final AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
         .setMetadata(new AlertMetadataDTO().setDataset(datasetConfigDTO));
-    Interval output = getCorrectedInterval(ALERT_ID,
-        inputTaskStart.getMillis(),
-        inputTaskEnd.getMillis(),
-        inputAlertTemplate);
+    final AlertDTO inputAlertDto = (AlertDTO) new AlertDTO().setTemplate(inputAlertTemplate)
+        .setId(ALERT_ID);
+    final Interval output = intervalCalculator.getCorrectedInterval(inputAlertDto,
+        inputTaskStart.getMillis(), inputTaskEnd.getMillis());
 
-    Interval expected = new Interval(
+    final Interval expected = new Interval(
         inputTaskStart,  // unchanged
         DATE_PARSER.parseDateTime("2021-11-23 13:02:12.333 UTC"));  // minus 1 day
 
@@ -88,22 +105,22 @@ public class AlertDetectionIntervalCalculatorTest {
   }
 
   @Test
-  public void testGetCorrectedIntervalWithGranularity() {
+  public void testGetCorrectedIntervalWithGranularity() throws IOException, ClassNotFoundException {
     // test that timeframe is changed when there is a granularity
-    DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
-    DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
-    DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO().setDataset(DATASET_NAME);
-    AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
+    final DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
+    final DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
+    final DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO().setDataset(DATASET_NAME);
+    final AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
         .setMetadata(new AlertMetadataDTO()
             .setDataset(datasetConfigDTO)
             .setGranularity("PT1H")  // granularity of 1H
         );
-    Interval output = getCorrectedInterval(ALERT_ID,
-        inputTaskStart.getMillis(),
-        inputTaskEnd.getMillis(),
-        inputAlertTemplate);
+    final AlertDTO inputAlertDto = (AlertDTO) new AlertDTO().setTemplate(inputAlertTemplate)
+        .setId(ALERT_ID);
+    final Interval output = intervalCalculator.getCorrectedInterval(inputAlertDto,
+        inputTaskStart.getMillis(), inputTaskEnd.getMillis());
 
-    Interval expected = new Interval(
+    final Interval expected = new Interval(
         DATE_PARSER.parseDateTime("2021-11-22 11:00:00.000 UTC"),   // floored to hour
         DATE_PARSER.parseDateTime("2021-11-24 13:00:00.000 UTC"));  // floored to hour
 
@@ -111,51 +128,53 @@ public class AlertDetectionIntervalCalculatorTest {
   }
 
   @Test
-  public void testGetCorrectedIntervalWithDelayAndGranularity() {
+  public void testGetCorrectedIntervalWithDelayAndGranularity()
+      throws IOException, ClassNotFoundException {
     // test that timeframe is changed when there is both delay and granularity
-    DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
-    DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
-    DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO()
+    final DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
+    final DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
+    final DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO()
         .setDataset(DATASET_NAME)
         .setCompletenessDelay("PT2H"); // delay of 2 hours
-    AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
+    final AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
         .setMetadata(new AlertMetadataDTO()
             .setDataset(datasetConfigDTO)
             .setGranularity("PT5M")  // granularity of 5 minutes
         );
-    Interval output = getCorrectedInterval(ALERT_ID,
-        inputTaskStart.getMillis(),
-        inputTaskEnd.getMillis(),
-        inputAlertTemplate);
+    final AlertDTO inputAlertDto = (AlertDTO) new AlertDTO().setTemplate(inputAlertTemplate)
+        .setId(ALERT_ID);
+    final Interval output = intervalCalculator.getCorrectedInterval(inputAlertDto,
+        inputTaskStart.getMillis(), inputTaskEnd.getMillis());
 
-    Interval expected = new Interval(
+    final Interval expected = new Interval(
         DATE_PARSER.parseDateTime("2021-11-22 11:20:00.000 UTC"),   // floored to 5 minutes
-        DATE_PARSER.parseDateTime("2021-11-24 11:00:0.000 UTC"));  // minus 2 hours + floored to 5 minutes
+        DATE_PARSER.parseDateTime(
+            "2021-11-24 11:00:0.000 UTC"));  // minus 2 hours + floored to 5 minutes
 
     assertThat(output).isEqualTo(expected);
   }
 
   @Test
-  public void testGetCorrectedIntervalWithStartTimeGreaterThanEndTimeMinusDelay() {
+  public void testGetCorrectedIntervalWithStartTimeGreaterThanEndTimeMinusDelay()
+      throws IOException, ClassNotFoundException {
     // test that both start and endTime are changed when end-delay < start
     // this can happen if delay is augmented
-    DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
-    DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
-    DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO()
+    final DateTime inputTaskStart = DATE_PARSER.parseDateTime("2021-11-22 11:22:33.444 UTC");
+    final DateTime inputTaskEnd = DATE_PARSER.parseDateTime("2021-11-24 13:02:12.333 UTC");
+    final DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO()
         .setDataset(DATASET_NAME)
         .setCompletenessDelay("P3D");   // delay of 3 day end - delay < start
-    AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
+    final AlertTemplateDTO inputAlertTemplate = new AlertTemplateDTO()
         .setMetadata(new AlertMetadataDTO().setDataset(datasetConfigDTO));
-    Interval output = getCorrectedInterval(ALERT_ID,
-        inputTaskStart.getMillis(),
-        inputTaskEnd.getMillis(),
-        inputAlertTemplate);
+    final AlertDTO inputAlertDto = (AlertDTO) new AlertDTO().setTemplate(inputAlertTemplate)
+        .setId(ALERT_ID);
+    final Interval output = intervalCalculator.getCorrectedInterval(inputAlertDto,
+        inputTaskStart.getMillis(), inputTaskEnd.getMillis());
 
-    Interval expected = new Interval(
+    final Interval expected = new Interval(
         DATE_PARSER.parseDateTime("2021-11-19 11:22:33.444 UTC"),   // minus 3 days
         DATE_PARSER.parseDateTime("2021-11-21 13:02:12.333 UTC"));  // minus 3 days
 
     assertThat(output).isEqualTo(expected);
-
   }
 }

--- a/thirdeye-scheduler/pom.xml
+++ b/thirdeye-scheduler/pom.xml
@@ -51,5 +51,22 @@
       <version>62.1</version>
     </dependency>
 
+    <!-- test -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/JobSchedulerService.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/JobSchedulerService.java
@@ -13,6 +13,11 @@
  */
 package ai.startree.thirdeye.scheduler;
 
+import static ai.startree.thirdeye.alert.AlertDetectionIntervalCalculator.getDateTimeZone;
+import static ai.startree.thirdeye.spi.Constants.DEFAULT_CHRONOLOGY;
+import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
+
+import ai.startree.thirdeye.alert.AlertTemplateRenderer;
 import ai.startree.thirdeye.spi.datalayer.AnomalyFilter;
 import ai.startree.thirdeye.spi.datalayer.Predicate;
 import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
@@ -20,35 +25,51 @@ import ai.startree.thirdeye.spi.datalayer.bao.AnomalyManager;
 import ai.startree.thirdeye.spi.datalayer.bao.AnomalySubscriptionGroupNotificationManager;
 import ai.startree.thirdeye.spi.datalayer.bao.TaskManager;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AlertMetadataDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AnomalySubscriptionGroupNotificationDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DetectionPipelineTaskInfo;
 import ai.startree.thirdeye.spi.datalayer.dto.SubscriptionGroupDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.TaskDTO;
 import ai.startree.thirdeye.spi.task.TaskStatus;
+import ai.startree.thirdeye.spi.util.TimeUtils;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.joda.time.Chronology;
+import org.joda.time.DateTime;
 import org.joda.time.Interval;
+import org.joda.time.Period;
 import org.quartz.JobKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class JobSchedulerService {
 
+  private static final Logger LOG = LoggerFactory.getLogger(JobSchedulerService.class);
+  public static final Interval UNUSED_DETECTION_INTERVAL = new Interval(0, 0, DEFAULT_CHRONOLOGY);
   private final TaskManager taskManager;
   private final AlertManager alertManager;
   private final AnomalyManager anomalyManager;
   private final AnomalySubscriptionGroupNotificationManager notificationManager;
+  private final AlertTemplateRenderer alertTemplateRenderer;
 
   @Inject
   public JobSchedulerService(final TaskManager taskManager,
       final AlertManager alertManager,
       final AnomalyManager anomalyManager,
-      final AnomalySubscriptionGroupNotificationManager notificationManager) {
+      final AnomalySubscriptionGroupNotificationManager notificationManager,
+      final AlertTemplateRenderer alertTemplateRenderer) {
     this.taskManager = taskManager;
     this.alertManager = alertManager;
     this.anomalyManager = anomalyManager;
     this.notificationManager = notificationManager;
+    this.alertTemplateRenderer = alertTemplateRenderer;
   }
 
   public boolean taskAlreadyRunning(final String jobName) {
@@ -71,9 +92,37 @@ public class JobSchedulerService {
       return null;
     }
 
-    // start and end are corrected with delay and granularity at execution time
-    long start = alert.getLastTimestamp();
+    final long start = computeTaskStart(alert, endTime);
     return new DetectionPipelineTaskInfo(alert.getId(), start, endTime);
+  }
+
+  private long computeTaskStart(final AlertDTO alert, final long endTime) {
+    try {
+      final AlertTemplateDTO templateWithProperties = alertTemplateRenderer.renderAlert(alert,
+          UNUSED_DETECTION_INTERVAL);
+      final Chronology chronology = optional(getDateTimeZone(templateWithProperties)).orElse(
+          DEFAULT_CHRONOLOGY);
+      final DateTime defaultStartTime = new DateTime(alert.getLastTimestamp(), chronology);
+      final DateTime endDateTime = new DateTime(endTime, chronology);
+      final Period mutabilityPeriod = getMutabilityPeriod(templateWithProperties);
+      final DateTime mutabilityStart = endDateTime.minus(mutabilityPeriod);
+      if (mutabilityStart.isBefore(defaultStartTime)) {
+        LOG.info(
+            "Applied mutability period of {} for alert id {} between {} and {}. Corrected task interval is between {} and {}",
+            mutabilityPeriod,
+            alert.getId(),
+            defaultStartTime,
+            endDateTime,
+            mutabilityStart,
+            endDateTime
+        );
+        return mutabilityStart.getMillis();
+      } else {
+        return defaultStartTime.getMillis();
+      }
+    } catch (IOException | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static Long getIdFromJobKey(String jobKey) {
@@ -121,5 +170,14 @@ public class JobSchedulerService {
         notificationManager.findByPredicate(
             Predicate.IN("detectionConfigId", vectorClocks.keySet().toArray()));
     return !anomalySubscriptionGroupNotifications.isEmpty();
+  }
+
+  @NonNull
+  private static Period getMutabilityPeriod(final AlertTemplateDTO templateWithProperties) {
+    return optional(templateWithProperties.getMetadata())
+        .map(AlertMetadataDTO::getDataset)
+        .map(DatasetConfigDTO::getMutabilityPeriod)
+        .map(TimeUtils::isoPeriod)
+        .orElse(Period.ZERO);
   }
 }

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/JobSchedulerService.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/JobSchedulerService.java
@@ -34,6 +34,7 @@ import ai.startree.thirdeye.spi.datalayer.dto.SubscriptionGroupDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.TaskDTO;
 import ai.startree.thirdeye.spi.task.TaskStatus;
 import ai.startree.thirdeye.spi.util.TimeUtils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.io.IOException;
@@ -96,7 +97,8 @@ public class JobSchedulerService {
     return new DetectionPipelineTaskInfo(alert.getId(), start, endTime);
   }
 
-  private long computeTaskStart(final AlertDTO alert, final long endTime) {
+  @VisibleForTesting
+  protected long computeTaskStart(final AlertDTO alert, final long endTime) {
     try {
       final AlertTemplateDTO templateWithProperties = alertTemplateRenderer.renderAlert(alert,
           UNUSED_DETECTION_INTERVAL);

--- a/thirdeye-scheduler/src/test/java/ai/startree/thirdeye/scheduler/JobSchedulerServiceTest.java
+++ b/thirdeye-scheduler/src/test/java/ai/startree/thirdeye/scheduler/JobSchedulerServiceTest.java
@@ -1,0 +1,66 @@
+package ai.startree.thirdeye.scheduler;/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.startree.thirdeye.alert.AlertTemplateRenderer;
+import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AlertMetadataDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
+import java.io.IOException;
+import org.joda.time.Period;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class JobSchedulerServiceTest {
+
+  private JobSchedulerService jobSchedulerService;
+
+  @BeforeMethod
+  public void setUp() throws IOException, ClassNotFoundException {
+    final AlertTemplateRenderer alertTemplateRenderer = mock(AlertTemplateRenderer.class);
+    when(alertTemplateRenderer.renderAlert(any(AlertDTO.class), any())).then(
+        i -> ((AlertDTO) i.getArguments()[0]).getTemplate());
+    jobSchedulerService = new JobSchedulerService(null, null, null, null, alertTemplateRenderer);
+  }
+
+  @DataProvider(name = "computeTaskStartTestCases")
+  public Object[][] computeTaskStartTestCases() {
+    // one alert for each template
+    final Object[] noMutabilityPeriod = {10L, 20L, null, 10L};
+    final Object[] zeroMutabilityPeriod = {10L, 20L, Period.ZERO.toString(), 10L};
+    final Object[] mutabilityPeriod = {10L, 20L, Period.millis(15).toString(), 5L};
+    final Object[] mutabilityPeriodStartBiggerThanTaskStart = {10L, 20L,
+        Period.millis(5).toString(), 10L};
+
+    return new Object[][]{noMutabilityPeriod, zeroMutabilityPeriod, mutabilityPeriod,
+        mutabilityPeriodStartBiggerThanTaskStart};
+  }
+
+  @Test(dataProvider = "computeTaskStartTestCases")
+  public void testComputeTaskStart(final long lastTimestamp,
+      final long endTime, final String mutabilityPeriod, final long expectedStartTime) {
+    final AlertDTO alert = new AlertDTO().setTemplate(new AlertTemplateDTO().setMetadata(
+            new AlertMetadataDTO().setDataset(
+                new DatasetConfigDTO().setMutabilityPeriod(mutabilityPeriod))))
+        .setLastTimestamp(lastTimestamp);
+    final var output = jobSchedulerService.computeTaskStart(alert, endTime);
+    assertThat(output).isEqualTo(expectedStartTime);
+  }
+}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/DatasetApi.java
@@ -37,6 +37,12 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
    */
   private String completenessDelay;
   /**
+   * ISO-8601 period. Eg P7D. At detection run, TE re-runs the detection starting from
+   * min(lastTimestamp,
+   * endTime-replayPeriod). Used to manage data mutability.
+   */
+  private String mutabilityPeriod;
+  /**
    * Dimensions to exclude from RCA algorithm runs.
    */
   private Templatable<List<String>> rcaExcludedDimensions;
@@ -150,6 +156,15 @@ public class DatasetApi implements ThirdEyeCrudApi<DatasetApi> {
 
   public DatasetApi setAuth(final AuthorizationConfigurationApi auth) {
     this.auth = auth;
+    return this;
+  }
+
+  public String getMutabilityPeriod() {
+    return mutabilityPeriod;
+  }
+
+  public DatasetApi setMutabilityPeriod(final String mutabilityPeriod) {
+    this.mutabilityPeriod = mutabilityPeriod;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertDTO.java
@@ -89,8 +89,9 @@ public class AlertDTO extends AbstractDTO {
     return lastTimestamp;
   }
 
-  public void setLastTimestamp(long lastTimestamp) {
+  public AlertDTO setLastTimestamp(long lastTimestamp) {
     this.lastTimestamp = lastTimestamp;
+    return this;
   }
 
   public boolean isActive() {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DatasetConfigDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DatasetConfigDTO.java
@@ -47,6 +47,11 @@ public class DatasetConfigDTO extends AbstractDTO {
    */
   private String completenessDelay;
   /**
+   * ISO-8601 period. Eg P7D. At detection run, TE re-runs the detection starting from min(lastTimestamp,
+   * endTime-replayPeriod). Used to manage data mutability.
+   */
+  private String mutabilityPeriod;
+  /**
    * Dimensions to exclude from RCA algorithm runs.
    */
   private Templatable<List<String>> rcaExcludedDimensions;
@@ -370,5 +375,14 @@ public class DatasetConfigDTO extends AbstractDTO {
           (size != null && timeUnit != null) ? new TimeGranularity(size, timeUnit) : null;
     }
     return bucketTimeGranularity;
+  }
+
+  public String getMutabilityPeriod() {
+    return mutabilityPeriod;
+  }
+
+  public DatasetConfigDTO setMutabilityPeriod(final String mutabilityPeriod) {
+    this.mutabilityPeriod = mutabilityPeriod;
+    return this;
   }
 }


### PR DESCRIPTION
Introduce `mutabilityPeriod` as defined in design doc https://docs.google.com/document/d/1bSbv4XhTQsdGR1XVM_dYL1cK9Q6JlntvzNYmmMiXQRI/edit#heading=h.ffhc3nomfqi9

There are 5 ways a detection pipeline can be triggered: 
- Via the evaluate endpoint
- Via the create endpoint
- Via the reset endpoint
- Via the run endpoint
- Via the cron scheduled execution
`mutabilityPeriod` is only relevant for the cron scheduled execution. It is not applied for other cases. 


Changes: 
- add `mutabilityPeriod` to DatasetConfigDto/Api
- apply `mutabilityPeriod` in the JobSchedulerService
- refactorings to `AlertDetectionIntervalCalculator` and `AlertDetectionIntervalCalculatorTest` - not directly related anymore following rewrite of the PR