### PR TITLE
[build] add sub-module dependencies to fix flaky parallel build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,21 @@
                 <version>${aspectj.version}</version>
               </configuration>
             </execution>
+            <!-- failing build on dependency analysis warnings -->
+            <execution>
+              <id>analyze</id>
+              <goals>
+                <goal>analyze-only</goal>
+              </goals>
+              <configuration>
+                <!-- workaround for https://issues.apache.org/jira/browse/MDEP-791 -->
+                <ignoredNonTestScopedDependencies>
+                  <ignoredNonTestScopedDependency>*</ignoredNonTestScopedDependency>
+                </ignoredNonTestScopedDependencies>
+                <!--TODO(TE-1501): turn on failure once all existing dependency warnings are resolved. -->
+                <failOnWarning>false</failOnWarning>
+              </configuration>
+            </execution>
           </executions>
         </plugin>
         <plugin>

--- a/thirdeye-core/pom.xml
+++ b/thirdeye-core/pom.xml
@@ -26,6 +26,10 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-spi</artifactId>
     </dependency>
     <dependency>

--- a/thirdeye-detectionpipeline/pom.xml
+++ b/thirdeye-detectionpipeline/pom.xml
@@ -26,6 +26,14 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-core</artifactId>
     </dependency>
 

--- a/thirdeye-integration-tests/pom.xml
+++ b/thirdeye-integration-tests/pom.xml
@@ -27,6 +27,18 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-persistence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-server</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/thirdeye-notification/pom.xml
+++ b/thirdeye-notification/pom.xml
@@ -28,6 +28,10 @@
       <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-spi</artifactId>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/thirdeye-plugins/thirdeye-contributors-simple/pom.xml
+++ b/thirdeye-plugins/thirdeye-contributors-simple/pom.xml
@@ -27,8 +27,11 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-spi</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>

--- a/thirdeye-plugins/thirdeye-datasources/pom.xml
+++ b/thirdeye-plugins/thirdeye-datasources/pom.xml
@@ -26,6 +26,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-db</artifactId>
     </dependency>

--- a/thirdeye-plugins/thirdeye-detectors/pom.xml
+++ b/thirdeye-plugins/thirdeye-detectors/pom.xml
@@ -26,6 +26,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
     </dependency>

--- a/thirdeye-plugins/thirdeye-pinot/pom.xml
+++ b/thirdeye-plugins/thirdeye-pinot/pom.xml
@@ -33,6 +33,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service-annotations</artifactId>
     </dependency>

--- a/thirdeye-plugins/thirdeye-postprocessors/pom.xml
+++ b/thirdeye-plugins/thirdeye-postprocessors/pom.xml
@@ -27,6 +27,10 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-spi</artifactId>
     </dependency>
     <dependency>

--- a/thirdeye-scheduler/pom.xml
+++ b/thirdeye-scheduler/pom.xml
@@ -26,6 +26,14 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-worker</artifactId>
     </dependency>
 

--- a/thirdeye-server/pom.xml
+++ b/thirdeye-server/pom.xml
@@ -27,8 +27,40 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-detectionpipeline</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-persistence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-scheduler</artifactId>
-      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-worker</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-scheduler</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/thirdeye-worker/pom.xml
+++ b/thirdeye-worker/pom.xml
@@ -26,11 +26,19 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-detectionpipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
       <artifactId>thirdeye-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-spi</artifactId>
     </dependency>
 
     <!-- test dependencies -->


### PR DESCRIPTION
#### Issue(s)
When enabling the parallel build using parameter like `-T 1C` (one thread per core), build is likely to have compilation failure (see below image), especially for computers with more cores.

![image](https://user-images.githubusercontent.com/3389485/232163649-e331489b-eedb-4f8c-b50a-8bcea5c245f5.png)

Github CI has similar issues but much less frequent due to only having 2 cores:
https://github.com/startreedata/thirdeye/actions/runs/4195972819/jobs/7276285646

Related ticket: TE-1501

#### Description

The fix is to manually add the thirdeye related dependencies explicitly into pom whenever the package is being imported directly (no transitive dependency isn't added here).

Dependency analyze is turned on by using the maven-dependency-plugin, warnings be printed out to console if direct dependencies are used but not added into the pom file.

However, not all dependencies issues are taken care of by this PR. For example:

[INFO] --- maven-dependency-plugin:3.3.0:analyze-only (analyze) @ thirdeye-server ---
[WARNING] Used undeclared dependencies found:
[WARNING]    com.google.code.findbugs:jsr305:jar:3.0.2:compile
[WARNING]    io.dropwizard.metrics:metrics-annotation:jar:4.1.33:compile
[WARNING]    org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile
[WARNING]    io.dropwizard:dropwizard-jersey:jar:2.0.33:compile
[WARNING]    org.apache.commons:commons-lang3:jar:3.9:compile
[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5:compile
[WARNING]    io.swagger:swagger-annotations:jar:1.6.0:compile
[WARNING]    org.slf4j:slf4j-api:jar:1.7.12:compile
[WARNING]    ch.qos.logback:logback-access:jar:1.2.11:compile
[WARNING]    io.dropwizard.metrics:metrics-healthchecks:jar:4.1.33:compile
[WARNING]    io.dropwizard:dropwizard-configuration:jar:2.0.33:compile
[WARNING]    io.dropwizard.metrics:metrics-core:jar:4.0.7:compile
[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
[WARNING]    org.checkerframework:checker-qual:jar:3.21.2:compile
[WARNING]    org.glassfish.jersey.core:jersey-server:jar:2.33:compile
[WARNING]    org.eclipse.jetty:jetty-servlets:jar:9.4.48.v20220622:compile
[WARNING]    joda-time:joda-time:jar:2.7:compile
[WARNING]    jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
[WARNING]    org.apache.calcite:calcite-core:jar:1.32.0:compile
[WARNING]    ch.qos.logback:logback-core:jar:1.2.11:compile
[WARNING]    com.fasterxml.jackson.core:jackson-core:jar:2.10.5:compile
[WARNING]    javax.servlet:javax.servlet-api:jar:3.1.0:compile
[WARNING]    io.dropwizard:dropwizard-lifecycle:jar:2.0.33:compile
[WARNING]    jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
[WARNING]    com.google.guava:guava:jar:20.0:compile
[WARNING]    io.dropwizard:dropwizard-jetty:jar:2.0.33:compile
[WARNING]    io.prometheus:simpleclient:jar:0.11.0:compile
[WARNING]    com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.10.5:compile
[WARNING]    com.google.inject:guice:jar:4.2.3:compile
[WARNING]    com.smoketurner:dropwizard-swagger:jar:2.0.0-1:compile
[WARNING]    org.apache.tomcat:tomcat-jdbc:jar:9.0.65:compile
[WARNING]    io.dropwizard:dropwizard-logging:jar:2.0.33:compile
[WARNING]    com.couchbase.client:core-io:jar:1.7.9:compile
[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.10.5:compile
[WARNING]    org.quartz-scheduler:quartz:jar:2.3.2:compile

#### How to test

`./mvnw clean install -T 1C  -DskipTests -pl '!thirdeye-ui'` should work much reliable now. The issue could still occur sometimes (not sure if it's maven's concurrence issue) but with much lower occurrence rate compare to the state before this fix.