### PR TITLE
[Helm] Enable MySQL port to be set when using external

### DIFF
--- a/kubernetes/helm/startree-thirdeye/README.md
+++ b/kubernetes/helm/startree-thirdeye/README.md
@@ -23,7 +23,7 @@ To deploy thirdeye on Kubernetes, you may need access credentials to fetch docke
 Startree artifactory. To do that, simply create a kubernetes secret using the vault credentials.
 
 ```bash
-kubectl create secret docker-registry startree \ 
+kubectl create secret docker-registry startree \
   --docker-server="<DOCKER-REPO>" \
   --docker-username=<your-name> \
   --docker-password=<your-pword> \
@@ -49,14 +49,14 @@ helm install thirdeye . --namespace te
 ```
 
 To see the notifications in action ThirdEye can be configured to fire emails once it set up with an SMTP server. The following example
-uses the Google SMTP server.  
+uses the Google SMTP server.
 Make sure you pass the `ui.publicUrl` as it will be used to form the anomaly page links shared in the email.
 
 ```bash
 export SMTP_PASSWORD="password"
 export SMTP_USERNAME="from.email@gmail.com"
 export THIRDEYE_UI_PUBLIC_URL="http://localhost:8081"
-# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart 
+# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart
 export DOCKER_CONTAINER_URL=<TE_DOCKER_CONTAINER_URL>
 
 helm install thirdeye . \
@@ -100,8 +100,8 @@ helm install thirdeye . -f values.yaml
 
 ### Dynamic Secrets
 
-ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret` 
-resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below 
+ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret`
+resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below
 is a snippet from the `values.yaml` file
 ```yaml
 secrets:
@@ -115,11 +115,11 @@ secrets:
     encoded: true
     value: <base 64 encoded json key>
 ```
-1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`. 
-2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.  
-   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,  
+1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`.
+2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.
+   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,
    while `holidayLoaderKey` won't be injected as environment variable.
-3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts. 
+3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts.
 4. It is recommended to pass values other than simple string (e.g. JSON payload) as `base64` encoded value to avoid any parsing issues.
 
 ### Holiday Events
@@ -303,6 +303,7 @@ mysql:
 | `prometheus.enabled`                               | Flag to expose prometheus metrics and adding annotations for prometheus to scrape the metrics                        |
 | `mysql.enabled`                                    | Flag to disable MySQL deployment if using external instance                                                          |
 | `mysql.url`                                        | Database URL if using external instance                                                                              |
+| `mysql.port`                                       | Database port if using external instance                                                                             |
 | `mysql.mysqlUser`                                  | Database username                                                                                                    |
 | `mysql.mysqlPassword`                              | Database password                                                                                                    |
 | `mysql.persistence.size`                           | Size of persistent volume created for database storage                                                               |

--- a/kubernetes/helm/startree-thirdeye/README.md
+++ b/kubernetes/helm/startree-thirdeye/README.md
@@ -23,7 +23,7 @@ To deploy thirdeye on Kubernetes, you may need access credentials to fetch docke
 Startree artifactory. To do that, simply create a kubernetes secret using the vault credentials.
 
 ```bash
-kubectl create secret docker-registry startree \
+kubectl create secret docker-registry startree \ 
   --docker-server="<DOCKER-REPO>" \
   --docker-username=<your-name> \
   --docker-password=<your-pword> \
@@ -49,14 +49,14 @@ helm install thirdeye . --namespace te
 ```
 
 To see the notifications in action ThirdEye can be configured to fire emails once it set up with an SMTP server. The following example
-uses the Google SMTP server.
+uses the Google SMTP server.  
 Make sure you pass the `ui.publicUrl` as it will be used to form the anomaly page links shared in the email.
 
 ```bash
 export SMTP_PASSWORD="password"
 export SMTP_USERNAME="from.email@gmail.com"
 export THIRDEYE_UI_PUBLIC_URL="http://localhost:8081"
-# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart
+# please ask for access to Startree repo - see https://github.com/startreedata/thirdeye/tree/master/recipes/quickstart 
 export DOCKER_CONTAINER_URL=<TE_DOCKER_CONTAINER_URL>
 
 helm install thirdeye . \
@@ -100,8 +100,8 @@ helm install thirdeye . -f values.yaml
 
 ### Dynamic Secrets
 
-ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret`
-resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below
+ThirdEye has plugin infrastructure which allow users to go ahead and create their own plugins. To avoid creating `Secret` 
+resources for the sensitive data for each new plugin, it provides a way of creating dynamic secrets as required. Below 
 is a snippet from the `values.yaml` file
 ```yaml
 secrets:
@@ -115,11 +115,11 @@ secrets:
     encoded: true
     value: <base 64 encoded json key>
 ```
-1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`.
-2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.
-   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,
+1. A single Secret resource will be created which will have data fields corresponding to each entry in `secrets`. 
+2. A secret data field will be injected as an environment variable, with name as `env`, in the server pods if we pass the `env`.  
+   For example, smtpUsername will be injected as environment variable with variable name as `SMTP_USER` and value as `tobefedexternally`,  
    while `holidayLoaderKey` won't be injected as environment variable.
-3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts.
+3. The values will be considered as plain text by default and will be encoded internally unless we provide `encoded: true`, then the value won't be encoded by the charts. 
 4. It is recommended to pass values other than simple string (e.g. JSON payload) as `base64` encoded value to avoid any parsing issues.
 
 ### Holiday Events

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -40,7 +40,7 @@ data:
           keyStorePassword: {{ .Values.tls.password }}
           keyStoreType: {{ .Values.tls.type }}
         {{- end }}
-
+  
       requestLog:
         appenders:
         - type: console

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -40,7 +40,7 @@ data:
           keyStorePassword: {{ .Values.tls.password }}
           keyStoreType: {{ .Values.tls.type }}
         {{- end }}
-  
+
       requestLog:
         appenders:
         - type: console
@@ -59,8 +59,8 @@ data:
 {{ toYaml .Values.auth | indent 6 }}
 
     database:
-      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 3306
-      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 'mysql.port'
+      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}:{{- .Values.mysql.port -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -54,7 +54,7 @@ data:
         - type: http
           port: {{ .Values.scheduler.port }}
           idleTimeout: 620s
-
+  
       requestLog:
         appenders:
         - type: console

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -111,11 +111,11 @@ data:
       {{- end }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-
+    
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-
+    
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -54,7 +54,7 @@ data:
         - type: http
           port: {{ .Values.scheduler.port }}
           idleTimeout: 620s
-  
+
       requestLog:
         appenders:
         - type: console
@@ -83,8 +83,8 @@ data:
     #      ttl: 60000
 
     database:
-      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 3306
-      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 'mysql.port'
+      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}:{{- .Values.mysql.port -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver
@@ -111,11 +111,11 @@ data:
       {{- end }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-    
+
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-    
+
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -115,11 +115,11 @@ data:
       noTaskDelay: {{ .Values.worker.config.noTaskDelay | default 15 }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-
+    
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-
+    
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -83,8 +83,8 @@ data:
     #      ttl: 60000
 
     database:
-      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 3306
-      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
+      # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 'mysql.port'
+      url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}:{{- .Values.mysql.port -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}
       user: {{ .Values.mysql.mysqlUser }}
       password: {{ .Values.mysql.mysqlPassword }}
       driver: com.mysql.cj.jdbc.Driver
@@ -115,11 +115,11 @@ data:
       noTaskDelay: {{ .Values.worker.config.noTaskDelay | default 15 }}
       heartbeatInterval: {{ .Values.worker.config.heartbeatInterval | default 30 }}
       activeThresholdMultiplier: {{ .Values.worker.config.activeThresholdMultiplier | default 30 }}
-    
+
     time:
       timezone: {{ .Values.time.timezone }}
       minimumOnboardingStartTime: {{ .Values.time.minimumOnboardingStartTime }}
-    
+
     rca:
       topContributors:
         algorithm: {{ .Values.rca.topContributors.algorithm }}

--- a/kubernetes/helm/startree-thirdeye/values.yaml
+++ b/kubernetes/helm/startree-thirdeye/values.yaml
@@ -193,8 +193,9 @@ mysql:
   # Use the MySQL chart dependency
   # Set to false if bringing your own MySQL
   enabled: true
-  # Set the value when internal MySQL server is disabled (mysql.enabled: false)
+  # Set the following values when internal MySQL server is disabled (mysql.enabled: false)
   url: ""
+  port: 3306
 
   imageTag: 8.0.28
   mysqlRootPassword: password


### PR DESCRIPTION
#### Issue(s)

- At my company, we only use PostgreSQL instances so a lot of the infrastructure particularly the security group networking rules are tailored for it
- Right now the default 3306 port is not allowed
- It would be easier for us to allow a different port as opposed to trying to modify the networking rules

#### Description

- Allow port to be set if external MySQL is provided, default still 3306

#### How to test

Verified working with different values of

```
helm install --dry-run --debug thirdeye . > dry-run.txt
```
