### PR TITLE
refactor(ui): TE-1418 alert accuracy fetches in component

### DIFF
--- a/thirdeye-ui/src/app/components/alert-accuracy-colored/alert-accuracy-colored.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-accuracy-colored/alert-accuracy-colored.component.tsx
@@ -84,69 +84,67 @@ export const AlertAccuracyColored: FunctionComponent<AlertAccuracyColoredProps> 
         }
 
         return (
-            <Typography
-                color="secondary"
-                innerRef={ref}
-                style={typographyColor}
-                variant="body1"
-                {...typographyProps}
+            <TooltipV1
+                delay={50}
+                placement="bottom"
+                title={
+                    !!alertStats && (
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        {t("message.total-reported-anomalies")}
+                                    </td>
+                                    <td>{alertStats.totalCount}</td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        {t("message.anomalies-with-feedback")}
+                                    </td>
+                                    <td>{alertStats.countWithFeedback}</td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        {t("message.misreported-anomalies")}
+                                    </td>
+                                    <td>
+                                        {
+                                            alertStats.feedbackStats[
+                                                AnomalyFeedbackType.NOT_ANOMALY
+                                            ]
+                                        }
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    )
+                }
             >
-                <LoadingErrorStateSwitch
-                    isError={false}
-                    isLoading={
-                        status === ActionStatus.Initial ||
-                        status === ActionStatus.Working
-                    }
-                    loadingState={
-                        <SkeletonV1 width={50} {...defaultSkeletonProps} />
-                    }
-                >
-                    <TooltipV1
-                        title={
-                            !!alertStats && (
-                                <table>
-                                    <tbody>
-                                        <tr>
-                                            <td>
-                                                {t(
-                                                    "message.total-reported-anomalies"
-                                                )}
-                                            </td>
-                                            <td>{alertStats.totalCount}</td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                {t(
-                                                    "message.anomalies-with-feedback"
-                                                )}
-                                            </td>
-                                            <td>
-                                                {alertStats.countWithFeedback}
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                {t(
-                                                    "message.misreported-anomalies"
-                                                )}
-                                            </td>
-                                            <td>
-                                                {
-                                                    alertStats.feedbackStats[
-                                                        AnomalyFeedbackType
-                                                            .NOT_ANOMALY
-                                                    ]
-                                                }
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            )
-                        }
+                <div>
+                    <Typography
+                        color="secondary"
+                        innerRef={ref}
+                        style={typographyColor}
+                        variant="body1"
+                        {...typographyProps}
                     >
-                        <>{displayValue}</>
-                    </TooltipV1>
-                </LoadingErrorStateSwitch>
-            </Typography>
+                        <LoadingErrorStateSwitch
+                            isError={false}
+                            isLoading={
+                                status === ActionStatus.Initial ||
+                                status === ActionStatus.Working
+                            }
+                            loadingState={
+                                <SkeletonV1
+                                    width={50}
+                                    {...defaultSkeletonProps}
+                                />
+                            }
+                        >
+                            <>{displayValue}</>
+                        </LoadingErrorStateSwitch>
+                    </Typography>
+                </div>
+            </TooltipV1>
         );
     };

--- a/thirdeye-ui/src/app/components/alert-accuracy-colored/alert-accuracy-colored.interface.ts
+++ b/thirdeye-ui/src/app/components/alert-accuracy-colored/alert-accuracy-colored.interface.ts
@@ -14,17 +14,15 @@
  */
 
 import type { TypographyProps } from "@material-ui/core";
-import type { ReactElement, ReactNode } from "react";
+import type { ReactElement } from "react";
 import type { SkeletonV1Props } from "../../platform/components/skeleton-v1/skeleton-v1.interfaces";
-import type { AlertStats } from "../../rest/dto/alert.interfaces";
 
 export interface AlertAccuracyColoredProps {
-    alertStats: AlertStats | null;
+    alertId: number;
     renderCustomLoading?: ReactElement;
     defaultSkeletonProps?: SkeletonV1Props;
     typographyProps?: Partial<TypographyProps>;
-    renderCustomText?: (p: {
-        accuracy: number;
-        noAnomalyData: boolean;
-    }) => ReactNode;
+    label?: string;
+    start?: number;
+    end?: number;
 }

--- a/thirdeye-ui/src/app/components/alert-list-v1/alert-list-v1.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-list-v1/alert-list-v1.component.tsx
@@ -13,7 +13,6 @@
  * the License.
  */
 import { Button, Grid, Link } from "@material-ui/core";
-import { capitalize } from "lodash";
 import React, {
     FunctionComponent,
     ReactElement,
@@ -21,7 +20,7 @@ import React, {
     useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 import {
     DataGridColumnV1,
     DataGridScrollV1,
@@ -29,7 +28,6 @@ import {
     DataGridV1,
     PageContentsCardV1,
 } from "../../platform/components";
-import { AnomalyFeedbackType } from "../../rest/dto/anomaly.interfaces";
 import type { UiAlert } from "../../rest/dto/ui-alert.interfaces";
 import {
     getAlertsAlertPath,
@@ -78,7 +76,11 @@ export const AlertListV1: FunctionComponent<AlertListV1Props> = ({
         cellValue: Record<string, unknown>,
         data: UiAlert
     ): ReactElement => {
-        return <Link href={getAlertsAlertPath(data.id)}>{cellValue}</Link>;
+        return (
+            <Link component={RouterLink} to={getAlertsAlertPath(data.id)}>
+                {cellValue}
+            </Link>
+        );
     };
 
     const renderAlertAccuracy = (
@@ -86,61 +88,10 @@ export const AlertListV1: FunctionComponent<AlertListV1Props> = ({
         data: UiAlert
     ): ReactElement => (
         <AlertAccuracyColored
-            alertStats={data.accuracyStatistics ?? null}
-            renderCustomText={({ accuracy, noAnomalyData }) =>
-                noAnomalyData
-                    ? t("message.no-data")
-                    : `${(100 * accuracy).toFixed(2)}%`
-            }
+            alertId={data.id}
             typographyProps={{ variant: "body2" }}
         />
     );
-
-    const renderAlertAccuracyTooltip = (
-        _: Record<string, unknown>,
-        data: UiAlert
-    ): ReactElement | undefined => {
-        if (!data.accuracyStatistics) {
-            return (
-                <>
-                    {capitalize(
-                        t("message.fetching-entity", {
-                            entity: t("label.data"),
-                        })
-                    )}
-                    ...
-                </>
-            );
-        }
-
-        const { totalCount, countWithFeedback, feedbackStats } =
-            data.accuracyStatistics;
-
-        // Inform the user if there are no anomalies logged for this alert
-        if (totalCount === 0) {
-            return (
-                <>
-                    {capitalize(
-                        t("message.no-children-present-for-this-parent", {
-                            parent: t("label.alert"),
-                            children: t("label.anomalies"),
-                        })
-                    )}
-                </>
-            );
-        }
-
-        return (
-            <>
-                {t("message.total-reported-anomalies")}:&nbsp;{totalCount}
-                <br />
-                {t("message.anomalies-with-feedback")}:&nbsp;{countWithFeedback}
-                <br />
-                {t("message.misreported-anomalies")}:&nbsp;
-                {feedbackStats[AnomalyFeedbackType.NOT_ANOMALY]}
-            </>
-        );
-    };
 
     const renderAlertStatus = (
         _: Record<string, unknown>,
@@ -222,7 +173,6 @@ export const AlertListV1: FunctionComponent<AlertListV1Props> = ({
             minWidth: 0,
             flex: 1,
             customCellRenderer: renderAlertAccuracy,
-            customCellTooltipRenderer: renderAlertAccuracyTooltip,
         },
         {
             key: "active",

--- a/thirdeye-ui/src/app/components/alert-list-v1/alert-list-v1.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-list-v1/alert-list-v1.component.tsx
@@ -173,6 +173,7 @@ export const AlertListV1: FunctionComponent<AlertListV1Props> = ({
             minWidth: 0,
             flex: 1,
             customCellRenderer: renderAlertAccuracy,
+            cellTooltip: false,
         },
         {
             key: "active",

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
@@ -37,7 +37,6 @@ import {
     getAlertsAlertAnomaliesPath,
     getAnomaliesCreatePath,
 } from "../../../../utils/routes/routes.util";
-import { AlertAccuracyColored } from "../../../alert-accuracy-colored/alert-accuracy-colored.component";
 import { AnomalyWizardQueryParams } from "../../../anomalies-create/create-anomaly-wizard/create-anomaly-wizard.utils";
 import { Pluralize } from "../../../pluralize/pluralize.component";
 import {
@@ -57,7 +56,6 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     anomalies,
     expanded,
     onExpandChange,
-    alertStats,
     timezone,
 }) => {
     const navigate = useNavigate();
@@ -147,8 +145,8 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
                         <Grid
                             item
                             {...(isExpanded
-                                ? { sm: 4, xs: 12 }
-                                : { sm: 2, xs: 12 })}
+                                ? { sm: 6, xs: 12 }
+                                : { sm: 4, xs: 12 })}
                         >
                             <Typography
                                 className={classes.name}
@@ -156,22 +154,6 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
                             >
                                 {nameForDetectionEvaluation}
                             </Typography>
-                        </Grid>
-                        <Grid item sm={2} xs={12}>
-                            <AlertAccuracyColored
-                                alertStats={alertStats}
-                                defaultSkeletonProps={{
-                                    width: 100,
-                                    height: 30,
-                                }}
-                                renderCustomText={({ noAnomalyData }) =>
-                                    // Returning a null here will have the
-                                    // component render the default string
-                                    // The requirement here is to render nothing
-                                    // if `noAnomalyData` is true
-                                    noAnomalyData ? <>&nbsp;</> : null
-                                }
-                            />
                         </Grid>
                         {isExpanded && (
                             <Grid item sm={2} xs={12}>

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.interfaces.ts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import type { AlertStats } from "../../../../rest/dto/alert.interfaces";
 import type { Anomaly } from "../../../../rest/dto/anomaly.interfaces";
 import type { DetectionEvaluationForRender } from "../../enumeration-item-merger/enumeration-item-merger.interfaces";
 
@@ -22,6 +21,5 @@ export interface EnumerationItemRowProps {
     anomalies: Anomaly[];
     expanded: string[];
     onExpandChange: (isOpen: boolean, name: string) => void;
-    alertStats: AlertStats | null;
     timezone?: string;
 }

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.component.tsx
@@ -46,7 +46,6 @@ export const EnumerationItemsTable: FunctionComponent<EnumerationItemsTableProps
         onSearchTermChange,
         sortOrder,
         onSortOrderChange,
-        alertsStats,
         timezone,
     }) => {
         const [filteredDetectionEvaluations, setFilteredDetectionEvaluations] =
@@ -245,9 +244,6 @@ export const EnumerationItemsTable: FunctionComponent<EnumerationItemsTableProps
                                 return (
                                     <EnumerationItemRow
                                         alertId={alertId}
-                                        alertStats={
-                                            alertsStats?.[alertId] ?? null
-                                        }
                                         anomalies={
                                             detectionEvaluation.anomalies
                                         }

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-items-table.interfaces.ts
@@ -13,7 +13,6 @@
  * the License.
  */
 import type { DataGridSortOrderV1 } from "../../../platform/components";
-import type { AlertStats } from "../../../rest/dto/alert.interfaces";
 import type { DetectionEvaluationForRender } from "../enumeration-item-merger/enumeration-item-merger.interfaces";
 
 export interface EnumerationItemsTableProps {
@@ -25,6 +24,5 @@ export interface EnumerationItemsTableProps {
     initialSearchTerm: string;
     onSearchTermChange: (newTerm: string) => void;
     onSortOrderChange: (newOrder: DataGridSortOrderV1) => void;
-    alertsStats?: Record<number, AlertStats | null> | null;
     timezone?: string;
 }

--- a/thirdeye-ui/src/app/pages/alerts-all-page/alerts-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-all-page/alerts-all-page.component.tsx
@@ -221,7 +221,7 @@ export const AlertsAllPage: FunctionComponent = () => {
 
     const emptyStateParams = {
         emptyState: (
-            <Grid xs={12}>
+            <Grid item xs={12}>
                 <Card variant="outlined">
                     <CardContent>
                         <Box pb={20} pt={20}>

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -21,7 +21,6 @@ import {
     Grid,
 } from "@material-ui/core";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
-import { capitalize } from "lodash";
 import React, {
     FunctionComponent,
     MouseEvent,
@@ -64,11 +63,7 @@ import {
     updateAlert,
 } from "../../rest/alerts/alerts.rest";
 import { useGetAnomalies } from "../../rest/anomalies/anomaly.actions";
-import {
-    Alert,
-    AlertInEvaluation,
-    AlertStats,
-} from "../../rest/dto/alert.interfaces";
+import { Alert, AlertInEvaluation } from "../../rest/dto/alert.interfaces";
 import {
     createAlertEvaluation,
     determineTimezoneFromAlertInEvaluation,
@@ -93,11 +88,6 @@ export const AlertsViewPage: FunctionComponent = () => {
     const { showDialog } = useDialogProviderV1();
     const { id: alertId } = useParams<AlertsViewPageParams>();
 
-    // To be used for overall accuracy
-    const [overallAlertStats, setOverallAlertStats] =
-        useState<AlertStats | null>(null);
-    // To be used for accuracy filtered by startTime and endTime
-    const [alertStats, setAlertStats] = useState<AlertStats | null>(null);
     // Used for the scenario when user first creates an alert but no anomalies generated yet
     const [refreshAttempts, setRefreshAttempts] = useState(0);
     const [autoRefreshNotification, setAutoRefreshNotification] =
@@ -159,8 +149,6 @@ export const AlertsViewPage: FunctionComponent = () => {
             alertId: Number(alertId),
             startTime,
             endTime,
-        }).then((alertStatsData) => {
-            setAlertStats(alertStatsData);
         });
     };
 
@@ -227,11 +215,6 @@ export const AlertsViewPage: FunctionComponent = () => {
 
     useEffect(() => {
         getAlert(Number(alertId));
-        getAlertStats({
-            alertId: Number(alertId),
-        }).then((overallAlertStatsData) => {
-            setOverallAlertStats(overallAlertStatsData);
-        });
     }, [alertId]);
 
     useEffect(() => {
@@ -521,22 +504,12 @@ export const AlertsViewPage: FunctionComponent = () => {
                 }
                 subtitle={
                     <AlertAccuracyColored
-                        alertStats={overallAlertStats}
-                        renderCustomText={({ accuracy, noAnomalyData }) =>
-                            capitalize(
-                                noAnomalyData
-                                    ? t(
-                                          "message.no-children-present-for-this-parent",
-                                          {
-                                              children: t("label.anomalies"),
-                                              parent: t("label.alert"),
-                                          }
-                                      )
-                                    : `${t("label.overall-entity", {
-                                          entity: t("label.accuracy"),
-                                      })}: ${(100 * accuracy).toFixed(2)}%`
-                            )
-                        }
+                        alertId={Number(alertId) as number}
+                        end={endTime}
+                        label={t("label.overall-entity", {
+                            entity: t("label.accuracy"),
+                        })}
+                        start={startTime}
                     />
                 }
                 title={alert ? alert.name : ""}
@@ -617,9 +590,6 @@ export const AlertsViewPage: FunctionComponent = () => {
                                     return (
                                         <EnumerationItemsTable
                                             alertId={Number(alertId)}
-                                            alertsStats={{
-                                                [Number(alertId)]: alertStats,
-                                            }}
                                             detectionEvaluations={
                                                 detectionEvaluations
                                             }

--- a/thirdeye-ui/src/app/rest/alerts/alerts.actions.test.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.actions.test.ts
@@ -15,7 +15,12 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import axios from "axios";
 import { ActionStatus } from "../actions.interfaces";
-import { useGetAlert, useGetEvaluation, useResetAlert } from "./alerts.actions";
+import {
+    useGetAlert,
+    useGetAlertStats,
+    useGetEvaluation,
+    useResetAlert,
+} from "./alerts.actions";
 
 const mockEvaluation = {
     id: 1,
@@ -147,6 +152,47 @@ describe("Alerts Actions", () => {
                     // When REST call is completed
                     expect(result.current.alert).toEqual({ id: 123 });
                     expect(result.current.resetAlert).toBeDefined();
+                    expect(result.current.status).toEqual(ActionStatus.Done);
+                    expect(result.current.errorMessages).toEqual([]);
+                });
+            });
+        });
+    });
+
+    describe("useGetAlertStats", () => {
+        it("should return initial default values", () => {
+            const { result } = renderHook(() => useGetAlertStats());
+
+            expect(result.current.alertStats).toBeNull();
+            expect(result.current.getAlertStats).toBeDefined();
+            expect(result.current.status).toEqual(ActionStatus.Initial);
+            expect(result.current.errorMessages).toEqual([]);
+        });
+
+        it("should update data appropriately when making a successful REST call", async () => {
+            mockedAxios.get.mockResolvedValueOnce({
+                data: { id: 123 },
+            });
+            const { result, waitFor } = renderHook(() => useGetAlertStats());
+
+            await act(async () => {
+                const promise = result.current.getAlertStats({ alertId: 123 });
+
+                // Wait for state update
+                await waitFor(
+                    () => result.current.status === ActionStatus.Initial
+                );
+
+                // When REST call is in progress
+                expect(result.current.alertStats).toBeNull();
+                expect(result.current.getAlertStats).toBeDefined();
+                expect(result.current.status).toEqual(ActionStatus.Working);
+                expect(result.current.errorMessages).toEqual([]);
+
+                return promise.then(() => {
+                    // When REST call is completed
+                    expect(result.current.alertStats).toEqual({ id: 123 });
+                    expect(result.current.getAlertStats).toBeDefined();
                     expect(result.current.status).toEqual(ActionStatus.Done);
                     expect(result.current.errorMessages).toEqual([]);
                 });

--- a/thirdeye-ui/src/app/rest/alerts/alerts.actions.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.actions.ts
@@ -17,6 +17,7 @@ import {
     Alert,
     AlertEvaluation,
     AlertInsight,
+    AlertStats,
     EditableAlert,
 } from "../dto/alert.interfaces";
 import { EnumerationItem } from "../dto/enumeration-item.interfaces";
@@ -24,6 +25,8 @@ import {
     GetAlert,
     GetAlertInsight,
     GetAlerts,
+    GetAlertStats,
+    GetAlertStatsParams,
     GetEvaluation,
     ResetAlert,
     UseGetEvaluationParams,
@@ -32,6 +35,7 @@ import {
     getAlert as getAlertREST,
     getAlertEvaluation,
     getAlertInsight as getAlertInsightREST,
+    getAlertStats as getAlertStatsREST,
     getAllAlerts,
     resetAlert as resetAlertREST,
 } from "./alerts.rest";
@@ -96,4 +100,17 @@ export const useResetAlert = (): ResetAlert => {
     };
 
     return { alert: data, resetAlert, status, errorMessages };
+};
+
+export const useGetAlertStats = (): GetAlertStats => {
+    const { data, makeRequest, status, errorMessages } =
+        useHTTPAction<AlertStats>(getAlertStatsREST);
+
+    const getAlertStats = (
+        params: GetAlertStatsParams
+    ): Promise<AlertStats | undefined> => {
+        return makeRequest(params);
+    };
+
+    return { alertStats: data, getAlertStats, status, errorMessages };
 };

--- a/thirdeye-ui/src/app/rest/alerts/alerts.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.interfaces.ts
@@ -17,6 +17,7 @@ import {
     Alert,
     AlertEvaluation,
     AlertInsight,
+    AlertStats,
     EditableAlert,
 } from "../dto/alert.interfaces";
 import { EnumerationItemParams } from "../dto/detection.interfaces";
@@ -65,6 +66,13 @@ export interface ResetAlert extends ActionHook {
     resetAlert: (id: number) => Promise<Alert | undefined>;
 }
 
+export interface GetAlertStats extends ActionHook {
+    alertStats: AlertStats | null;
+    getAlertStats: (
+        params: GetAlertStatsParams
+    ) => Promise<AlertStats | undefined>;
+}
+
 export interface GetEvaluationRequestPayload extends UseGetEvaluationParams {
     evaluationContext?: {
         filters?: string[];
@@ -74,4 +82,10 @@ export interface GetEvaluationRequestPayload extends UseGetEvaluationParams {
               }
             | EnumerationItemParams;
     };
+}
+
+export interface GetAlertStatsParams {
+    alertId: number;
+    startTime?: number;
+    endTime?: number;
 }

--- a/thirdeye-ui/src/app/rest/alerts/alerts.rest.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.rest.ts
@@ -23,7 +23,10 @@ import type {
     EditableAlert,
 } from "../dto/alert.interfaces";
 import { EnumerationItemParams } from "../dto/detection.interfaces";
-import { GetEvaluationRequestPayload } from "./alerts.interfaces";
+import {
+    GetAlertStatsParams,
+    GetEvaluationRequestPayload,
+} from "./alerts.interfaces";
 
 const BASE_URL_ALERTS = "/api/alerts";
 
@@ -37,11 +40,7 @@ export const getAlertStats = async ({
     alertId,
     startTime,
     endTime,
-}: {
-    alertId: number;
-    startTime?: number;
-    endTime?: number;
-}): Promise<AlertStats> => {
+}: GetAlertStatsParams): Promise<AlertStats> => {
     const queryParams = new URLSearchParams([]);
 
     if (startTime) {

--- a/thirdeye-ui/src/app/rest/dto/ui-alert.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/ui-alert.interfaces.ts
@@ -12,14 +12,13 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import type { Alert, AlertStats } from "./alert.interfaces";
+import type { Alert } from "./alert.interfaces";
 
 export interface UiAlert {
     id: number;
     name: string;
     active: boolean;
     activeText: string;
-    accuracyStatistics?: AlertStats;
     userId: number;
     createdBy: string;
     detectionTypes: string[];


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1418

#### Description

When you try to check or even click on an alert while accuracy requests are in flight, you can't since the table keeps re-rendering on every request completion. Refactoring to making the accuracy component make the API request so the table does not re-render.

Also removing the accuracy from enumeration item since that just displays the same data as the header.

#### Screenshots

No visible changes to UI except the removal of the accuracy in enumeration items

![image](https://user-images.githubusercontent.com/2080348/226835238-6a6e84a1-07c4-4c16-ba43-e5ea118e6f6f.png)

