### PR TITLE
[server] Add heap and sentry configs to ui config container

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/config/UiConfiguration.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/config/UiConfiguration.java
@@ -18,6 +18,9 @@ public class UiConfiguration {
   private String externalUrl;
   private String clientId;
 
+  private HeapConfiguration heap;
+  private SentryConfiguration sentry;
+
   public String getExternalUrl() {
     return externalUrl;
   }
@@ -34,5 +37,51 @@ public class UiConfiguration {
   public UiConfiguration setClientId(String clientId) {
     this.clientId = clientId;
     return this;
+  }
+
+  public HeapConfiguration getHeap() {
+    return heap;
+  }
+
+  public UiConfiguration setHeap(HeapConfiguration heap) {
+    this.heap = heap;
+    return this;
+  }
+
+  public SentryConfiguration getSentry() {
+    return sentry;
+  }
+
+  public UiConfiguration setSentry(SentryConfiguration sentry) {
+    this.sentry = sentry;
+    return this;
+  }
+
+  public static class HeapConfiguration {
+
+    private String environmentId;
+
+    public String getEnvironmentId() {
+      return environmentId;
+    }
+
+    public HeapConfiguration setEnvironmentId(final String environmentId) {
+      this.environmentId = environmentId;
+      return this;
+    }
+  }
+
+  public static class SentryConfiguration {
+
+    private String clientDsn;
+
+    public String getClientDsn() {
+      return clientDsn;
+    }
+
+    public SentryConfiguration setClientDsn(final String clientDsn) {
+      this.clientDsn = clientDsn;
+      return this;
+    }
   }
 }

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/UiConfigurationMapper.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/mapper/UiConfigurationMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.mapper;
+
+import ai.startree.thirdeye.config.UiConfiguration;
+import ai.startree.thirdeye.spi.api.UiConfigurationApi;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface UiConfigurationMapper {
+
+  UiConfigurationMapper INSTANCE = Mappers.getMapper(UiConfigurationMapper.class);
+
+  UiConfigurationApi toApi(UiConfiguration config);
+}

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/UiResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/UiResource.java
@@ -17,7 +17,7 @@ import static ai.startree.thirdeye.util.ResourceUtils.respondOk;
 
 import ai.startree.thirdeye.auth.AuthConfiguration;
 import ai.startree.thirdeye.config.UiConfiguration;
-import ai.startree.thirdeye.spi.api.UiConfigurationApi;
+import ai.startree.thirdeye.mapper.UiConfigurationMapper;
 import com.codahale.metrics.annotation.Timed;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.inject.Inject;
@@ -33,25 +33,23 @@ import javax.ws.rs.core.Response;
 @Produces(MediaType.APPLICATION_JSON)
 public class UiResource {
 
-    private final UiConfiguration configuration;
-    private final AuthConfiguration authConfiguration;
+  private final UiConfiguration configuration;
+  private final AuthConfiguration authConfiguration;
 
-    @Inject
-    public UiResource(final UiConfiguration uiConfiguration,
-        final AuthConfiguration authConfiguration) {
-        this.configuration = uiConfiguration;
-        this.authConfiguration = authConfiguration;
-    }
+  @Inject
+  public UiResource(final UiConfiguration uiConfiguration,
+      final AuthConfiguration authConfiguration) {
+    this.configuration = uiConfiguration;
+    this.authConfiguration = authConfiguration;
+  }
 
-    @GET
-    @Path("config")
-    @Timed
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response get() {
-        return respondOk(
-            new UiConfigurationApi()
-                .setClientId(configuration.getClientId())
-                .setAuthEnabled(authConfiguration.isEnabled())
-        );
-    }
+  @GET
+  @Path("config")
+  @Timed
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response get() {
+    return respondOk(UiConfigurationMapper.INSTANCE.toApi(configuration)
+        .setAuthEnabled(authConfiguration.isEnabled())
+    );
+  }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/UiConfigurationApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/UiConfigurationApi.java
@@ -18,17 +18,19 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UiConfigurationApi implements ThirdEyeApi {
 
-    private String clientId;
-    private boolean authEnabled;
+  private String clientId;
+  private boolean authEnabled;
+  private HeapConfigurationApi heap;
+  private SentryConfigurationApi sentry;
 
-    public String getClientId() {
-        return clientId;
-    }
+  public String getClientId() {
+    return clientId;
+  }
 
-    public UiConfigurationApi setClientId(final String clientId) {
-        this.clientId = clientId;
-        return this;
-    }
+  public UiConfigurationApi setClientId(final String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
 
   public boolean isAuthEnabled() {
     return authEnabled;
@@ -37,5 +39,51 @@ public class UiConfigurationApi implements ThirdEyeApi {
   public UiConfigurationApi setAuthEnabled(final boolean authEnabled) {
     this.authEnabled = authEnabled;
     return this;
+  }
+
+  public HeapConfigurationApi getHeap() {
+    return heap;
+  }
+
+  public UiConfigurationApi setHeap(HeapConfigurationApi heap) {
+    this.heap = heap;
+    return this;
+  }
+
+  public SentryConfigurationApi getSentry() {
+    return sentry;
+  }
+
+  public UiConfigurationApi setSentry(SentryConfigurationApi sentry) {
+    this.sentry = sentry;
+    return this;
+  }
+
+  public static class HeapConfigurationApi {
+
+    private String environmentId;
+
+    public String getEnvironmentId() {
+      return environmentId;
+    }
+
+    public HeapConfigurationApi setEnvironmentId(final String environmentId) {
+      this.environmentId = environmentId;
+      return this;
+    }
+  }
+
+  public static class SentryConfigurationApi {
+
+    private String clientDsn;
+
+    public String getClientDsn() {
+      return clientDsn;
+    }
+
+    public SentryConfigurationApi setClientDsn(final String clientDsn) {
+      this.clientDsn = clientDsn;
+      return this;
+    }
   }
 }


### PR DESCRIPTION
UI Configuration would look something like this

```
ui:
  externalUrl: "http://localhost:8081"
  heap:
    environmentId: 1234567890
  sentry:
    clientDsn: https://something.ingest.sentry.io/someid
```

API
```
GET http://localhost:8080/api/ui/config
```

Response
```
{
  "authEnabled": false,
  "heap": {
    "environmentId": "1234567890"
  },
  "sentry": {
    "clientDsn": "https://something.ingest.sentry.io/someid"
  }
}
```