### PR TITLE
[core] fix completenessDelay behaviour

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertDetectionIntervalCalculator.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertDetectionIntervalCalculator.java
@@ -96,7 +96,7 @@ public class AlertDetectionIntervalCalculator {
     DateTime correctedEnd = taskEnd;
     // apply delay correction
     final Period delay = getDelay(metadata);
-    final DateTime dataWatermark = new DateTime(chronology).minus(delay);
+    final DateTime dataWatermark = DateTime.now(chronology).minus(delay);
     if (correctedEnd.isAfter(dataWatermark)) {
       correctedEnd = dataWatermark;
       LOG.info(

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertDetectionIntervalCalculator.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/alert/AlertDetectionIntervalCalculator.java
@@ -96,10 +96,13 @@ public class AlertDetectionIntervalCalculator {
     DateTime correctedEnd = taskEnd;
     // apply delay correction
     final Period delay = getDelay(metadata);
-    // if alert has already run: start = lastTimestamp = correctedEnd from last run -> delay was applied
-    // if alert has never run: delay is not important if end-delay > start.
-    // only apply delay on start if end-delay > start is not true
-    correctedEnd = correctedEnd.minus(delay);
+    final DateTime dataWatermark = new DateTime(chronology).minus(delay);
+    if (correctedEnd.isAfter(dataWatermark)) {
+      correctedEnd = dataWatermark;
+      LOG.info(
+          "Applied delay correction of {} for id {} between {} and {}. Corrected end time is {}",
+          delay, alertId, taskStart, taskEnd, correctedEnd);
+    }
     if (correctedEnd.isBefore(correctedStart)) {
       correctedStart = correctedStart.minus(delay);
       LOG.warn(
@@ -108,14 +111,6 @@ public class AlertDetectionIntervalCalculator {
           correctedEnd,
           correctedStart);
     }
-    LOG.info(
-        "Applied delay correction of {} for id {} between {} and {}. Corrected timeframe is between {} and {}",
-        delay,
-        alertId,
-        taskStart,
-        taskEnd,
-        correctedStart,
-        correctedEnd);
 
     // apply granularity correction
     final Period granularity = getGranularity(metadata);

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/alert/AlertInsightsProviderTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/alert/AlertInsightsProviderTest.java
@@ -40,7 +40,7 @@ public class AlertInsightsProviderTest {
         JANUARY_1_2022_2AM,
         DateTimeZone.UTC);
     final Interval res = AlertInsightsProvider.getDefaultChartInterval(datasetInterval,
-        DAILY_GRANULARITY, Period.ZERO);
+        DAILY_GRANULARITY);
 
     // end of end bucket
     final DateTime expectedEnd = new DateTime(JANUARY_2_2022_0AM, DateTimeZone.UTC);
@@ -51,28 +51,12 @@ public class AlertInsightsProviderTest {
   }
 
   @Test
-  public void testDefaultIntervalWithDailyGranularityWithCompletenessDelay() {
-    final Interval datasetInterval = new Interval(JANUARY_1_2019_OAM,
-        JANUARY_1_2022_2AM,
-        DateTimeZone.UTC);
-    final Interval res = AlertInsightsProvider.getDefaultChartInterval(datasetInterval,
-        DAILY_GRANULARITY, Period.days(1));
-
-    // end of bucket = JANUARY_2_2022_0AM then delay is added
-    final DateTime expectedEnd = new DateTime(JANUARY_3_2022_0AM, DateTimeZone.UTC);
-    // 6 months from start of end bucket
-    final DateTime expectedStart = new DateTime(JANUARY_2_2022_0AM, DateTimeZone.UTC).minus(DAILY_GRANULARITY).minus(Period.months(6));
-    final Interval expected = new Interval(expectedStart, expectedEnd);
-    assertThat(res).isEqualTo(expected);
-  }
-
-  @Test
   public void testDefaultIntervalWithDailyGranularityWithParisTimezone() {
     final Interval datasetInterval = new Interval(JANUARY_1_2019_OAM,
         JANUARY_1_2022_2AM,
         PARIS_TIMEZONE);
     final Interval res = AlertInsightsProvider.getDefaultChartInterval(datasetInterval,
-        DAILY_GRANULARITY, Period.ZERO);
+        DAILY_GRANULARITY);
 
 
     // end of end bucket
@@ -89,7 +73,7 @@ public class AlertInsightsProviderTest {
         JANUARY_1_2022_2AM,
         DateTimeZone.UTC);
     final Interval res = AlertInsightsProvider.getDefaultChartInterval(datasetInterval,
-        DAILY_GRANULARITY, Period.ZERO);
+        DAILY_GRANULARITY);
 
     final Interval expected = new Interval(JULY_2_2021_0AM, JANUARY_2_2022_0AM, DateTimeZone.UTC);
     assertThat(res).isEqualTo(expected);


### PR DESCRIPTION
only apply completenessDelay when the endTime is bigger than the data watermark


The change is simple but it’s a big design change: /evaluate and /run are not “pure” anymore --> the behaviour depends on the time at which they run.
These parts were already pretty well tested with unit test and e2e scheduling test so I did not add much tests.