### PR TITLE
[kubernetes] Allow MySQL instance to be external

### DIFF
--- a/kubernetes/helm/startree-thirdeye/Chart.lock
+++ b/kubernetes/helm/startree-thirdeye/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mysql
   repository: https://charts.helm.sh/stable
   version: 1.6.6
-digest: sha256:eeb4902062cbccaddabfd3c4ad716b67a42ca42ba134efc807facc60fddb7efe
-generated: "2021-02-22T17:20:23.477894-08:00"
+digest: sha256:88a440879286bda0a809880757c8ab514603757b9206af2baab081fdc2de182b
+generated: "2023-02-17T15:00:34.217849-08:00"

--- a/kubernetes/helm/startree-thirdeye/Chart.yaml
+++ b/kubernetes/helm/startree-thirdeye/Chart.yaml
@@ -37,3 +37,4 @@ dependencies:
 - name: mysql
   version: 1.6.6
   repository: https://charts.helm.sh/stable
+  condition: mysql.enabled

--- a/kubernetes/helm/startree-thirdeye/README.md
+++ b/kubernetes/helm/startree-thirdeye/README.md
@@ -23,7 +23,7 @@ To deploy thirdeye on Kubernetes, you may need access credentials to fetch docke
 Startree artifactory. To do that, simply create a kubernetes secret using the vault credentials.
 
 ```bash
-kubectl create secret docker-registry startree \
+kubectl create secret docker-registry startree \ 
   --docker-server="<DOCKER-REPO>" \
   --docker-username=<your-name> \
   --docker-password=<your-pword> \
@@ -49,14 +49,14 @@ helm install thirdeye . --namespace te
 ```
 
 To see the notifications in action ThirdEye can be configured to fire emails once it set up with an SMTP server. The following example
-uses the Google SMTP server.
+uses the Google SMTP server.  
 Make sure you pass the `ui.publicUrl` as it will be used to form the anomaly page links shared in the email.
 
 ```bash
 export SMTP_PASSWORD="password"
 export SMTP_USERNAME="from.email@gmail.com"
 export THIRDEYE_UI_PUBLIC_URL="http://localhost:8081"
-# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart
+# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart 
 export DOCKER_CONTAINER_URL=<TE_DOCKER_CONTAINER_URL>
 
 helm install thirdeye . \
@@ -100,8 +100,8 @@ helm install thirdeye . -f values.yaml
 
 ### Dynamic Secrets
 
-ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret`
-resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below
+ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret` 
+resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below 
 is a snippet from the `values.yaml` file
 ```yaml
 secrets:
@@ -115,11 +115,11 @@ secrets:
     encoded: true
     value: <base 64 encoded json key>
 ```
-1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`.
-2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.
-   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,
+1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`. 
+2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.  
+   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,  
    while `holidayLoaderKey` won't be injected as environment variable.
-3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts.
+3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts. 
 4. It is recommended to pass values other than simple string (e.g. JSON payload) as `base64` encoded value to avoid any parsing issues.
 
 ### Holiday Events
@@ -301,8 +301,8 @@ mysql:
 | `worker.replicas`                                  | Number of worker pods required                                                                                       |
 | `worker.randomWorkerIdEnabled`                     | Flag to enable assigning random worker ids to worker pods. Must be set true for multiple workers.                    |
 | `prometheus.enabled`                               | Flag to expose prometheus metrics and adding annotations for prometheus to scrape the metrics                        |
-| `mysql.enabled`                                    | Flag to disable MySQL deployment if using external instance
-| `mysql.mysqlUrl`                                   | Database URL if using external instance
+| `mysql.enabled`                                    | Flag to disable MySQL deployment if using external instance                                                          |
+| `mysql.mysqlUrl`                                   | Database URL if using external instance                                                                              |
 | `mysql.mysqlUser`                                  | Database username                                                                                                    |
 | `mysql.mysqlPassword`                              | Database password                                                                                                    |
 | `mysql.persistence.size`                           | Size of persistent volume created for database storage                                                               |

--- a/kubernetes/helm/startree-thirdeye/README.md
+++ b/kubernetes/helm/startree-thirdeye/README.md
@@ -23,7 +23,7 @@ To deploy thirdeye on Kubernetes, you may need access credentials to fetch docke
 Startree artifactory. To do that, simply create a kubernetes secret using the vault credentials.
 
 ```bash
-kubectl create secret docker-registry startree \ 
+kubectl create secret docker-registry startree \
   --docker-server="<DOCKER-REPO>" \
   --docker-username=<your-name> \
   --docker-password=<your-pword> \
@@ -49,14 +49,14 @@ helm install thirdeye . --namespace te
 ```
 
 To see the notifications in action ThirdEye can be configured to fire emails once it set up with an SMTP server. The following example
-uses the Google SMTP server.  
+uses the Google SMTP server.
 Make sure you pass the `ui.publicUrl` as it will be used to form the anomaly page links shared in the email.
 
 ```bash
 export SMTP_PASSWORD="password"
 export SMTP_USERNAME="from.email@gmail.com"
 export THIRDEYE_UI_PUBLIC_URL="http://localhost:8081"
-# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart 
+# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart
 export DOCKER_CONTAINER_URL=<TE_DOCKER_CONTAINER_URL>
 
 helm install thirdeye . \
@@ -100,8 +100,8 @@ helm install thirdeye . -f values.yaml
 
 ### Dynamic Secrets
 
-ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret` 
-resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below 
+ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret`
+resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below
 is a snippet from the `values.yaml` file
 ```yaml
 secrets:
@@ -115,11 +115,11 @@ secrets:
     encoded: true
     value: <base 64 encoded json key>
 ```
-1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`. 
-2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.  
-   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,  
+1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`.
+2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.
+   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,
    while `holidayLoaderKey` won't be injected as environment variable.
-3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts. 
+3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts.
 4. It is recommended to pass values other than simple string (e.g. JSON payload) as `base64` encoded value to avoid any parsing issues.
 
 ### Holiday Events
@@ -301,6 +301,8 @@ mysql:
 | `worker.replicas`                                  | Number of worker pods required                                                                                       |
 | `worker.randomWorkerIdEnabled`                     | Flag to enable assigning random worker ids to worker pods. Must be set true for multiple workers.                    |
 | `prometheus.enabled`                               | Flag to expose prometheus metrics and adding annotations for prometheus to scrape the metrics                        |
+| `mysql.enabled`                                    | Flag to disable MySQL deployment if using external instance
+| `mysql.mysqlUrl`                                   | Database URL if using external instance
 | `mysql.mysqlUser`                                  | Database username                                                                                                    |
 | `mysql.mysqlPassword`                              | Database password                                                                                                    |
 | `mysql.persistence.size`                           | Size of persistent volume created for database storage                                                               |

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -40,7 +40,7 @@ data:
           keyStorePassword: {{ .Values.tls.password }}
           keyStoreType: {{ .Values.tls.type }}
         {{- end }}
-  
+
       requestLog:
         appenders:
         - type: console
@@ -59,8 +59,12 @@ data:
 {{ toYaml .Values.auth | indent 6 }}
 
     database:
-      # Assuming a local MySQL server running on the default port 3306
+      # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
+      {{ if .Values.mysql.mysqlUrl }}
+      url: jdbc:mysql://{{- .Values.mysql.mysqlUrl -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ else }}
       url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ end }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -40,7 +40,7 @@ data:
           keyStorePassword: {{ .Values.tls.password }}
           keyStoreType: {{ .Values.tls.type }}
         {{- end }}
-
+  
       requestLog:
         appenders:
         - type: console

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -54,7 +54,7 @@ data:
         - type: http
           port: {{ .Values.scheduler.port }}
           idleTimeout: 620s
-
+  
       requestLog:
         appenders:
         - type: console
@@ -115,11 +115,11 @@ data:
       {{- end }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-
+  
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-
+  
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -54,7 +54,7 @@ data:
         - type: http
           port: {{ .Values.scheduler.port }}
           idleTimeout: 620s
-  
+
       requestLog:
         appenders:
         - type: console
@@ -83,8 +83,12 @@ data:
     #      ttl: 60000
 
     database:
-      # Assuming a local MySQL server running on the default port 3306
+      # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
+      {{ if .Values.mysql.mysqlUrl }}
+      url: jdbc:mysql://{{- .Values.mysql.mysqlUrl -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ else }}
       url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ end }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver
@@ -111,11 +115,11 @@ data:
       {{- end }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-    
+
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-    
+
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -115,11 +115,11 @@ data:
       {{- end }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-  
+    
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-  
+    
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -119,11 +119,11 @@ data:
       noTaskDelay: {{ .Values.worker.config.noTaskDelay | default 15 }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-
+  
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-
+  
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -83,8 +83,12 @@ data:
     #      ttl: 60000
 
     database:
-      # Assuming a local MySQL server running on the default port 3306
+      # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
+      {{ if .Values.mysql.mysqlUrl }}
+      url: jdbc:mysql://{{- .Values.mysql.mysqlUrl -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ else }}
       url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ end }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver
@@ -115,11 +119,11 @@ data:
       noTaskDelay: {{ .Values.worker.config.noTaskDelay | default 15 }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-    
+
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-    
+
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -119,11 +119,11 @@ data:
       noTaskDelay: {{ .Values.worker.config.noTaskDelay | default 15 }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-  
+    
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-  
+    
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/values.yaml
+++ b/kubernetes/helm/startree-thirdeye/values.yaml
@@ -190,6 +190,11 @@ traefik:
 
 # Persistence layer configuration
 mysql:
+  # Use the MySQL chart dependency
+  # Set to false if bringing your own MySQL
+  enabled: true
+  mysqlUrl: ""
+
   imageTag: 8.0.28
   mysqlRootPassword: password
   mysqlUser: uthirdeye


### PR DESCRIPTION
#### Issue(s)

- https://github.com/startreedata/thirdeye/issues/977

#### Description

- Use `condition` on the MySQL subchart so that local MySQL doesn't have to be deployed
- Add `.Values.mysql.mysqlUrl` so that external URL can be provided
- Updated configmaps so that `mysqlUrl` is used if provided

#### Screenshots

N/A

#### How to test

From `kubernetes/helm/startree-thirdeye`, I ran the following with different values of `mysql.enabled` and `mysql.mysqlUrl`. Saw working.

```
helm install --dry-run --debug thirdeye . > dry-run.txt
```