### PR TITLE
fix(ui): TE-1496 auto-open notifications if subscription groups are selected

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-notifications/alert-notifications.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-notifications/alert-notifications.component.tsx
@@ -26,7 +26,9 @@ export const AlertNotifications: FunctionComponent<AlertNotificationsProps> = ({
     initiallySelectedSubscriptionGroups,
 }) => {
     const { t } = useTranslation();
-    const [isNotificationsOn, setIsNotificationsOn] = useState(false);
+    const [isNotificationsOn, setIsNotificationsOn] = useState(
+        initiallySelectedSubscriptionGroups.length > 0
+    );
 
     return (
         <PageContentsCardV1 fullHeight>

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-notifications/alert-notifications.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-notifications/alert-notifications.component.tsx
@@ -13,6 +13,7 @@
  * the License.
  */
 import { Box, Button, Grid, Switch, Typography } from "@material-ui/core";
+import { isEmpty } from "lodash";
 import React, { FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PageContentsCardV1 } from "../../../platform/components";
@@ -27,7 +28,7 @@ export const AlertNotifications: FunctionComponent<AlertNotificationsProps> = ({
 }) => {
     const { t } = useTranslation();
     const [isNotificationsOn, setIsNotificationsOn] = useState(
-        initiallySelectedSubscriptionGroups.length > 0
+        !isEmpty(initiallySelectedSubscriptionGroups)
     );
 
     return (


### PR DESCRIPTION
#### Issue(s)

https://cortexdata.atlassian.net/browse/TE-1496

#### Description

Default the open state on the `initiallySelectedSubscriptionGroups` array length

#### Screenshots

No UI changes