### PR TITLE
fix(ui): TE-1439 make rcaAggregationFunction optional for JSON editor only

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v3/threshold-setup/threshold-setup.utils.test.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/threshold-setup/threshold-setup.utils.test.ts
@@ -53,7 +53,6 @@ describe("AlertWizardV3/Threshold Setup Utils", () => {
             aggregationFunction: "mockAggregationFunction",
             aggregationColumn: "mockMetric",
             timezone: "pst",
-            rcaAggregationFunction: "mockAggregationFunction",
         });
     });
 

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/threshold-setup/threshold-setup.utils.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/threshold-setup/threshold-setup.utils.ts
@@ -53,11 +53,6 @@ export function generateTemplateProperties(
         dataset: dataset.name,
         aggregationColumn: metric,
         aggregationFunction: aggregationFunction,
-        /**
-         * See https://cortex-data.slack.com/archives/C031NQQNDPX
-         *     /p1677746148239239?thread_ts=1677723158.158859&cid=C031NQQNDPX
-         */
-        rcaAggregationFunction: aggregationFunction,
     };
 
     templateProperties.timezone = dataset.timeColumn.timezone;


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1439

#### Description

rcaAggregationFunction is optional and should not be always set the same as aggregationFunction. Backend will decide its proper value when it's missing.

#### Screenshots
<img width="1294" alt="Screenshot 2023-04-06 at 12 11 47 PM" src="https://user-images.githubusercontent.com/3389485/230473169-28258097-f96c-4ff4-ab3b-432d2c66d76b.png">

