### PR TITLE
[server] fix anomaly namespace inherits alert namespace when enum namespace is not set

### DIFF
--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/auth/AuthorizationManagerTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/auth/AuthorizationManagerTest.java
@@ -86,4 +86,32 @@ public class AuthorizationManagerTest {
     assertThat(got.getNamespace()).isEqualTo("enum_namespace");
     assertThat(got.getEntityType()).isEqualTo("ANOMALY");
   }
+
+  @Test
+  public void testResourceIdOfAnomalyDtoWithAnEnumThatHasNoResourceIdInheritsTheAlertResourceId() {
+    final AlertManager alertManager = mock(AlertManager.class);
+    final AlertDTO alertDto = new AlertDTO();
+    alertDto.setId(1L);
+    alertDto.setAuth(new AuthorizationConfigurationDTO().setNamespace("alert_namespace"));
+    when(alertManager.findById(1L)).thenReturn(alertDto);
+
+    final EnumerationItemManager enumManager = mock(EnumerationItemManager.class);
+    final EnumerationItemDTO enumItemDto = new EnumerationItemDTO();
+    // enum with no auth info
+    enumItemDto.setId(2L);
+    when(enumManager.findById(2L)).thenReturn(enumItemDto);
+
+    final AnomalyDTO anomalyDto = new AnomalyDTO();
+    anomalyDto.setDetectionConfigId(1L);
+    anomalyDto.setEnumerationItem((EnumerationItemDTO) new EnumerationItemDTO().setId(2L));
+    anomalyDto.setId(3L);
+
+    final AuthorizationManager authorizationManager = new AuthorizationManager(
+        null, null, new NamespaceResolver(alertManager, enumManager, null));
+
+    final ResourceIdentifier got = authorizationManager.resourceId(anomalyDto);
+    assertThat(got.getName()).isEqualTo("3");
+    assertThat(got.getNamespace()).isEqualTo("alert_namespace");
+    assertThat(got.getEntityType()).isEqualTo("ANOMALY");
+  }
 }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/auth/AuthorizationManagerTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/auth/AuthorizationManagerTest.java
@@ -30,58 +30,58 @@ public class AuthorizationManagerTest {
 
   @Test
   public void testResourceIdForNullDto() {
-    final var authorizationManager = new AuthorizationManager(
+    final AuthorizationManager authorizationManager = new AuthorizationManager(
         null, null, new NamespaceResolver(null, null, null));
-    final var got = authorizationManager.resourceId(null);
+    final ResourceIdentifier got = authorizationManager.resourceId(null);
     assertThat(got.getName()).isEqualTo(ResourceIdentifier.DEFAULT_NAME);
     assertThat(got.getNamespace()).isEqualTo(ResourceIdentifier.DEFAULT_NAMESPACE);
     assertThat(got.getEntityType()).isEqualTo(ResourceIdentifier.DEFAULT_ENTITY_TYPE);
   }
 
   @Test
-  public void testResourceIdForAnomalyDtoWithoutEnum() {
-    final var alertManager = mock(AlertManager.class);
-    final var alertDto = new AlertDTO();
+  public void testResourceIdOfAnomalyDtoWithoutEnumInheritsAlertResourceId() {
+    final AlertManager alertManager = mock(AlertManager.class);
+    final AlertDTO alertDto = new AlertDTO();
     alertDto.setId(1L);
     alertDto.setAuth(new AuthorizationConfigurationDTO().setNamespace("alert_namespace"));
     when(alertManager.findById(1L)).thenReturn(alertDto);
 
-    final var anomalyDto = new AnomalyDTO();
+    final AnomalyDTO anomalyDto = new AnomalyDTO();
     anomalyDto.setDetectionConfigId(1L);
     anomalyDto.setId(2L);
 
-    final var authorizationManager = new AuthorizationManager(
+    final AuthorizationManager authorizationManager = new AuthorizationManager(
         null, null, new NamespaceResolver(alertManager, null, null));
 
-    final var got = authorizationManager.resourceId(anomalyDto);
+    final ResourceIdentifier got = authorizationManager.resourceId(anomalyDto);
     assertThat(got.getName()).isEqualTo("2");
     assertThat(got.getNamespace()).isEqualTo("alert_namespace");
     assertThat(got.getEntityType()).isEqualTo("ANOMALY");
   }
 
   @Test
-  public void testResourceIdForAnomalyDtoWithEnum() {
-    final var alertManager = mock(AlertManager.class);
-    final var alertDto = new AlertDTO();
+  public void testResourceIdOfAnomalyDtoWithAnEnumThatHasAResourceIdInheritsTheEnumResourceId() {
+    final AlertManager alertManager = mock(AlertManager.class);
+    final AlertDTO alertDto = new AlertDTO();
     alertDto.setId(1L);
     alertDto.setAuth(new AuthorizationConfigurationDTO().setNamespace("alert_namespace"));
     when(alertManager.findById(1L)).thenReturn(alertDto);
 
-    final var enumManager = mock(EnumerationItemManager.class);
-    final var enumItemDto = new EnumerationItemDTO();
+    final EnumerationItemManager enumManager = mock(EnumerationItemManager.class);
+    final EnumerationItemDTO enumItemDto = new EnumerationItemDTO();
     enumItemDto.setId(2L);
     enumItemDto.setAuth(new AuthorizationConfigurationDTO().setNamespace("enum_namespace"));
     when(enumManager.findById(2L)).thenReturn(enumItemDto);
 
-    final var anomalyDto = new AnomalyDTO();
+    final AnomalyDTO anomalyDto = new AnomalyDTO();
     anomalyDto.setDetectionConfigId(1L);
     anomalyDto.setEnumerationItem((EnumerationItemDTO) new EnumerationItemDTO().setId(2L));
     anomalyDto.setId(3L);
 
-    final var authorizationManager = new AuthorizationManager(
+    final AuthorizationManager authorizationManager = new AuthorizationManager(
         null, null, new NamespaceResolver(alertManager, enumManager, null));
 
-    final var got = authorizationManager.resourceId(anomalyDto);
+    final ResourceIdentifier got = authorizationManager.resourceId(anomalyDto);
     assertThat(got.getName()).isEqualTo("3");
     assertThat(got.getNamespace()).isEqualTo("enum_namespace");
     assertThat(got.getEntityType()).isEqualTo("ANOMALY");


### PR DESCRIPTION
- refactor
- add failing test anomaly from enum inherits alert resourceId if enum has no resourceId
- add null annotations - make the bug easier to see
- fix issue

Make the cache a cache of Optional<String> because guava cache cannot return null.
Remove confusing behaviour of chains of optional. Put `.orElse(DEFAULT_NAMESPACE)` in a single place.
Use if else where this can help for debugging.