### PR TITLE
feat(ui): TE-1206 cancel api calls when user leaves some pages

### DIFF
--- a/thirdeye-ui/src/app/components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component.tsx
+++ b/thirdeye-ui/src/app/components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component.tsx
@@ -18,7 +18,6 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { CancelAPICallsOnPageUnloadProps } from "./cancel-api-calls-on-page-unload.interfaces";
 
 /**
- * This has to be wrapped around a page and not a router.
  * The `key` property needs to be set so that this component is unique when
  * used in react router: https://stackoverflow.com/questions/38710250/react-multiple
  * -instances-of-same-component-are-getting-same-state

--- a/thirdeye-ui/src/app/components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component.tsx
+++ b/thirdeye-ui/src/app/components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import axios from "axios";
+import React, { FunctionComponent, useEffect, useState } from "react";
+import { CancelAPICallsOnPageUnloadProps } from "./cancel-api-calls-on-page-unload.interfaces";
+
+/**
+ * This has to be wrapped around a page and not a router.
+ * The `key` property needs to be set so that this component is unique when
+ * used in react router: https://stackoverflow.com/questions/38710250/react-multiple
+ * -instances-of-same-component-are-getting-same-state
+ */
+export const CancelAPICallsOnPageUnload: FunctionComponent<CancelAPICallsOnPageUnloadProps> =
+    ({ children }) => {
+        const [controller] = useState(new AbortController());
+        axios.defaults.signal = controller.signal;
+
+        useEffect(() => {
+            axios.defaults.signal = controller.signal;
+
+            return () => {
+                controller.abort();
+                axios.defaults.signal = undefined;
+            };
+        }, []);
+
+        return <>{children}</>;
+    };

--- a/thirdeye-ui/src/app/components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.interfaces.ts
+++ b/thirdeye-ui/src/app/components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.interfaces.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export interface CancelAPICallsOnPageUnloadProps {
+    key: string;
+}

--- a/thirdeye-ui/src/app/rest/alerts/alerts.rest.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.rest.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import axios, { AxiosRequestConfig, CancelToken } from "axios";
+import axios from "axios";
 import { extractDetectionEvaluation } from "../../utils/alerts/alerts.util";
 import { filterOutIgnoredAnomalies } from "../../utils/anomalies/anomalies.util";
 import type {
@@ -37,13 +37,10 @@ export const getAlertStats = async ({
     alertId,
     startTime,
     endTime,
-    axiosConfig,
 }: {
     alertId: number;
     startTime?: number;
     endTime?: number;
-    cancelToken?: CancelToken;
-    axiosConfig?: AxiosRequestConfig;
 }): Promise<AlertStats> => {
     const queryParams = new URLSearchParams([]);
 
@@ -56,8 +53,7 @@ export const getAlertStats = async ({
     }
 
     const response = await axios.get<AlertStats>(
-        `${BASE_URL_ALERTS}/${alertId}/stats?${queryParams.toString()}`,
-        axiosConfig
+        `${BASE_URL_ALERTS}/${alertId}/stats?${queryParams.toString()}`
     );
 
     return response.data;

--- a/thirdeye-ui/src/app/routers/alert-templates/alert-templates.router.tsx
+++ b/thirdeye-ui/src/app/routers/alert-templates/alert-templates.router.tsx
@@ -14,6 +14,7 @@
  */
 import { default as React, FunctionComponent, lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import { AppLoadingIndicatorV1 } from "../../platform/components";
 import { AppRouteRelative } from "../../utils/routes/routes.util";
 
@@ -65,7 +66,11 @@ export const AlertTemplatesRouter: FunctionComponent = () => {
 
                 {/* AlertTemplates all path */}
                 <Route
-                    element={<AlertTemplatesAllPage />}
+                    element={
+                        <CancelAPICallsOnPageUnload>
+                            <AlertTemplatesAllPage />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={AppRouteRelative.ALERT_TEMPLATES_ALL}
                 />
 

--- a/thirdeye-ui/src/app/routers/alert-templates/alert-templates.router.tsx
+++ b/thirdeye-ui/src/app/routers/alert-templates/alert-templates.router.tsx
@@ -14,7 +14,6 @@
  */
 import { default as React, FunctionComponent, lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
-import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import { AppLoadingIndicatorV1 } from "../../platform/components";
 import { AppRouteRelative } from "../../utils/routes/routes.util";
 
@@ -66,11 +65,7 @@ export const AlertTemplatesRouter: FunctionComponent = () => {
 
                 {/* AlertTemplates all path */}
                 <Route
-                    element={
-                        <CancelAPICallsOnPageUnload>
-                            <AlertTemplatesAllPage />
-                        </CancelAPICallsOnPageUnload>
-                    }
+                    element={<AlertTemplatesAllPage />}
                     path={AppRouteRelative.ALERT_TEMPLATES_ALL}
                 />
 

--- a/thirdeye-ui/src/app/routers/alerts-guided-create/alerts-guided-create.router.tsx
+++ b/thirdeye-ui/src/app/routers/alerts-guided-create/alerts-guided-create.router.tsx
@@ -14,6 +14,7 @@
  */
 import React, { FunctionComponent, lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import { AppLoadingIndicatorV1 } from "../../platform/components";
 import { AppRouteRelative } from "../../utils/routes/routes.util";
 import { AlertsGuidedCreateRouterProps } from "./alerts-guided-create.router.interface";
@@ -97,16 +98,22 @@ export const AlertsCreateGuidedRouter: FunctionComponent<AlertsGuidedCreateRoute
                         />
                         <Route
                             element={
-                                <SelectTypePage
-                                    hideCurrentlySelected={
-                                        hideCurrentlySelected
+                                <CancelAPICallsOnPageUnload
+                                    key={
+                                        AppRouteRelative.WELCOME_CREATE_ALERT_SELECT_TYPE
                                     }
-                                    hideSampleAlerts={hideSampleAlerts}
-                                    navigateToAlertDetailAfterCreate={
-                                        navigateToAlertDetailAfterSampleAlertCreate
-                                    }
-                                    sampleAlertsBottom={sampleAlertsBottom}
-                                />
+                                >
+                                    <SelectTypePage
+                                        hideCurrentlySelected={
+                                            hideCurrentlySelected
+                                        }
+                                        hideSampleAlerts={hideSampleAlerts}
+                                        navigateToAlertDetailAfterCreate={
+                                            navigateToAlertDetailAfterSampleAlertCreate
+                                        }
+                                        sampleAlertsBottom={sampleAlertsBottom}
+                                    />
+                                </CancelAPICallsOnPageUnload>
                             }
                             path={
                                 AppRouteRelative.WELCOME_CREATE_ALERT_SELECT_TYPE
@@ -114,21 +121,45 @@ export const AlertsCreateGuidedRouter: FunctionComponent<AlertsGuidedCreateRoute
                         />
 
                         <Route
-                            element={<SetupDimensionGroupsPage />}
+                            element={
+                                <CancelAPICallsOnPageUnload
+                                    key={
+                                        AppRouteRelative.WELCOME_CREATE_ALERT_SETUP_DIMENSION_EXPLORATION
+                                    }
+                                >
+                                    <SetupDimensionGroupsPage />
+                                </CancelAPICallsOnPageUnload>
+                            }
                             path={
                                 AppRouteRelative.WELCOME_CREATE_ALERT_SETUP_DIMENSION_EXPLORATION
                             }
                         />
 
                         <Route
-                            element={<SetupMonitoringPage />}
+                            element={
+                                <CancelAPICallsOnPageUnload
+                                    key={
+                                        AppRouteRelative.WELCOME_CREATE_ALERT_SETUP_MONITORING
+                                    }
+                                >
+                                    <SetupMonitoringPage />
+                                </CancelAPICallsOnPageUnload>
+                            }
                             path={
                                 AppRouteRelative.WELCOME_CREATE_ALERT_SETUP_MONITORING
                             }
                         />
 
                         <Route
-                            element={<SetupAnomaliesFilterPage />}
+                            element={
+                                <CancelAPICallsOnPageUnload
+                                    key={
+                                        AppRouteRelative.WELCOME_CREATE_ALERT_ANOMALIES_FILTER
+                                    }
+                                >
+                                    <SetupAnomaliesFilterPage />
+                                </CancelAPICallsOnPageUnload>
+                            }
                             path={
                                 AppRouteRelative.WELCOME_CREATE_ALERT_ANOMALIES_FILTER
                             }
@@ -136,13 +167,19 @@ export const AlertsCreateGuidedRouter: FunctionComponent<AlertsGuidedCreateRoute
 
                         <Route
                             element={
-                                <SetupDetailsPage
-                                    createLabel={createLabel}
-                                    inProgressLabel={inProgressLabel}
-                                    showEmailOnlyForSubscriptionGroup={
-                                        showEmailOnlyForSubscriptionGroup
+                                <CancelAPICallsOnPageUnload
+                                    key={
+                                        AppRouteRelative.WELCOME_CREATE_ALERT_SETUP_DETAILS
                                     }
-                                />
+                                >
+                                    <SetupDetailsPage
+                                        createLabel={createLabel}
+                                        inProgressLabel={inProgressLabel}
+                                        showEmailOnlyForSubscriptionGroup={
+                                            showEmailOnlyForSubscriptionGroup
+                                        }
+                                    />
+                                </CancelAPICallsOnPageUnload>
                             }
                             path={
                                 AppRouteRelative.WELCOME_CREATE_ALERT_SETUP_DETAILS

--- a/thirdeye-ui/src/app/routers/alerts/alerts.router.tsx
+++ b/thirdeye-ui/src/app/routers/alerts/alerts.router.tsx
@@ -15,6 +15,7 @@
 import React, { FunctionComponent, lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, Outlet, Route, Routes } from "react-router-dom";
+import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import { TimeRangeQueryStringKey } from "../../components/time-range/time-range-provider/time-range-provider.interfaces";
 import { AlertsUpdateBasePage } from "../../pages/alerts-update-page/alerts-update-base-page.component";
 import { AppLoadingIndicatorV1 } from "../../platform/components";
@@ -109,7 +110,13 @@ export const AlertsRouter: FunctionComponent = () => {
 
                 {/* Alerts all path */}
                 <Route
-                    element={<AlertsAllPage />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={AppRouteRelative.ALERTS_ALL}
+                        >
+                            <AlertsAllPage />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={AppRouteRelative.ALERTS_ALL}
                 />
 
@@ -126,7 +133,13 @@ export const AlertsRouter: FunctionComponent = () => {
                     />
 
                     <Route
-                        element={<AlertsCreatePageNew />}
+                        element={
+                            <CancelAPICallsOnPageUnload
+                                key={`${AppRouteRelative.ALERTS_CREATE_NEW}/*`}
+                            >
+                                <AlertsCreatePageNew />
+                            </CancelAPICallsOnPageUnload>
+                        }
                         path={`${AppRouteRelative.ALERTS_CREATE_NEW}/*`}
                     >
                         <Route
@@ -145,13 +158,17 @@ export const AlertsRouter: FunctionComponent = () => {
 
                         <Route
                             element={
-                                <AlertsCreateGuidedRouter
-                                    navigateToAlertDetailAfterSampleAlertCreate
-                                    sampleAlertsBottom
-                                    useParentForNonWelcomeFlow
-                                    createLabel={t("label.create")}
-                                    inProgressLabel={t("label.creating")}
-                                />
+                                <CancelAPICallsOnPageUnload
+                                    key={`${AppRouteRelative.ALERTS_CREATE_NEW_USER}/*`}
+                                >
+                                    <AlertsCreateGuidedRouter
+                                        navigateToAlertDetailAfterSampleAlertCreate
+                                        sampleAlertsBottom
+                                        useParentForNonWelcomeFlow
+                                        createLabel={t("label.create")}
+                                        inProgressLabel={t("label.creating")}
+                                    />
+                                </CancelAPICallsOnPageUnload>
                             }
                             path={`${AppRouteRelative.ALERTS_CREATE_NEW_USER}/*`}
                         />

--- a/thirdeye-ui/src/app/routers/anomalies/anomalies.router.tsx
+++ b/thirdeye-ui/src/app/routers/anomalies/anomalies.router.tsx
@@ -14,6 +14,7 @@
  */
 import { default as React, FunctionComponent, lazy, Suspense } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import { TimeRangeQueryStringKey } from "../../components/time-range/time-range-provider/time-range-provider.interfaces";
 import { AnomaliesListAllPage } from "../../pages/anomalies-list-page/anomalies-list-page.component";
 import { MetricsReportAllPage } from "../../pages/anomalies-metrics-report-page/anomalies-metrics-report-page.component";
@@ -91,7 +92,13 @@ export const AnomaliesRouter: FunctionComponent = () => {
                                 to=".."
                             >
                                 <SaveLastUsedSearchParams>
-                                    <AnomaliesAllPage />
+                                    <CancelAPICallsOnPageUnload
+                                        key={
+                                            AppRouteRelative.ANOMALIES_ALL_RANGE
+                                        }
+                                    >
+                                        <AnomaliesAllPage />
+                                    </CancelAPICallsOnPageUnload>
                                 </SaveLastUsedSearchParams>
                             </RedirectValidation>
                         }
@@ -111,11 +118,25 @@ export const AnomaliesRouter: FunctionComponent = () => {
                             }
                         />
                         <Route
-                            element={<AnomaliesListAllPage />}
+                            element={
+                                <CancelAPICallsOnPageUnload
+                                    key={AppRouteRelative.ANOMALIES_LIST}
+                                >
+                                    <AnomaliesListAllPage />
+                                </CancelAPICallsOnPageUnload>
+                            }
                             path={AppRouteRelative.ANOMALIES_LIST}
                         />
                         <Route
-                            element={<MetricsReportAllPage />}
+                            element={
+                                <CancelAPICallsOnPageUnload
+                                    key={
+                                        AppRouteRelative.ANOMALIES_METRICS_REPORT
+                                    }
+                                >
+                                    <MetricsReportAllPage />
+                                </CancelAPICallsOnPageUnload>
+                            }
                             path={AppRouteRelative.ANOMALIES_METRICS_REPORT}
                         />
                     </Route>

--- a/thirdeye-ui/src/app/routers/app/app.router.tsx
+++ b/thirdeye-ui/src/app/routers/app/app.router.tsx
@@ -14,6 +14,7 @@
  */
 import React, { FunctionComponent, lazy, Suspense } from "react";
 import { Route, Routes } from "react-router-dom";
+import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import {
     AppLoadingIndicatorV1,
     useAuthProviderV1,
@@ -83,7 +84,13 @@ export const AppRouter: FunctionComponent = () => {
 
                     {/* Direct all configuration paths to configuration router */}
                     <Route
-                        element={<ConfigurationRouter />}
+                        element={
+                            <CancelAPICallsOnPageUnload
+                                key={AppRoute.CONFIGURATION}
+                            >
+                                <ConfigurationRouter />
+                            </CancelAPICallsOnPageUnload>
+                        }
                         path={`${AppRoute.CONFIGURATION}/*`}
                     />
 

--- a/thirdeye-ui/src/app/routers/configuration/configuration.router.tsx
+++ b/thirdeye-ui/src/app/routers/configuration/configuration.router.tsx
@@ -14,6 +14,7 @@
  */
 import { default as React, FunctionComponent, lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import { AppLoadingIndicatorV1 } from "../../platform/components";
 import { AppRouteRelative } from "../../utils/routes/routes.util";
 
@@ -73,36 +74,72 @@ export const ConfigurationRouter: FunctionComponent = () => {
 
                 {/* Direct all subscription groups paths to subscription groups router */}
                 <Route
-                    element={<SubscriptionGroupsRouter />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={`${AppRouteRelative.SUBSCRIPTION_GROUPS}/*`}
+                        >
+                            <SubscriptionGroupsRouter />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.SUBSCRIPTION_GROUPS}/*`}
                 />
 
                 {/* Direct all datasets paths to datasets router */}
                 <Route
-                    element={<DatasetsRouter />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={`${AppRouteRelative.DATASETS}/*`}
+                        >
+                            <DatasetsRouter />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.DATASETS}/*`}
                 />
 
                 {/* Direct all datasource paths to datasources router */}
                 <Route
-                    element={<DatasourcesRouter />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={`${AppRouteRelative.DATASOURCES}/*`}
+                        >
+                            <DatasourcesRouter />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.DATASOURCES}/*`}
                 />
 
                 {/* Direct all metrics paths to metrics router */}
                 <Route
-                    element={<MetricsRouter />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={`${AppRouteRelative.METRICS}/*`}
+                        >
+                            <MetricsRouter />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.METRICS}/*`}
                 />
 
                 {/* Alert templates path */}
                 <Route
-                    element={<AlertTemplatesRouter />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={`${AppRouteRelative.ALERT_TEMPLATES}/*`}
+                        >
+                            <AlertTemplatesRouter />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.ALERT_TEMPLATES}/*`}
                 />
 
                 <Route
-                    element={<EventsRouter />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={`${AppRouteRelative.EVENTS}/*`}
+                        >
+                            <EventsRouter />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.EVENTS}/*`}
                 />
 

--- a/thirdeye-ui/src/app/routers/general-authenticated/general-authenticated.router.tsx
+++ b/thirdeye-ui/src/app/routers/general-authenticated/general-authenticated.router.tsx
@@ -14,6 +14,7 @@
  */
 import React, { FunctionComponent, lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { CancelAPICallsOnPageUnload } from "../../components/cancel-api-calls-on-page-unload/cancel-api-calls-on-page-unload.component";
 import { AppLoadingIndicatorV1 } from "../../platform/components";
 import {
     AppRoute,
@@ -65,13 +66,23 @@ export const GeneralAuthenticatedRouter: FunctionComponent = () => {
 
                 {/* Home path */}
                 <Route
-                    element={<HomePage />}
+                    element={
+                        <CancelAPICallsOnPageUnload key={AppRouteRelative.HOME}>
+                            <HomePage />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.HOME}`}
                 />
 
                 {/* Admin path */}
                 <Route
-                    element={<AdminPage />}
+                    element={
+                        <CancelAPICallsOnPageUnload
+                            key={AppRouteRelative.ADMIN}
+                        >
+                            <AdminPage />
+                        </CancelAPICallsOnPageUnload>
+                    }
                     path={`${AppRouteRelative.ADMIN}`}
                 />
 


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1206

#### Description

Developers have to explicitly wrap the pages or routers with `CancelAPICallsOnPageUnload` if they wish to cancel API calls on the page or route unload with the react router route definitions.

Some caveats here is that they `key` property is necessary so that the components are unique instance

#### Screenshots

No UI changes

