### PR TITLE
[persistence] fix anomaly enumerationItem migration logic

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/EnumerationItemManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/EnumerationItemManagerImpl.java
@@ -127,7 +127,7 @@ public class EnumerationItemManagerImpl extends AbstractManagerImpl<EnumerationI
     LOG.info("Migrating enumeration item {} to {} for alert {}", from.getId(), toId, alertId);
 
     /* Migrate anomalies */
-    final var filter = new AnomalyFilter().setEnumerationItemId(from.getId());
+    final var filter = new AnomalyFilter().setEnumerationItemId(from.getId()).setAlertId(alertId);
     anomalyManager.filter(filter).stream()
         .filter(Objects::nonNull)
         .map(a -> a.setEnumerationItem(eiRef(toId)))


### PR DESCRIPTION
I think there is a bug in the migration logic that makes enumeration item anomalies messed up when their enumerationItem is migrated.
In the [migrate](https://github.com/startreedata/thirdeye/blob/d5b25e1e14102c53e07139977d849c0a90d510b2/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/EnumerationItemManagerImpl.java#L119) method:
- `from` is an enumerationItem that has no alertId. So it may have been shared between multiple alerts, meaning some anomalies from different alerts can have this enumeration.
- anomalies are fetched with the filter `enumerationItemId=from.Id`
--> **a filter on the alert Id is missing.**
--> anomalies from multiple alerts are migrated to the enumerationItem

--> I think this happened concurrently between multiple alerts. The last migration run by a detection job overrides anomaly enumeration items in others alerts anomalies.
So it's hard to track.