### PR TITLE
[persistence] Add task.ref_id field to reference an entity connected to a task

### DIFF
--- a/thirdeye-notification/pom.xml
+++ b/thirdeye-notification/pom.xml
@@ -26,11 +26,15 @@
   <dependencies>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
-      <artifactId>thirdeye-core</artifactId>
+      <artifactId>thirdeye-spi</artifactId>
     </dependency>
     <dependency>
       <groupId>ai.startree.thirdeye</groupId>
-      <artifactId>thirdeye-spi</artifactId>
+      <artifactId>thirdeye-persistence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-core</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/entity/TaskEntity.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/entity/TaskEntity.java
@@ -15,7 +15,7 @@ package ai.startree.thirdeye.datalayer.entity;
 
 import java.sql.Timestamp;
 
-public class TaskEntity extends AbstractEntity implements HasJsonVal<TaskEntity>{
+public class TaskEntity extends AbstractEntity implements HasJsonVal<TaskEntity> {
 
   private String name;
   private String status;
@@ -26,6 +26,8 @@ public class TaskEntity extends AbstractEntity implements HasJsonVal<TaskEntity>
   private long workerId;
   private Timestamp lastActive;
   private String jsonVal;
+
+  private Long refId;
 
   @Override
   public String getJsonVal() {
@@ -107,6 +109,15 @@ public class TaskEntity extends AbstractEntity implements HasJsonVal<TaskEntity>
 
   public TaskEntity setLastActive(final Timestamp lastActive) {
     this.lastActive = lastActive;
+    return this;
+  }
+
+  public Long getRefId() {
+    return refId;
+  }
+
+  public TaskEntity setRefId(final Long refId) {
+    this.refId = refId;
     return this;
   }
 }

--- a/thirdeye-persistence/src/main/resources/db/migration/mysql/V1_196_0__task_add_ref_id.sql
+++ b/thirdeye-persistence/src/main/resources/db/migration/mysql/V1_196_0__task_add_ref_id.sql
@@ -11,23 +11,11 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package ai.startree.thirdeye.spi.task;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
-/**
- * Interface for task info of the various types of tasks
- */
-public interface TaskInfo {
+-- Add ref_id to task entity
+-- ref_id is nullable and refers to the id of the alert or subscription group
+ALTER TABLE task_entity ADD COLUMN ref_id BIGINT(20) UNSIGNED DEFAULT NULL;
 
-  /**
-   * refId is the id of the entity that the task is associated with.
-   * For example, if the task is to run a detection pipeline, the refId is the id of the alert. In
-   * case of a notification task, the refId is the id of the subscription group.
-   * @return the id of the reference entity
-   */
-  @JsonIgnore
-  default Long getRefId() {
-    return null;
-  }
-}
+-- Create index on ref_id
+CREATE INDEX task_ref_id_idx ON task_entity (ref_id);

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/job/DetectionAlertJob.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/job/DetectionAlertJob.java
@@ -37,22 +37,22 @@ public class DetectionAlertJob extends ThirdEyeAbstractJob {
 
   @Override
   public void execute(final JobExecutionContext ctx) {
-    final SubscriptionGroupManager alertConfigDAO = getInstance(ctx,
+    final SubscriptionGroupManager subscriptionGroupManager = getInstance(ctx,
         SubscriptionGroupManager.class);
 
     final JobSchedulerService service = getInstance(ctx, JobSchedulerService.class);
 
     final String jobKey = ctx.getJobDetail().getKey().getName();
-    final long detectionAlertConfigId = getIdFromJobKey(jobKey);
-    final SubscriptionGroupDTO configDTO = alertConfigDAO.findById(detectionAlertConfigId);
+    final long subscriptionGroupId = getIdFromJobKey(jobKey);
+    final SubscriptionGroupDTO configDTO = subscriptionGroupManager.findById(subscriptionGroupId);
     if (configDTO == null) {
-      LOG.error("Subscription config {} does not exist", detectionAlertConfigId);
+      LOG.error("Subscription config {} does not exist", subscriptionGroupId);
     }
 
-    final DetectionAlertTaskInfo taskInfo = new DetectionAlertTaskInfo(detectionAlertConfigId);
+    final DetectionAlertTaskInfo taskInfo = new DetectionAlertTaskInfo(subscriptionGroupId);
 
     // if a task is pending and not time out yet, don't schedule more
-    final String jobName = String.format("%s_%d", TaskType.NOTIFICATION, detectionAlertConfigId);
+    final String jobName = String.format("%s_%d", TaskType.NOTIFICATION, subscriptionGroupId);
     if (service.taskAlreadyRunning(jobName)) {
       LOG.trace("Skip scheduling subscription task {}. Already queued", jobName);
       return;
@@ -65,7 +65,7 @@ public class DetectionAlertJob extends ThirdEyeAbstractJob {
 
     try {
       final TaskManager taskManager = getInstance(ctx, TaskManager.class);
-      final TaskDTO taskDTO = taskManager.createTaskDto(detectionAlertConfigId,
+      final TaskDTO taskDTO = taskManager.createTaskDto(subscriptionGroupId,
           taskInfo,
           TaskType.NOTIFICATION);
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 public interface TaskManager extends AbstractManager<TaskDTO> {
 
-  TaskDTO createTaskDto(final long alertId, final TaskInfo taskInfo, final TaskType taskType)
+  TaskDTO createTaskDto(final long refId, final TaskInfo taskInfo, final TaskType taskType)
       throws JsonProcessingException;
 
   List<TaskDTO> findByJobIdStatusNotIn(Long jobId, TaskStatus status);

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DetectionPipelineTaskInfo.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/DetectionPipelineTaskInfo.java
@@ -57,4 +57,9 @@ public class DetectionPipelineTaskInfo implements TaskInfo {
     this.end = end;
     return this;
   }
+
+  @Override
+  public Long getRefId() {
+    return getConfigId();
+  }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TaskDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TaskDTO.java
@@ -39,6 +39,8 @@ public class TaskDTO extends AbstractDTO {
   private Timestamp lastModified;
   private Timestamp lastActive;
 
+  private Long refId;
+
   public Long getWorkerId() {
     return workerId;
   }
@@ -135,6 +137,15 @@ public class TaskDTO extends AbstractDTO {
 
   public TaskDTO setJobId(Long jobId) {
     this.jobId = jobId;
+    return this;
+  }
+
+  public Long getRefId() {
+    return refId;
+  }
+
+  public TaskDTO setRefId(final Long refId) {
+    this.refId = refId;
     return this;
   }
 

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/DetectionAlertTaskInfo.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/DetectionAlertTaskInfo.java
@@ -36,4 +36,9 @@ public class DetectionAlertTaskInfo implements TaskInfo {
   public void setDetectionAlertConfigId(long detectionAlertConfigId) {
     this.detectionAlertConfigId = detectionAlertConfigId;
   }
+
+  @Override
+  public Long getRefId() {
+    return getDetectionAlertConfigId();
+  }
 }


### PR DESCRIPTION
For a detection pipeline task, it is the alert id. For a notification task, it is the subscription group id