### PR TITLE
[k8s] optimize init images

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         {{- toYaml .Values.coordinator.tolerations | nindent 8 }}
       initContainers:
       - name: init-keystore
-        image: eclipse-temurin:17-jdk
+        image: eclipse-temurin:17-jre
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
         command:
         - /bin/sh

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         {{- toYaml .Values.scheduler.tolerations | nindent 8 }}
       initContainers:
       - name: init-keystore
-        image: eclipse-temurin:17-jdk
+        image: eclipse-temurin:17-jre
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
         command:
         - /bin/sh

--- a/kubernetes/helm/startree-thirdeye/templates/ui/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/ui/deployment.yaml
@@ -50,7 +50,7 @@ spec:
 {{ toYaml .Values.ui.tolerations | indent 8 }}
       initContainers:
       - name: init-config
-        image: adoptopenjdk/openjdk11:alpine
+        image: alpine:3.18
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
         env:
         - name: NGINX_ENVSUBST_TEMPLATE_DIR

--- a/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         {{- toYaml .Values.worker.tolerations | nindent 8 }}
       initContainers:
       - name: init-keystore
-        image: eclipse-temurin:17-jdk
+        image: eclipse-temurin:17-jre
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
         command:
         - /bin/sh


### PR DESCRIPTION
initContainers images were not optimal. 
no perf improvement is expected from this change. In effect [images are cached](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) by default.

goal here is to make it clearer that no java build is happening here.