### PR TITLE
[persistence] metric to emit anomaly feedback count

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
@@ -83,6 +83,12 @@ public class AnomalyManagerImpl extends AbstractManagerImpl<AnomalyDTO>
         return countParentAnomalies(null);
       }
     });
+    metricRegistry.register("anomalyFeedbackCount", new CachedGauge<Long>(15, TimeUnit.MINUTES) {
+      @Override
+      protected Long loadValue() {
+        return genericPojoDao.count(AnomalyFeedbackDTO.class);
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1344

#### Description

Introducing new metric to emit anomaly feedback count
metric : `anomalyFeedbackCount `
type : `CachedGauge `
cache timeout : 15 minutes