### PR TITLE
[kubernetes] External mysql connection config refactor

### DIFF
--- a/kubernetes/helm/startree-thirdeye/README.md
+++ b/kubernetes/helm/startree-thirdeye/README.md
@@ -302,7 +302,7 @@ mysql:
 | `worker.randomWorkerIdEnabled`                     | Flag to enable assigning random worker ids to worker pods. Must be set true for multiple workers.                    |
 | `prometheus.enabled`                               | Flag to expose prometheus metrics and adding annotations for prometheus to scrape the metrics                        |
 | `mysql.enabled`                                    | Flag to disable MySQL deployment if using external instance                                                          |
-| `mysql.mysqlUrl`                                   | Database URL if using external instance                                                                              |
+| `mysql.url`                                        | Database URL if using external instance                                                                              |
 | `mysql.mysqlUser`                                  | Database username                                                                                                    |
 | `mysql.mysqlPassword`                              | Database password                                                                                                    |
 | `mysql.persistence.size`                           | Size of persistent volume created for database storage                                                               |

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -60,8 +60,8 @@ data:
 
     database:
       # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
-      {{ if .Values.mysql.mysqlUrl }}
-      url: jdbc:mysql://{{- .Values.mysql.mysqlUrl -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ if .Values.mysql.url }}
+      url: jdbc:mysql://{{- .Values.mysql.url -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       {{ else }}
       url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       {{ end }}

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -59,12 +59,8 @@ data:
 {{ toYaml .Values.auth | indent 6 }}
 
     database:
-      # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
-      {{ if .Values.mysql.url }}
-      url: jdbc:mysql://{{- .Values.mysql.url -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
-      {{ else }}
-      url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
-      {{ end }}
+      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 3306
+      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -83,12 +83,8 @@ data:
     #      ttl: 60000
 
     database:
-      # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
-      {{ if .Values.mysql.url }}
-      url: jdbc:mysql://{{- .Values.mysql.url -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
-      {{ else }}
-      url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
-      {{ end }}
+      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 3306
+      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -84,8 +84,8 @@ data:
 
     database:
       # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
-      {{ if .Values.mysql.mysqlUrl }}
-      url: jdbc:mysql://{{- .Values.mysql.mysqlUrl -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ if .Values.mysql.url }}
+      url: jdbc:mysql://{{- .Values.mysql.url -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       {{ else }}
       url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       {{ end }}

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -83,12 +83,8 @@ data:
     #      ttl: 60000
 
     database:
-      # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
-      {{ if .Values.mysql.url }}
-      url: jdbc:mysql://{{- .Values.mysql.url -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
-      {{ else }}
-      url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
-      {{ end }}
+      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 3306
+      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -84,8 +84,8 @@ data:
 
     database:
       # Defaults to k8s cluster local MySQL server running on port 3306, but uses URL if provided
-      {{ if .Values.mysql.mysqlUrl }}
-      url: jdbc:mysql://{{- .Values.mysql.mysqlUrl -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      {{ if .Values.mysql.url }}
+      url: jdbc:mysql://{{- .Values.mysql.url -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       {{ else }}
       url: jdbc:mysql://{{ include "thirdeye.mysql.fullname" . }}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       {{ end }}

--- a/kubernetes/helm/startree-thirdeye/values.yaml
+++ b/kubernetes/helm/startree-thirdeye/values.yaml
@@ -193,6 +193,7 @@ mysql:
   # Use the MySQL chart dependency
   # Set to false if bringing your own MySQL
   enabled: true
+  # Set the value when internal MySQL server is disabled (mysql.enabled: false)
   url: ""
 
   imageTag: 8.0.28

--- a/kubernetes/helm/startree-thirdeye/values.yaml
+++ b/kubernetes/helm/startree-thirdeye/values.yaml
@@ -193,7 +193,7 @@ mysql:
   # Use the MySQL chart dependency
   # Set to false if bringing your own MySQL
   enabled: true
-  mysqlUrl: ""
+  url: ""
 
   imageTag: 8.0.28
   mysqlRootPassword: password


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1350

#### Description

Helm config value renamed from `mysql.mysqlUrl` to `mysql.url`.
Updated the logic in config maps to use the the mysql host name based on `mysql.enabled` flag instead of `mysql.url`

