### PR TITLE
[misc] update e2e test Pinot version from 0.11.0 to 0.12.1

### DIFF
--- a/pinot-test-container/src/main/java/org/apache/pinot/testcontainer/PinotContainer.java
+++ b/pinot-test-container/src/main/java/org/apache/pinot/testcontainer/PinotContainer.java
@@ -39,7 +39,7 @@ public class PinotContainer extends GenericContainer<PinotContainer> {
 
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse(
       "apachepinot/pinot");
-  private static final String DEFAULT_TAG = "0.11.0";
+  private static final String DEFAULT_TAG = "0.12.1";
   private static final String DEFAULT_TAG_ARM64 = DEFAULT_TAG + "-arm64";
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private List<AddTable> addTables;

--- a/thirdeye-integration-tests/src/test/resources/datasets/pageviews/batch-job-spec.yml
+++ b/thirdeye-integration-tests/src/test/resources/datasets/pageviews/batch-job-spec.yml
@@ -36,3 +36,5 @@ tableSpec:
   tableConfigURI: 'http://localhost:9000/tables/pageviews'
 pinotClusterSpecs:
   - controllerURI: 'http://localhost:9000'
+pushJobSpec:
+  pushAttempts: 1


### PR DESCRIPTION
#### Issue(s)

[TE-1519
](https://cortexdata.atlassian.net/browse/TE-1519)

#### Description

Pinot version in example has been [upgraded to 0.12.1](https://github.com/startreedata/thirdeye/pull/1068) 
e2e tests are often failed in local due to connection timeout when using 0.11.0 (low performance warnings in Docker Desktop)

#### Screenshots
Local run with 0.12.1 pinot:
<img width="1641" alt="Screenshot 2023-04-25 at 5 24 44 PM" src="https://user-images.githubusercontent.com/3389485/234438016-618d0aac-905c-4ef5-b59e-3124769ca4c8.png">

