### PR TITLE
feat(ui): TE-1378 enable callback function for when users make a range selection in TimeSeriesChart

### DIFF
--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.component.tsx
@@ -13,6 +13,7 @@
  * the License.
  */
 import { Box, Button } from "@material-ui/core";
+import { Bounds } from "@visx/brush/lib/types";
 import { ParentSize } from "@visx/responsive";
 import { scaleOrdinal, scaleTime } from "@visx/scale";
 import { TooltipWithBounds, useTooltip } from "@visx/tooltip";
@@ -386,6 +387,26 @@ export const TimeSeriesChartInternal: FunctionComponent<TimeSeriesChartInternalP
             });
         };
 
+        const shouldRenderSelectionComponent =
+            isZoomEnabled || chartEvents?.onRangeSelection;
+
+        const handleZoomChange = (domain: Bounds | null): void => {
+            let shouldZoom: boolean | undefined = true;
+
+            /**
+             * If chart `onRangeSelection` exists, determine whether to continue
+             * changing the zoom window by the value returned by `onRangeSelection`
+             *
+             * Falsey will prevent the zoom window change and truthy will
+             * continue the window change
+             */
+            if (chartEvents?.onRangeSelection) {
+                shouldZoom = chartEvents.onRangeSelection(domain);
+            }
+
+            shouldZoom && isZoomEnabled && handleBrushChange(domain);
+        };
+
         return (
             <div style={{ position: "relative" }}>
                 {events && events.length > 0 && (
@@ -426,7 +447,7 @@ export const TimeSeriesChartInternal: FunctionComponent<TimeSeriesChartInternalP
                         {(xScale, yScale) => {
                             return (
                                 <>
-                                    {isZoomEnabled &&
+                                    {shouldRenderSelectionComponent &&
                                         processedMainChartSeries && (
                                             <ChartZoom
                                                 colorScale={colorScale}
@@ -436,7 +457,7 @@ export const TimeSeriesChartInternal: FunctionComponent<TimeSeriesChartInternalP
                                                     processedMainChartSeries
                                                 }
                                                 width={width}
-                                                onZoomChange={handleBrushChange}
+                                                onZoomChange={handleZoomChange}
                                             />
                                         )}
                                     {tooltipData && (

--- a/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.interfaces.ts
+++ b/thirdeye-ui/src/app/components/visualizations/time-series-chart/time-series-chart.interfaces.ts
@@ -151,6 +151,11 @@ export interface TimeSeriesChartProps {
     height?: number;
     chartEvents?: {
         onZoomChange?: (domain: ZoomDomain | null) => void;
+        /**
+         * Return true to continue the default behavior (chart zoom)
+         * otherwise falsey
+         */
+        onRangeSelection?: (domain: ZoomDomain | null) => boolean | undefined;
     };
     initialZoom?: ZoomDomain;
     events?: Event[];


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1378

#### Description

Enabling feature allowing consumers of `TimeSeriesChart` to pass callback function when user makes a range selection.

Usage in the configuration is as follows:

```jsx
{
    series,
    legend: true,
    brush: true,
    zoom: true,
    tooltip: true,
    yAxis: {
        position: Orientation.right,
    },
    chartEvents: {
        onRangeSelection: (domain) => {
            console.log(domain);

            return true;
        },
    },
}
```

Some fine details about the expected return value of `onRangeSelection`. If return value is falsey (undefined, null, 0, false) then the default zoom behavior will not happen but if the return value is true then the chart will continue to change the zoom window