### PR TITLE
Check access for enumeration items before returning evaluation results

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -95,6 +95,10 @@ public class AuthorizationManager {
     }
   }
 
+  public <T extends AbstractDTO> boolean canRead(final ThirdEyePrincipal principal, final T entity) {
+    return hasAccess(principal, resourceId(entity), AccessType.READ);
+  }
+
   public <T extends AbstractDTO> boolean hasAccess(final ThirdEyePrincipal principal,
       final T entity, final AccessType accessType) {
     return hasAccess(principal, resourceId(entity), accessType);


### PR DESCRIPTION
After the alert evaluation is complete, ThirdEye will check access to each result timeseries.

https://cortexdata.atlassian.net/browse/TE-1327


## Testing

Alert config w/ multiple enum items:

<img width="648" alt="Screenshot 2023-02-16 at 11 25 53 AM" src="https://user-images.githubusercontent.com/7391437/219426852-2e7a3a13-766f-43eb-becc-48db44e255d9.png">

User can only access osx, and that's the only series they see in ui

<img width="1039" alt="Screenshot 2023-02-16 at 11 25 28 AM" src="https://user-images.githubusercontent.com/7391437/219426749-298e4a0e-6772-4497-b855-b52ec5d6fcff.png">

