### PR TITLE
[spi] add micrometers for simpler metrics collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <swagger.version>2.1.6-1</swagger.version>
     <testcontainers.version>1.18.3</testcontainers.version>
+    <micrometer.version>1.11.4</micrometer.version>
   </properties>
 
   <licenses>
@@ -916,10 +917,22 @@
         <artifactId>hsqldb</artifactId>
         <version>${hsqldb.version}</version>
       </dependency>
+      <!-- legacy metrics library-->
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>4.2.19</version>
+      </dependency>
+      <!-- new metrics system - core is a facade, registry is the implementation -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${micrometer.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-prometheus</artifactId>
+        <version>${micrometer.version}</version>
       </dependency>
 
       <!-- checkers -->

--- a/thirdeye-server/pom.xml
+++ b/thirdeye-server/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>simpleclient_servlet</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/MergingMetricsServlet.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/MergingMetricsServlet.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Temporary classes that merges old metrics from dropwizard-metrics and new metrics from micrometers
+ */
+public class MergingMetricsServlet extends HttpServlet {
+
+  private final PrometheusMeterRegistry promRegistry;
+  // based on dropwizard metrics and prometheus client
+  private final CollectorRegistry legacyRegistry;
+
+  public MergingMetricsServlet(final PrometheusMeterRegistry newRegistry, final
+  CollectorRegistry legacyRegistry) {
+    this.promRegistry = newRegistry;
+    this.legacyRegistry = legacyRegistry;
+  }
+
+  @Override
+  protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+      throws ServletException, IOException {
+    resp.setStatus(200);
+    String contentType = TextFormat.chooseContentType(req.getHeader("Accept"));
+    resp.setContentType(contentType);
+    try (Writer writer = new BufferedWriter(resp.getWriter())) {
+      writer.write(promRegistry.scrape());
+      writer.flush();
+      TextFormat.writeFormat(contentType, writer,
+          this.legacyRegistry.filteredMetricFamilySamples(this.parse(req)));
+      writer.flush();
+    }
+  }
+
+  private Set<String> parse(HttpServletRequest req) {
+    String[] includedParam = req.getParameterValues("name[]");
+    return (Set) (includedParam == null ? Collections.emptySet()
+        : new HashSet(Arrays.asList(includedParam)));
+  }
+}

--- a/thirdeye-spi/pom.xml
+++ b/thirdeye-spi/pom.xml
@@ -42,6 +42,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <!-- metrics facade -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/PluginClassLoader.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/PluginClassLoader.java
@@ -33,9 +33,9 @@ public class PluginClassLoader extends URLClassLoader {
   public static final ImmutableList<String> SHARED_PACKAGES = ImmutableList.<String>builder()
       .add("ai.startree.thirdeye.spi")
       .add("com.google.common")
+      .add("io.micrometer")
       .add("org.joda.time")
       .add("org.slf4j")
-      .add("org.h2")
       .add("com.mysql")
       .add("javax.activation")
       .build();


### PR DESCRIPTION
Introducing micrometers as a metrics facade (slf4j but for metric collection).

`micrometer-core` does nothing on its own, it's similar to `slf4j-api`.  
We add it to the spi.  
Every modules can now do:
```
counter = Metrics.counter("my_metric")
...
counter.increment()
```
(same with other metrics type)
the `Metrics` static methods makes the creation of metrics possible without DI of the actual registry instance like we do today.

This should make it simpler to add metrics in "deep" places in the code.
Also other libraries used by TE can expose their own metrics.

For prometheus, micrometer automatically respects prom conventions: 
`.` are replaced by `_` , `_total` is appended to counter metrics, default/recommended metrics respect the prometheus convention,  etc...
I suggest we use the `.` separator as recommended by micrometer. This will make it easier to change from prometheus to another metrics collection system if need be.

Note on spi size: micrometer-core and its dependencies: 
``` 
46K  micrometer-commons-1.11.4.jar
847K micrometer-core-1.11.4.jar
69K  micrometer-observation-1.11.4.jar
```
This should be fine.
from the website:
> The micrometer-core module aims to have minimal dependencies. It does not require any third-party (non-Micrometer) dependencies on the classpath at compile time for applications using Micrometer.

so this should stay small forever.

This is not a complete migration. For the moment we duplicate 2 counters and we will compare old/new metrics.