### PR TITLE
[mvn] rollback mysql jdbc client from 8.0.33 to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,9 @@
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <mockito.version>4.3.1</mockito.version>
     <modelmapper.version>3.1.1</modelmapper.version>
-    <mysql.connector.version>8.0.33</mysql.connector.version>
+    <!-- WARNING do not upgrade before MySql regression is fixed: https://bugs.mysql.com/bug.php?id=113378 -->
+    <!-- See our internal ticket for more info https://startree.atlassian.net/browse/TE-1970 -->
+    <mysql.connector.version>8.0.28</mysql.connector.version>
     <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
     <pinot.version>0.10.0</pinot.version>
     <prometheus.version>0.11.0</prometheus.version>


### PR DESCRIPTION
A regression was introduced in MySql connector.
I opened a ticket here: 
https://bugs.mysql.com/bug.php?id=113378

Ignoring Snyk. There are no security issues in ThirdEye with this downgrade.