### PR TITLE
fix(ui): TE-1449 cosmetic fix to padding on left and right sides with loading switch component

### DIFF
--- a/thirdeye-ui/src/app/components/page-states/loading-error-state-switch/loading-error-state-switch.component.tsx
+++ b/thirdeye-ui/src/app/components/page-states/loading-error-state-switch/loading-error-state-switch.component.tsx
@@ -14,7 +14,11 @@
  */
 import { Box, Grid } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
-import { PageContentsCardV1, SkeletonV1 } from "../../../platform/components";
+import {
+    PageContentsCardV1,
+    PageContentsGridV1,
+    SkeletonV1,
+} from "../../../platform/components";
 import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
 import { LoadingErrorStateSwitchProps } from "./loading-error-state-switch.interfaces";
 
@@ -41,73 +45,47 @@ export const LoadingErrorStateSwitch: FunctionComponent<LoadingErrorStateSwitchP
         children,
         wrapInGrid,
         wrapInCard,
+        wrapInGridContainer,
     }) => {
-        if (isError) {
-            if (errorState) {
-                return <>{errorState}</>;
+        if (isError || isLoading) {
+            let outputState;
+
+            if (isError) {
+                if (errorState) {
+                    return <>{errorState}</>;
+                }
+
+                outputState = DEFAULT_ERROR_ELEMENT;
             }
 
-            if (wrapInGrid && wrapInCard) {
-                return (
-                    <Grid item xs={12}>
-                        <PageContentsCardV1>
-                            {DEFAULT_ERROR_ELEMENT}
-                        </PageContentsCardV1>
-                    </Grid>
-                );
-            }
+            if (isLoading) {
+                if (loadingState) {
+                    return <>{loadingState}</>;
+                }
 
-            if (wrapInGrid) {
-                return (
-                    <Grid item xs={12}>
-                        {DEFAULT_ERROR_ELEMENT}
-                    </Grid>
-                );
+                outputState = DEFAULT_LOADING_ELEMENT;
             }
 
             if (wrapInCard) {
-                return (
-                    <PageContentsCardV1>
-                        {DEFAULT_ERROR_ELEMENT}
-                    </PageContentsCardV1>
+                outputState = (
+                    <PageContentsCardV1>{outputState}</PageContentsCardV1>
                 );
             }
-
-            return DEFAULT_ERROR_ELEMENT;
-        }
-
-        if (isLoading) {
-            if (loadingState) {
-                return <>{loadingState}</>;
-            }
-
-            if (wrapInGrid && wrapInCard) {
-                return (
-                    <Grid item xs={12}>
-                        <PageContentsCardV1>
-                            {DEFAULT_LOADING_ELEMENT}
-                        </PageContentsCardV1>
-                    </Grid>
-                );
-            }
-
             if (wrapInGrid) {
-                return (
+                outputState = (
                     <Grid item xs={12}>
-                        {DEFAULT_LOADING_ELEMENT}
+                        {outputState}
                     </Grid>
                 );
             }
 
-            if (wrapInCard) {
-                return (
-                    <PageContentsCardV1>
-                        {DEFAULT_LOADING_ELEMENT}
-                    </PageContentsCardV1>
+            if (wrapInGridContainer) {
+                outputState = (
+                    <PageContentsGridV1>{outputState}</PageContentsGridV1>
                 );
             }
 
-            return DEFAULT_LOADING_ELEMENT;
+            return <>{outputState}</>;
         }
 
         return <>{children}</>;

--- a/thirdeye-ui/src/app/components/page-states/loading-error-state-switch/loading-error-state-switch.interfaces.ts
+++ b/thirdeye-ui/src/app/components/page-states/loading-error-state-switch/loading-error-state-switch.interfaces.ts
@@ -22,4 +22,5 @@ export interface LoadingErrorStateSwitchProps {
     isError: boolean;
     wrapInGrid?: boolean;
     wrapInCard?: boolean;
+    wrapInGridContainer?: boolean;
 }

--- a/thirdeye-ui/src/app/pages/alerts-update-page/alerts-edit-base-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-update-page/alerts-edit-base-page.component.tsx
@@ -237,6 +237,7 @@ export const AlertsEditBasePage: FunctionComponent<AlertsEditPageProps> = ({
             <LoadingErrorStateSwitch
                 wrapInCard
                 wrapInGrid
+                wrapInGridContainer
                 isError={false}
                 isLoading={
                     alertTemplatesRequestStatus === ActionStatus.Working ||

--- a/thirdeye-ui/src/app/pages/welcome-page/create-alert/create-alert-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/welcome-page/create-alert/create-alert-page.component.tsx
@@ -191,6 +191,7 @@ export const CreateAlertPage: FunctionComponent = () => {
             <LoadingErrorStateSwitch
                 wrapInCard
                 wrapInGrid
+                wrapInGridContainer
                 isError={false}
                 isLoading={
                     alertTemplatesRequestStatus === ActionStatus.Working ||


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1449

#### Description

Sometimes the loading screen takes on entire page width which looks different than when loaded since the loader is not wrapped in `PageContentsGridV1`

#### Screenshots

Before
<img width="1490" alt="Screenshot 2023-03-31 at 3 48 56 PM" src="https://user-images.githubusercontent.com/2080348/229246077-014a2713-2182-47e0-8e58-5069ca7748f5.png">


After
<img width="1490" alt="Screenshot 2023-03-31 at 3 49 50 PM" src="https://user-images.githubusercontent.com/2080348/229246133-eef75eb3-af51-4322-853a-a48c421a6eff.png">

