### PR TITLE
[server] add sentry.io collect

### DIFF
--- a/config/server.yaml
+++ b/config/server.yaml
@@ -174,9 +174,10 @@ prometheus:
 sentry:
   # set the sentry dsn here - if not set or blank, sentry is disabled
   dsn: ""
-  environment: development
+  # Some characters are forbidden - see https://docs.sentry.io/platforms/java/configuration/environments/?original_referrer=https%3A%2F%2Fwww.google.com%2F
+  environment: "localhost:7004"
   tags:
-    service: coordinator
+    component: coordinator
 
 scheduler:
   # Run the Quartz Scheduler.

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -169,6 +169,14 @@ phantomJsPath: "/usr/local/bin/jstf"
 # Prometheus compatible metrics will be exposed at /admin/prometheus
 prometheus:
   enabled: false
+  
+# sentry.io collect
+sentry:
+  # set the sentry dsn here - if not set or blank, sentry is disabled
+  dsn: ""
+  environment: development
+  tags:
+    service: coordinator
 
 scheduler:
   # Run the Quartz Scheduler.

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <swagger.version>2.1.6-1</swagger.version>
     <testcontainers.version>1.18.3</testcontainers.version>
     <micrometer.version>1.11.4</micrometer.version>
+    <sentry.version>7.2.0</sentry.version>
   </properties>
 
   <licenses>
@@ -823,6 +824,11 @@
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient_servlet</artifactId>
         <version>${prometheus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.sentry</groupId>
+        <artifactId>sentry</artifactId>
+        <version>${sentry.version}</version>
       </dependency>
 
       <dependency>

--- a/thirdeye-server/pom.xml
+++ b/thirdeye-server/pom.xml
@@ -86,6 +86,10 @@
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/config/BackendSentryConfiguration.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/config/BackendSentryConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.config;
+
+import java.util.Map;
+
+public class BackendSentryConfiguration {
+  
+  private String dsn = null;
+  
+  private String environment;
+
+  private Map<String, String> tags = Map.of();
+
+  public String getDsn() {
+    return dsn;
+  }
+
+  public BackendSentryConfiguration setDsn(final String dsn) {
+    this.dsn = dsn;
+    return this;
+  }
+
+  public String getEnvironment() {
+    return environment;
+  }
+
+  public BackendSentryConfiguration setEnvironment(final String environment) {
+    this.environment = environment;
+    return this;
+  }
+
+  public Map<String, String> getTags() {
+    return tags;
+  }
+
+  public BackendSentryConfiguration setTags(final Map<String, String> tags) {
+    this.tags = tags;
+    return this;
+  }
+}

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
@@ -64,6 +64,9 @@ public class ThirdEyeServerConfiguration extends Configuration {
 
   @JsonProperty("prometheus")
   private PrometheusConfiguration prometheusConfiguration = new PrometheusConfiguration();
+  
+  @JsonProperty("sentry")
+  private BackendSentryConfiguration sentryConfiguration = new BackendSentryConfiguration();
 
   @JsonProperty("time")
   private TimeConfiguration timeConfiguration = new TimeConfiguration();
@@ -258,6 +261,16 @@ public class ThirdEyeServerConfiguration extends Configuration {
 
   public ThirdEyeServerConfiguration setAccessControlConfiguration(AccessControlConfiguration config) {
     this.accessControlConfiguration = config;
+    return this;
+  }
+
+  public BackendSentryConfiguration getSentryConfiguration() {
+    return sentryConfiguration;
+  }
+
+  public ThirdEyeServerConfiguration setSentryConfiguration(
+      final BackendSentryConfiguration sentryConfiguration) {
+    this.sentryConfiguration = sentryConfiguration;
     return this;
   }
 }


### PR DESCRIPTION
config piece: 
```yaml
sentry:
   dsn: "https://dsn.sentry.io"
   environment: "production"
   tags:
     service: coordinator
     key: value
```

- `environment` will contain the ui.externalUrl without the forbidden characters
- there will be tags `service` that correspond to the kubernetes labels we use


NEXT:
- helm chart setup will be done in the next PR
- Collection of logs will be done in a second iteration.

