### PR TITLE
[misc] update pinot version from 0.11.0 to 0.12.1

### DIFF
--- a/examples/AdCampaignData/ingestion_job_spec.yaml
+++ b/examples/AdCampaignData/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/AdCampaignData'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/CleanPageViewsData/ingestion_job_spec.yaml
+++ b/examples/CleanPageViewsData/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/CleanPageViewsData'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/LogisticsData/ingestion_job_spec.yaml
+++ b/examples/LogisticsData/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/LogisticsData'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/USStoreSalesOrderData/ingestion_job_spec.yaml
+++ b/examples/USStoreSalesOrderData/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/USStoreSalesOrderData'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/new_customers_holiday/ingestion_job_spec.yaml
+++ b/examples/new_customers_holiday/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/new_customers_holiday'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/order_events/ingestion_job_spec.yaml
+++ b/examples/order_events/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/order_events'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/pageviews/ingestion_job_spec.yaml
+++ b/examples/pageviews/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/pageviews'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/pageviews_with_floats/ingestion_job_spec.yaml
+++ b/examples/pageviews_with_floats/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/pageviews_with_floats'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/pageviews_with_missing_data/ingestion_job_spec.yaml
+++ b/examples/pageviews_with_missing_data/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/pageviews_with_missing_data'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/pageviews_with_nulls/ingestion_job_spec.yaml
+++ b/examples/pageviews_with_nulls/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/pageviews_with_nulls'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/examples/us_monthly_air_passengers_simplified/ingestion_job_spec.yaml
+++ b/examples/us_monthly_air_passengers_simplified/ingestion_job_spec.yaml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: '${controllerProtocol}://${controllerHost}:${controllerPort}/tables/us_monthly_air_passengers_simplified'
 pinotClusterSpecs:
   - controllerURI: '${controllerProtocol}://${controllerHost}:${controllerPort}'
+pushJobSpec:
+  pushAttempts: 1

--- a/scripts/load-datasets.sh
+++ b/scripts/load-datasets.sh
@@ -16,7 +16,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TE_REPO="${SCRIPT_DIR}/.."
 if [ -z "${PINOT_VERSION}" ]; then
-  PINOT_VERSION=0.11.0
+  PINOT_VERSION=0.12.1
 fi
 if [ -z "${CONTROLLER_PROTOCOL}" ]; then
   CONTROLLER_PROTOCOL=http

--- a/scripts/start-pinot.sh
+++ b/scripts/start-pinot.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_DIR="${SCRIPT_DIR}/.."
 
 if [ -z "${PINOT_VERSION}" ]; then
-    PINOT_VERSION=0.11.0
+  PINOT_VERSION=0.12.1
 fi
 
 export PINOT_INSTALL_TMP_DIR="${REPO_DIR}/tmp/pinot-bin"


### PR DESCRIPTION
#### Issue(s)

Pinot version 0.11.0 is not available anymore: https://downloads.apache.org/pinot/

Update the version to 0.12.1 for in quick start scripts.

#### Description

For the newer version of Pinot, pushJobSpec was missing in original configs and the ingestion always fail when uploading the Segment.
![Screenshot 2023-04-17 at 2 11 52 PM](https://user-images.githubusercontent.com/3389485/232612533-7240b18d-03a4-4e68-90e1-d5fd4f02b318.png)

Docs on push job spec:
https://docs.pinot.apache.org/v/release-0.12.1/configuration-reference/job-specification#push-job-spec

#### Screenshots

Added this spec and loading data into Pinot works again:
<img width="1125" alt="Screenshot 2023-04-17 at 2 11 34 PM" src="https://user-images.githubusercontent.com/3389485/232612782-637477a7-5016-4bb0-a887-b5e9fbb39c5f.png">

