### PR TITLE
fix(ui): TE-1356 use evaluation.alert.template in preview charts when for timezone

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
@@ -39,6 +39,7 @@ import {
 } from "../../../../rest/alerts/alerts.actions";
 import {
     AlertEvaluation,
+    AlertInEvaluation,
     EditableAlert,
 } from "../../../../rest/dto/alert.interfaces";
 import { DetectionEvaluation } from "../../../../rest/dto/detection.interfaces";
@@ -173,7 +174,10 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                 t,
                 undefined,
                 determineTimezoneFromAlertInEvaluation(
-                    evaluation?.alert.template
+                    evaluation?.alert.template as Pick<
+                        AlertInEvaluation,
+                        "metadata"
+                    >
                 )
             );
 
@@ -438,7 +442,10 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                                 <Grid item>
                                     <TimeRangeButtonWithContext
                                         timezone={determineTimezoneFromAlertInEvaluation(
-                                            evaluation?.alert.template
+                                            evaluation?.alert.template as Pick<
+                                                AlertInEvaluation,
+                                                "metadata"
+                                            >
                                         )}
                                         onTimeRangeChange={(start, end) =>
                                             displayState ===

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
@@ -172,7 +172,9 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                 detectionEvaluation.anomalies,
                 t,
                 undefined,
-                determineTimezoneFromAlertInEvaluation(evaluation?.alert)
+                determineTimezoneFromAlertInEvaluation(
+                    evaluation?.alert.template
+                )
             );
 
             timeseriesConfiguration.brush = false;
@@ -436,7 +438,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                                 <Grid item>
                                     <TimeRangeButtonWithContext
                                         timezone={determineTimezoneFromAlertInEvaluation(
-                                            evaluation?.alert
+                                            evaluation?.alert.template
                                         )}
                                         onTimeRangeChange={(start, end) =>
                                             displayState ===

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/preview-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/preview-chart.component.tsx
@@ -134,7 +134,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
             detectionEvaluations[0].anomalies,
             t,
             undefined,
-            determineTimezoneFromAlertInEvaluation(evaluation?.alert)
+            determineTimezoneFromAlertInEvaluation(evaluation?.alert.template)
         );
 
         timeseriesConfiguration.brush = false;
@@ -253,7 +253,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                                     hideQuickExtend
                                     btnGroupColor="primary"
                                     timezone={determineTimezoneFromAlertInEvaluation(
-                                        evaluation?.alert
+                                        evaluation?.alert.template
                                     )}
                                     onTimeRangeChange={(start, end) =>
                                         fetchAlertEvaluation(start, end)
@@ -374,7 +374,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                                             detectionEvaluations
                                         }
                                         timezone={determineTimezoneFromAlertInEvaluation(
-                                            evaluation?.alert
+                                            evaluation?.alert.template
                                         )}
                                         onDeleteClick={
                                             handleDeleteEnumerationItemClick

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/preview-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/preview-chart.component.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../../rest/alerts/alerts.actions";
 import {
     AlertEvaluation,
+    AlertInEvaluation,
     EditableAlert,
     EnumerationItemConfig,
 } from "../../../rest/dto/alert.interfaces";
@@ -134,7 +135,12 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
             detectionEvaluations[0].anomalies,
             t,
             undefined,
-            determineTimezoneFromAlertInEvaluation(evaluation?.alert.template)
+            determineTimezoneFromAlertInEvaluation(
+                evaluation?.alert.template as Pick<
+                    AlertInEvaluation,
+                    "metadata"
+                >
+            )
         );
 
         timeseriesConfiguration.brush = false;
@@ -253,7 +259,10 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                                     hideQuickExtend
                                     btnGroupColor="primary"
                                     timezone={determineTimezoneFromAlertInEvaluation(
-                                        evaluation?.alert.template
+                                        evaluation?.alert.template as Pick<
+                                            AlertInEvaluation,
+                                            "metadata"
+                                        >
                                     )}
                                     onTimeRangeChange={(start, end) =>
                                         fetchAlertEvaluation(start, end)
@@ -374,7 +383,10 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
                                             detectionEvaluations
                                         }
                                         timezone={determineTimezoneFromAlertInEvaluation(
-                                            evaluation?.alert.template
+                                            evaluation?.alert.template as Pick<
+                                                AlertInEvaluation,
+                                                "metadata"
+                                            >
                                         )}
                                         onDeleteClick={
                                             handleDeleteEnumerationItemClick


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1356

#### Description

When passing an entire alert object in evaluation call, time zone is in `alert.template.metadta.timezone`

#### Screenshots

No UI changes