### PR TITLE
refactor(ui): TE-1142 make form component for template property more reuseable

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/alert-template-form-field.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/alert-template-form-field.component.tsx
@@ -12,230 +12,43 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import {
-    Box,
-    Grid,
-    Switch,
-    TextField,
-    Tooltip,
-    Typography,
-    useTheme,
-} from "@material-ui/core";
-import InfoIconOutlined from "@material-ui/icons/InfoOutlined";
-import { Autocomplete } from "@material-ui/lab";
-import React, { FunctionComponent, useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import { JSONEditorV1, LinkV1 } from "../../../../platform/components";
-import { useEventMetadataFormStyles } from "../../../event-wizard/event-metadata-form/event-metadata-form.styles";
+import React, { FunctionComponent, useState } from "react";
+import { PropertyConfigValueTypes } from "../../../../rest/dto/alert.interfaces";
 import { InputSection } from "../../../form-basics/input-section/input-section.component";
-import { ParseMarkdown } from "../../../parse-markdown/parse-markdown.component";
-import { ParseMarkdownProps } from "../../../parse-markdown/parse-markdown.interfaces";
 import { AlertTemplateFormFieldProps } from "./alert-template-form-field.interfaces";
+import { FormComponentForTemplateField } from "./form-component-for-template-field/form-component-for-template-field.component";
+import { LabelForTemplateField } from "./label-for-template-field/label-for-template-field.component";
 
 export const AlertTemplateFormField: FunctionComponent<AlertTemplateFormFieldProps> =
     ({ item, tabIndex, placeholder, tooltipText, onChange }) => {
-        const { t } = useTranslation();
-        const classes = useEventMetadataFormStyles();
-        const theme = useTheme();
+        const [localValueCopy, setLocalValueCopy] =
+            useState<PropertyConfigValueTypes>(item.value);
 
-        const parseMarkdownProps = useMemo<
-            Omit<ParseMarkdownProps, "children">
-        >(
-            () => ({
-                customOptions: {
-                    components: {
-                        a: ({ children, ...props }) => (
-                            <LinkV1
-                                {...props}
-                                externalLink
-                                color="primary"
-                                style={{
-                                    // Using the light color to improve contrast
-                                    // against the dark tooltip background
-                                    color: theme.palette.primary.light,
-                                }}
-                                target="_blank"
-                                variant="caption"
-                            >
-                                {children}
-                            </LinkV1>
-                        ),
-                    },
-                },
-            }),
-            []
-        );
-
-        const label = useMemo(() => {
-            return (
-                <Box
-                    alignItems="center"
-                    display="flex"
-                    gridGap={8}
-                    paddingBottom={1}
-                    paddingTop={1}
-                >
-                    <Typography variant="body2">{item.key}</Typography>
-                    {!!tooltipText && (
-                        <Tooltip
-                            arrow
-                            interactive
-                            placement="top"
-                            title={
-                                <Typography variant="caption">
-                                    <ParseMarkdown {...parseMarkdownProps}>
-                                        {tooltipText}
-                                    </ParseMarkdown>
-                                </Typography>
-                            }
-                        >
-                            <InfoIconOutlined
-                                color="secondary"
-                                fontSize="small"
-                            />
-                        </Tooltip>
-                    )}
-                </Box>
-            );
-        }, [parseMarkdownProps, tooltipText, item]);
-
-        let inputComponent;
-
-        // If value of property should one or multiple predefined values
-        if (item.metadata.options && item.metadata.options.length > 0) {
-            inputComponent = (
-                <Autocomplete
-                    fullWidth
-                    multiple={item.metadata.multiselect}
-                    options={item.metadata.options}
-                    renderInput={(params) => (
-                        <TextField
-                            data-testid={`optionedselect-${item.key}`}
-                            {...params}
-                            InputProps={{
-                                ...params.InputProps,
-                                // Override class name so the size of input is smaller
-                                className: classes.input,
-                                tabIndex: tabIndex,
-                            }}
-                            placeholder={
-                                placeholder
-                                    ? placeholder
-                                    : t(
-                                          "message.click-to-open-list-of-available-options"
-                                      )
-                            }
-                            variant="outlined"
-                        />
-                    )}
-                    value={item.value}
-                    onChange={(_, selected) => {
-                        onChange && onChange(selected as string[]);
-                    }}
-                />
-            );
-
-            // If value of item is some JSON object
-        } else if (
-            item.metadata.jsonType === "OBJECT" ||
-            item.key === "enumerationItems"
-        ) {
-            inputComponent = (
-                <JSONEditorV1
-                    hideValidationSuccessIcon
-                    data-testid={`jsoneditor-${item.key}`}
-                    value={item.value ?? {}}
-                    onChange={(json) => {
-                        onChange && onChange(JSON.parse(json));
-                    }}
-                />
-            );
-
-            // If value of item is arbitrary list of strings
-        } else if (item.metadata.jsonType === "ARRAY") {
-            inputComponent = (
-                <Autocomplete
-                    freeSolo
-                    fullWidth
-                    multiple
-                    options={[]}
-                    renderInput={(params) => (
-                        <TextField
-                            data-testid={`multifreesolo-${item.key}`}
-                            {...params}
-                            InputProps={{
-                                ...params.InputProps,
-                                // Override class name so the size of input is smaller
-                                className: classes.input,
-                            }}
-                            inputProps={{
-                                tabIndex: tabIndex,
-                                "data-testid": `multifreesolo-input-${item.key}`,
-                            }}
-                            placeholder={
-                                placeholder
-                                    ? placeholder
-                                    : t(
-                                          "message.type-a-value-and-press-enter-to-add"
-                                      )
-                            }
-                            variant="outlined"
-                        />
-                    )}
-                    value={item.value as string[]}
-                    onChange={(_, selected) => {
-                        onChange && onChange(selected as string[]);
-                    }}
-                />
-            );
-            // If value of item is a boolean value
-        } else if (item.metadata.jsonType === "BOOLEAN") {
-            inputComponent = (
-                <Grid
-                    container
-                    alignItems="center"
-                    component="label"
-                    justifyContent="space-around"
-                    spacing={1}
-                >
-                    <Grid item>{t("label.false")}</Grid>
-                    <Grid item>
-                        <Switch
-                            data-testid={`switch-${item.key}`}
-                            defaultChecked={!!item.value}
-                            onChange={(_, checked) => {
-                                onChange && onChange(checked);
-                            }}
-                        />
-                    </Grid>
-                    <Grid item>{t("label.true")}</Grid>
-                </Grid>
-            );
-            // Default to string input field
-        } else {
-            inputComponent = (
-                <TextField
-                    fullWidth
-                    data-testid={`textfield-${item.key}`}
-                    defaultValue={item.value}
-                    inputProps={{
-                        tabIndex: tabIndex,
-                        "data-testid": `input-${item.key}`,
-                    }}
-                    placeholder={placeholder}
-                    onChange={(e) => {
-                        onChange && onChange(e.currentTarget.value);
-                    }}
-                />
-            );
-        }
+        const handleOnChange = (newValue: PropertyConfigValueTypes): void => {
+            setLocalValueCopy(newValue);
+            onChange(newValue);
+        };
 
         return (
             <InputSection
                 gridContainerProps={{ alignItems: "flex-start" }}
-                inputComponent={inputComponent}
+                inputComponent={
+                    <FormComponentForTemplateField
+                        placeholder={placeholder}
+                        propertyKey={item.key}
+                        tabIndex={tabIndex}
+                        templateFieldProperty={item.metadata}
+                        value={localValueCopy}
+                        onChange={handleOnChange}
+                    />
+                }
                 key={item.key}
-                labelComponent={label}
+                labelComponent={
+                    <LabelForTemplateField
+                        name={item.key}
+                        tooltipText={tooltipText}
+                    />
+                }
             />
         );
     };

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/form-component-for-template-field/form-component-for-template-field.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/form-component-for-template-field/form-component-for-template-field.component.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { Grid, Switch, TextField } from "@material-ui/core";
+import { Autocomplete } from "@material-ui/lab";
+import React, { FunctionComponent } from "react";
+import { useTranslation } from "react-i18next";
+import { JSONEditorWithLocalCache } from "../../../../json-editor-with-local-cache/json-editor-with-local-cache.component";
+import { FormComponentForTemplateFieldProps } from "./form-component-for-template-field.interfaces";
+
+export const FormComponentForTemplateField: FunctionComponent<FormComponentForTemplateFieldProps> =
+    ({
+        templateFieldProperty,
+        onChange,
+        placeholder,
+        tabIndex,
+        value,
+        propertyKey,
+    }) => {
+        const { t } = useTranslation();
+
+        let inputComponent;
+
+        // If value of property should one or multiple predefined values
+        if (
+            templateFieldProperty.options &&
+            templateFieldProperty.options.length > 0
+        ) {
+            inputComponent = (
+                <Autocomplete
+                    fullWidth
+                    multiple={templateFieldProperty.multiselect}
+                    options={templateFieldProperty.options}
+                    renderInput={(params) => (
+                        <TextField
+                            data-testid={`optionedselect-${propertyKey}`}
+                            {...params}
+                            InputProps={{
+                                ...params.InputProps,
+                                tabIndex: tabIndex,
+                            }}
+                            placeholder={
+                                placeholder
+                                    ? placeholder
+                                    : t(
+                                          "message.click-to-open-list-of-available-options"
+                                      )
+                            }
+                            variant="outlined"
+                        />
+                    )}
+                    value={value}
+                    onChange={(_, selected) => {
+                        onChange && onChange(selected as string[]);
+                    }}
+                />
+            );
+
+            // If value of item is some JSON object
+        } else if (
+            templateFieldProperty.jsonType === "OBJECT" ||
+            propertyKey === "enumerationItems"
+        ) {
+            inputComponent = (
+                <JSONEditorWithLocalCache
+                    disableAutoFormat
+                    hideValidationSuccessIcon
+                    data-testid={`jsoneditor-${propertyKey}`}
+                    initialValue={(value as Record<string, unknown>) ?? {}}
+                    onChange={(json) => {
+                        onChange && onChange(JSON.parse(json));
+                    }}
+                />
+            );
+
+            // If value of item is arbitrary list of strings
+        } else if (templateFieldProperty.jsonType === "ARRAY") {
+            inputComponent = (
+                <Autocomplete
+                    freeSolo
+                    fullWidth
+                    multiple
+                    options={[]}
+                    renderInput={(params) => (
+                        <TextField
+                            data-testid={`multifreesolo-${propertyKey}`}
+                            {...params}
+                            InputProps={{
+                                ...params.InputProps,
+                                tabIndex: tabIndex,
+                            }}
+                            inputProps={{
+                                ...params.inputProps,
+                                "data-testid": `multifreesolo-input-${propertyKey}`,
+                            }}
+                            placeholder={
+                                placeholder
+                                    ? placeholder
+                                    : t(
+                                          "message.type-a-value-and-press-enter-to-add"
+                                      )
+                            }
+                            variant="outlined"
+                        />
+                    )}
+                    value={(value || []) as string[]}
+                    onChange={(_, selected) => {
+                        onChange && onChange(selected as string[]);
+                    }}
+                />
+            );
+            // If value of item is a boolean value
+        } else if (templateFieldProperty.jsonType === "BOOLEAN") {
+            inputComponent = (
+                <Grid
+                    container
+                    alignItems="center"
+                    component="label"
+                    justifyContent="space-around"
+                    spacing={1}
+                >
+                    <Grid item>{t("label.false")}</Grid>
+                    <Grid item>
+                        <Switch
+                            data-testid={`switch-${propertyKey}`}
+                            defaultChecked={!!value}
+                            onChange={(_, checked) => {
+                                onChange && onChange(checked);
+                            }}
+                        />
+                    </Grid>
+                    <Grid item>{t("label.true")}</Grid>
+                </Grid>
+            );
+            // Default to string input field
+        } else {
+            inputComponent = (
+                <TextField
+                    fullWidth
+                    data-testid={`textfield-${propertyKey}`}
+                    defaultValue={value}
+                    inputProps={{
+                        tabIndex: tabIndex,
+                        "data-testid": `input-${propertyKey}`,
+                    }}
+                    placeholder={placeholder}
+                    onChange={(e) => {
+                        onChange && onChange(e.currentTarget.value);
+                    }}
+                />
+            );
+        }
+
+        return inputComponent;
+    };

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/form-component-for-template-field/form-component-for-template-field.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/form-component-for-template-field/form-component-for-template-field.interfaces.ts
@@ -12,13 +12,14 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { PropertyConfigValueTypes } from "../../../../rest/dto/alert.interfaces";
-import type { PropertyRenderConfig } from "../alert-template-properties-builder/alert-template-properties-builder.interfaces";
+import { MetadataProperty } from "../../../../../rest/dto/alert-template.interfaces";
+import { PropertyConfigValueTypes } from "../../../../../rest/dto/alert.interfaces";
 
-export interface AlertTemplateFormFieldProps {
-    item: PropertyRenderConfig;
-    tabIndex: number;
-    placeholder: string;
-    tooltipText?: string | null;
+export interface FormComponentForTemplateFieldProps {
+    templateFieldProperty: MetadataProperty;
     onChange: (selected: PropertyConfigValueTypes) => void;
+    placeholder?: string;
+    tabIndex?: number;
+    value: PropertyConfigValueTypes;
+    propertyKey: string;
 }

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/label-for-template-field/label-for-template-field.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/label-for-template-field/label-for-template-field.component.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { Box, Tooltip, Typography, useTheme } from "@material-ui/core";
+import InfoIconOutlined from "@material-ui/icons/InfoOutlined";
+import React, { FunctionComponent, useMemo } from "react";
+import { LinkV1 } from "../../../../../platform/components";
+import { ParseMarkdown } from "../../../../parse-markdown/parse-markdown.component";
+import { ParseMarkdownProps } from "../../../../parse-markdown/parse-markdown.interfaces";
+import { LabelForTemplateFieldProps } from "./label-for-template-field.interfaces";
+
+export const LabelForTemplateField: FunctionComponent<LabelForTemplateFieldProps> =
+    ({ name, tooltipText }) => {
+        const theme = useTheme();
+
+        const parseMarkdownProps = useMemo<
+            Omit<ParseMarkdownProps, "children">
+        >(
+            () => ({
+                customOptions: {
+                    components: {
+                        a: ({ children, ...props }) => (
+                            <LinkV1
+                                {...props}
+                                externalLink
+                                color="primary"
+                                style={{
+                                    // Using the light color to improve contrast
+                                    // against the dark tooltip background
+                                    color: theme.palette.primary.light,
+                                }}
+                                target="_blank"
+                                variant="caption"
+                            >
+                                {children}
+                            </LinkV1>
+                        ),
+                    },
+                },
+            }),
+            []
+        );
+
+        return (
+            <Box
+                alignItems="center"
+                display="flex"
+                gridGap={8}
+                paddingBottom={1}
+                paddingTop={1}
+            >
+                <Typography variant="body2">{name}</Typography>
+                {!!tooltipText && (
+                    <Tooltip
+                        arrow
+                        interactive
+                        placement="top"
+                        title={
+                            <Typography variant="caption">
+                                <ParseMarkdown {...parseMarkdownProps}>
+                                    {tooltipText}
+                                </ParseMarkdown>
+                            </Typography>
+                        }
+                    >
+                        <InfoIconOutlined color="secondary" fontSize="small" />
+                    </Tooltip>
+                )}
+            </Box>
+        );
+    };

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/label-for-template-field/label-for-template-field.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/label-for-template-field/label-for-template-field.interfaces.ts
@@ -12,13 +12,8 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { PropertyConfigValueTypes } from "../../../../rest/dto/alert.interfaces";
-import type { PropertyRenderConfig } from "../alert-template-properties-builder/alert-template-properties-builder.interfaces";
 
-export interface AlertTemplateFormFieldProps {
-    item: PropertyRenderConfig;
-    tabIndex: number;
-    placeholder: string;
+export interface LabelForTemplateFieldProps {
+    name: string;
     tooltipText?: string | null;
-    onChange: (selected: PropertyConfigValueTypes) => void;
 }

--- a/thirdeye-ui/src/app/components/json-editor-with-local-cache/json-editor-with-local-cache.component.tsx
+++ b/thirdeye-ui/src/app/components/json-editor-with-local-cache/json-editor-with-local-cache.component.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React, { ReactElement, useState } from "react";
+import { JSONEditorV1 } from "../../platform/components";
+import { JSONEditorWithLocalCacheProps } from "./json-editor-with-local-cache.interfaces";
+
+export function JSONEditorWithLocalCache<T extends Record<string, unknown>>({
+    initialValue,
+    onChange,
+    ...otherProps
+}: JSONEditorWithLocalCacheProps<T>): ReactElement {
+    const [localCopy, setLocalCopy] = useState<T>(
+        initialValue || otherProps.value || ({} as T)
+    );
+
+    const handleChange = (updates: string): void => {
+        try {
+            const parsedString = JSON.parse(updates);
+            setLocalCopy(() => parsedString);
+            onChange && onChange(updates);
+        } catch {
+            // do nothing if invalid JSON string
+        }
+    };
+
+    return (
+        <JSONEditorV1
+            {...otherProps}
+            value={JSON.stringify(localCopy)}
+            onChange={handleChange}
+        />
+    );
+}

--- a/thirdeye-ui/src/app/components/json-editor-with-local-cache/json-editor-with-local-cache.interfaces.ts
+++ b/thirdeye-ui/src/app/components/json-editor-with-local-cache/json-editor-with-local-cache.interfaces.ts
@@ -12,13 +12,10 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { PropertyConfigValueTypes } from "../../../../rest/dto/alert.interfaces";
-import type { PropertyRenderConfig } from "../alert-template-properties-builder/alert-template-properties-builder.interfaces";
 
-export interface AlertTemplateFormFieldProps {
-    item: PropertyRenderConfig;
-    tabIndex: number;
-    placeholder: string;
-    tooltipText?: string | null;
-    onChange: (selected: PropertyConfigValueTypes) => void;
+import { JSONEditorV1Props } from "../../platform/components/json-editor-v1/json-editor-v1.interfaces";
+
+export interface JSONEditorWithLocalCacheProps<T = string>
+    extends JSONEditorV1Props<T> {
+    initialValue: T;
 }


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1142

#### Description

Refactoring `thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-form-field/alert-template-form-field.component.tsx` to extract out reuseable component pieces

#### Screenshots

No ui changes