### PR TITLE
check for read perm when evalutating alert

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -76,7 +76,7 @@ public class AuthorizationManager {
   }
 
   public void ensureCanEvaluate(final ThirdEyePrincipal principal, final AlertDTO entity) {
-    ensureCanCreate(principal, entity);
+    ensureCanRead(principal, entity);
   }
 
   public void ensureCanValidate(final ThirdEyePrincipal principal, final AlertDTO entity) {


### PR DESCRIPTION
Check for read instead of write when evaluating alerts. This way the UI can show the alert graph for anyone who can read the alert.