### PR TITLE
Enforce access control for generic entities, dataset onboarding, and anomly feedback

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -249,7 +249,7 @@ public class GenericPojoDao {
     }
   }
 
-  public Object getRaw(final Long id) {
+  public AbstractDTO getRaw(final Long id) {
     try {
       final GenericJsonEntity genericJsonEntity = transactionService.executeTransaction(
           (connection) -> databaseService.find(id, GenericJsonEntity.class, connection),

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -26,6 +26,7 @@ import ai.startree.thirdeye.spi.accessControl.ResourceIdentifier;
 import ai.startree.thirdeye.spi.datalayer.dto.AbstractDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertTemplateDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AnomalyDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.AuthorizationConfigurationDTO;
 import com.google.inject.Inject;
 import java.util.ArrayList;
@@ -81,6 +82,10 @@ public class AuthorizationManager {
 
   public void ensureCanValidate(final ThirdEyePrincipal principal, final AlertDTO entity) {
     ensureCanCreate(principal, entity);
+  }
+
+  public void ensureCanSetFeedback(final ThirdEyePrincipal principal, final AnomalyDTO entity) {
+    ensureHasAccess(principal, entity, AccessType.WRITE);
   }
 
   public <T extends AbstractDTO> void ensureHasAccess(final ThirdEyePrincipal principal,

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AnomalyResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AnomalyResource.java
@@ -121,6 +121,7 @@ public class AnomalyResource extends CrudResource<AnomalyApi, AnomalyDTO> {
       @PathParam("id") Long id,
       AnomalyFeedbackApi api) {
     final AnomalyDTO dto = get(id);
+    authorizationManager.ensureCanSetFeedback(principal, dto);
 
     final AnomalyFeedbackDTO feedbackDTO = ApiBeanMapper.toAnomalyFeedbackDTO(api);
     dto.setFeedback(feedbackDTO);

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/CrudResource.java
@@ -241,6 +241,12 @@ public abstract class CrudResource<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exte
     final RequestCache cache = createRequestCache();
     ensureExists(name, ERR_MISSING_NAME);
 
+    final DtoT dto = getDtoByName(name);
+    authorizationManager.ensureCanRead(principal, dto);
+    return respondOk(toApi(dto, cache));
+  }
+
+  public DtoT getDtoByName(final String name) {
     /* If name column is mapped, use the mapping, else use 'name' */
     final String nameColumn = optional(apiToIndexMap.get("name")).orElse("name");
     final List<DtoT> byName = dtoManager.filter(new DaoFilter()
@@ -250,9 +256,7 @@ public abstract class CrudResource<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exte
     if (byName.size() > 1) {
       throw serverError(ERR_UNKNOWN, "Error. Multiple objects with name: " + name);
     }
-    DtoT dtoT = byName.iterator().next();
-    authorizationManager.ensureCanRead(principal, dtoT);
-    return respondOk(toApi(dtoT, cache));
+    return byName.iterator().next();
   }
 
   @POST

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DataSourceResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DataSourceResource.java
@@ -116,6 +116,8 @@ public class DataSourceResource extends CrudResource<DataSourceApi, DataSourceDT
   public Response getDatasets(
       @ApiParam(hidden = true) @Auth ThirdEyePrincipal principal,
       @PathParam("name") String name) {
+    ensureExists(name, "name is a required field");
+    authorizationManager.ensureCanRead(principal, getDtoByName(name));
 
     final ThirdEyeDataSource dataSource = dataSourceCache.getDataSource(name);
     final List<DatasetApi> datasets = dataSource.getDatasets().stream()
@@ -135,6 +137,7 @@ public class DataSourceResource extends CrudResource<DataSourceApi, DataSourceDT
 
     ensureExists(dataSourceName, "dataSourceName is a required field");
     ensureExists(datasetName, "datasetName is a required field");
+    authorizationManager.ensureCanRead(principal, getDtoByName(dataSourceName));
 
     final DatasetConfigDTO datasetConfigDTO = dataSourceOnboarder.onboardDataset(dataSourceName,
         datasetName);
@@ -151,6 +154,8 @@ public class DataSourceResource extends CrudResource<DataSourceApi, DataSourceDT
       @FormParam("name") String name) {
 
     ensureExists(name, "name is a required field");
+    authorizationManager.ensureCanRead(principal, getDtoByName(name));
+
     final List<DatasetConfigDTO> datasets = dataSourceOnboarder.onboardAll(name);
 
     return respondOk(datasets.stream()
@@ -166,6 +171,7 @@ public class DataSourceResource extends CrudResource<DataSourceApi, DataSourceDT
       @ApiParam(hidden = true) @Auth ThirdEyePrincipal principal,
       @FormParam("name") String name) {
     ensureExists(name, "name is a required field");
+    authorizationManager.ensureCanRead(principal, getDtoByName(name));
 
     final List<DatasetConfigDTO> datasets = dataSourceOnboarder.offboardAll(name);
 

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AnomalyResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AnomalyResourceTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.resources;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.startree.thirdeye.alert.AlertTemplateRenderer;
+import ai.startree.thirdeye.auth.AccessControlProvider;
+import ai.startree.thirdeye.auth.AuthorizationManager;
+import ai.startree.thirdeye.auth.ThirdEyePrincipal;
+import ai.startree.thirdeye.core.AppAnalyticsService;
+import ai.startree.thirdeye.spi.api.AnomalyFeedbackApi;
+import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
+import ai.startree.thirdeye.spi.datalayer.bao.AnomalyManager;
+import ai.startree.thirdeye.spi.datalayer.dto.AnomalyDTO;
+import javax.ws.rs.ForbiddenException;
+import org.testng.annotations.Test;
+
+public class AnomalyResourceTest {
+
+  @Test(expectedExceptions = ForbiddenException.class)
+  public void testSetFeedback_withNoAccess() {
+    final AnomalyManager anomalyManager = mock(AnomalyManager.class);
+    when(anomalyManager.findById(1L))
+        .thenReturn((AnomalyDTO) new AnomalyDTO().setId(1L));
+    new AnomalyResource(
+        anomalyManager,
+        mock(AlertManager.class),
+        mock(AppAnalyticsService.class),
+        new AuthorizationManager(
+            mock(AlertTemplateRenderer.class),
+            AccessControlProvider.alwaysDeny
+        )
+    ).setFeedback(new ThirdEyePrincipal("nobody", ""), 1L, new AnomalyFeedbackApi());
+  }
+}

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.resources;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,7 +28,10 @@ import ai.startree.thirdeye.spi.ThirdEyeStatus;
 import ai.startree.thirdeye.spi.api.StatusApi;
 import ai.startree.thirdeye.spi.api.StatusListApi;
 import ai.startree.thirdeye.spi.datalayer.bao.DataSourceManager;
+import ai.startree.thirdeye.spi.datalayer.dto.DataSourceDTO;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSource;
+import java.util.Collections;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.Response;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -80,5 +84,58 @@ public class DataSourceResourceTest {
 
     final StatusApi statusApi = entity.getList().get(0);
     assertThat(statusApi.getCode()).isEqualTo(ThirdEyeStatus.ERR_DATASOURCE_VALIDATION_FAILED);
+  }
+
+  final ThirdEyePrincipal Nobody = new ThirdEyePrincipal("nobody", "");
+
+  @Test(expectedExceptions = ForbiddenException.class)
+  public void testOnboardDataset_withNoAccess() {
+    final DataSourceManager dataSourceManager = mock(DataSourceManager.class);
+    when(dataSourceManager.filter(any())).thenReturn(Collections.singletonList(
+        ((DataSourceDTO) new DataSourceDTO().setId(1L)).setName("datasource1"))
+    );
+    new DataSourceResource(
+        dataSourceManager,
+        mock(DataSourceCache.class),
+        mock(DataSourceOnboarder.class),
+        new AuthorizationManager(
+            mock(AlertTemplateRenderer.class),
+            AccessControlProvider.alwaysDeny
+        )
+    ).onboardDataset(Nobody, "datasource1", "dataset1");
+  }
+
+  @Test(expectedExceptions = ForbiddenException.class)
+  public void testOnboardAll_withNoAccess() {
+    final DataSourceManager dataSourceManager = mock(DataSourceManager.class);
+    when(dataSourceManager.filter(any())).thenReturn(Collections.singletonList(
+        ((DataSourceDTO) new DataSourceDTO().setId(1L)).setName("datasource1"))
+    );
+    new DataSourceResource(
+        dataSourceManager,
+        mock(DataSourceCache.class),
+        mock(DataSourceOnboarder.class),
+        new AuthorizationManager(
+            mock(AlertTemplateRenderer.class),
+            AccessControlProvider.alwaysDeny
+        )
+    ).onboardAll(Nobody, "datasource1");
+  }
+
+  @Test(expectedExceptions = ForbiddenException.class)
+  public void testOffboardAll_withNoAccess() {
+    final DataSourceManager dataSourceManager = mock(DataSourceManager.class);
+    when(dataSourceManager.filter(any())).thenReturn(Collections.singletonList(
+        ((DataSourceDTO) new DataSourceDTO().setId(1L)).setName("datasource1"))
+    );
+    new DataSourceResource(
+        dataSourceManager,
+        mock(DataSourceCache.class),
+        mock(DataSourceOnboarder.class),
+        new AuthorizationManager(
+            mock(AlertTemplateRenderer.class),
+            AccessControlProvider.alwaysDeny
+        )
+    ).offboardAll(Nobody, "datasource1");
   }
 }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/EntityResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/EntityResourceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.startree.thirdeye.alert.AlertTemplateRenderer;
+import ai.startree.thirdeye.auth.AccessControlProvider;
+import ai.startree.thirdeye.auth.AuthorizationManager;
+import ai.startree.thirdeye.auth.ThirdEyePrincipal;
+import ai.startree.thirdeye.datalayer.dao.GenericPojoDao;
+import ai.startree.thirdeye.spi.accessControl.AccessType;
+import ai.startree.thirdeye.spi.accessControl.ResourceIdentifier;
+import ai.startree.thirdeye.spi.datalayer.dto.DataSourceDTO;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.testng.annotations.Test;
+
+public class EntityResourceTest {
+
+  final ThirdEyePrincipal Nobody = new ThirdEyePrincipal("nobody", "");
+
+  @Test(expectedExceptions = ForbiddenException.class)
+  public void testGetRawEntity() throws SQLException {
+    final GenericPojoDao genericPojoDao = mock(GenericPojoDao.class);
+    when(genericPojoDao.getRaw(1L)).thenReturn(new DataSourceDTO().setId(1L));
+    new EntityResource(
+        genericPojoDao,
+        new AuthorizationManager(
+            mock(AlertTemplateRenderer.class),
+            AccessControlProvider.alwaysDeny
+        )
+    ).getRawEntity(Nobody, 1L);
+  }
+
+  @Test
+  public void testGetEntity_withNoAccess() {
+    final UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
+      put("limit", Collections.singletonList("10"));
+      put("offset", Collections.singletonList("0"));
+    }});
+    final GenericPojoDao genericPojoDao = mock(GenericPojoDao.class);
+    when(genericPojoDao.list(DataSourceDTO.class, 10, 0)).thenReturn(Arrays.asList(
+        (DataSourceDTO) new DataSourceDTO().setId(1L),
+        (DataSourceDTO) new DataSourceDTO().setId(2L),
+        (DataSourceDTO) new DataSourceDTO().setId(3L)
+    ));
+
+    Response resp = new EntityResource(
+        genericPojoDao,
+        new AuthorizationManager(
+            mock(AlertTemplateRenderer.class),
+            AccessControlProvider.alwaysDeny
+        )
+    ).getEntity(Nobody, "ai.startree.thirdeye.spi.datalayer.dto.DataSourceDTO", uriInfo);
+    assertThat(resp.getStatus()).isEqualTo(200);
+    final List<DataSourceDTO> entities = ((Stream<DataSourceDTO>) resp.getEntity())
+        .collect(Collectors.toList());
+    assertThat(entities).isEmpty();
+  }
+
+  @Test
+  public void testGetEntity_withPartialAccess() {
+    final UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
+      put("limit", Collections.singletonList("10"));
+      put("offset", Collections.singletonList("0"));
+    }});
+    final GenericPojoDao genericPojoDao = mock(GenericPojoDao.class);
+    when(genericPojoDao.list(DataSourceDTO.class, 10, 0)).thenReturn(Arrays.asList(
+        (DataSourceDTO) new DataSourceDTO().setId(1L),
+        (DataSourceDTO) new DataSourceDTO().setId(2L),
+        (DataSourceDTO) new DataSourceDTO().setId(3L)
+    ));
+
+    Response resp = new EntityResource(
+        genericPojoDao,
+        new AuthorizationManager(
+            mock(AlertTemplateRenderer.class),
+            (String token, ResourceIdentifier identifiers, AccessType accessType)
+                -> identifiers.name.equals("2")
+        )
+    ).getEntity(Nobody, "ai.startree.thirdeye.spi.datalayer.dto.DataSourceDTO", uriInfo);
+
+    assertThat(resp.getStatus()).isEqualTo(200);
+    final List<DataSourceDTO> entities = ((Stream<DataSourceDTO>) resp.getEntity())
+        .collect(Collectors.toList());
+    assertThat(1).isEqualTo(entities.size());
+    assertThat(2L).isEqualTo(entities.get(0).getId());
+  }
+}


### PR DESCRIPTION
Implements access control for:
 - Generic entities api - This would be an access control leak 😓 
 - Dataset onboarding
 - Setting feedback on anomalies
 
