### PR TITLE
chore(ui): STUI-611 removed hardcoded Slack channel name from release config

### DIFF
--- a/thirdeye-ui/release.config.js
+++ b/thirdeye-ui/release.config.js
@@ -125,12 +125,11 @@ module.exports = {
                 notifyOnSuccess: true,
                 notifyOnFail: false, // CI pipeline will notify upon failure
                 onSuccessTemplate: {
-                    channel: "#ci-startree-ui-publish",
                     username: `${projectName}-publish-${releaseBranch}`,
                     icon_emoji: ":white_circle:",
                     text:
                         "<!channel> Successfully published `$package_name $npm_package_version`\n" +
-                        "Links: <https://repo.startreedata.io/ui/repos/tree/General/startree-ui/$package_name/-/$package_name-$npm_package_version.tgz|Artifactory> | " +
+                        "Links: <https://repo.startreedata.io/ui/repos/tree/General/startree-ui/$package_name/-/$package_name-$npm_package_version.tgz|Artifacts> | " +
                         "<$repo_url/releases/tag/" +
                         projectName +
                         "-$npm_package_version|Github>",


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/STUI-611

#### Description

Slack channel name was hardcoded in release configurations. Going forward, it should be picked up in [CI](https://github.com/startreedata/ci-startree-ui/blob/master/.concourse/tasks/thirdeye-ui/publish.task.yaml#L15) (for example).

Reference: https://github.com/juliuscc/semantic-release-slack-bot#environment-variables

If the approach doesn't work, we'll revert to hardcoded value.