### PR TITLE
fix(ui): TE-1366 allow dimension exploration values in template properties validator

### DIFF
--- a/thirdeye-ui/src/app/utils/alerts/alerts-configuration-validator.util.test.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts-configuration-validator.util.test.ts
@@ -140,6 +140,23 @@ describe("Alerts Configuration Validator Util", () => {
 
         expect(result).toEqual([]);
     });
+
+    it("validateTemplateProperties should return no errors for dimension exploration values", () => {
+        const result = validateTemplateProperties(
+            [OPTIONED_SINGLE, OPTIONED_MULTISELECT, ARRAY, BOOLEAN, OBJECT],
+            {
+                optionedSingleProperty: "${foo}",
+                optionedMultiselectProperty: "${foo}",
+                arrayProperty: "${foo}",
+                booleanProperty: "${foo}",
+                objectProperty: "${foo}",
+                fieldNotIncluded: "${foo}",
+            },
+            MOCK_TRANSLATION
+        );
+
+        expect(result).toEqual([]);
+    });
 });
 
 const OPTIONED_SINGLE = {

--- a/thirdeye-ui/src/app/utils/alerts/alerts-configuration-validator.util.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts-configuration-validator.util.ts
@@ -16,6 +16,8 @@ import { AlertTemplatePropertyValidationError } from "../../pages/alerts-create-
 import { MetadataProperty } from "../../rest/dto/alert-template.interfaces";
 import { PropertyConfigValueTypes } from "../../rest/dto/alert.interfaces";
 
+const DIMENSION_EXPLORATION_VALUE_START = "${";
+
 export function validateTemplateProperties(
     alertTemplateProperties: MetadataProperty[],
     propertyValues: { [index: string]: PropertyConfigValueTypes },
@@ -27,12 +29,23 @@ export function validateTemplateProperties(
     const errors: AlertTemplatePropertyValidationError[] = [];
 
     Object.keys(propertyValues).forEach((propertyKey) => {
+        let isDimensionExplorationValue = false;
+        if (typeof propertyValues[propertyKey] === "string") {
+            if (
+                (propertyValues[propertyKey] as string).startsWith(
+                    DIMENSION_EXPLORATION_VALUE_START
+                )
+            ) {
+                isDimensionExplorationValue = true;
+            }
+        }
+
         const matchingPropertyMetadata = alertTemplateProperties.find(
             (propertyMetadataCandidate) =>
                 propertyMetadataCandidate.name === propertyKey
         );
 
-        if (matchingPropertyMetadata) {
+        if (matchingPropertyMetadata && !isDimensionExplorationValue) {
             const valueForProperty = propertyValues[propertyKey];
 
             // Value needs to be in list of predefined options


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1366

#### Description

Allow `${someVariable}` to be a valid value for a template property
