### PR TITLE
fix(ui): TE-2049 retain dimension, query, and selected cohorts when navigating back in alert flow

### DIFF
--- a/thirdeye-ui/src/app/components/cohort-detector/cohorts-table/cohorts-table.interfaces.ts
+++ b/thirdeye-ui/src/app/components/cohort-detector/cohorts-table/cohorts-table.interfaces.ts
@@ -24,6 +24,7 @@ export interface CohortsTableProps {
     onSelectionChange?: (cohorts: CohortResult[]) => void;
     title: string;
     subtitle?: string;
+    initiallySelectedCohorts: CohortTableRowData[];
 }
 
 export interface CohortTableRowData extends CohortResult {

--- a/thirdeye-ui/src/app/components/cohort-detector/cohorts-table/cohorts-table.utils.ts
+++ b/thirdeye-ui/src/app/components/cohort-detector/cohorts-table/cohorts-table.utils.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { CohortResult } from "../../../rest/dto/rca.interfaces";
+import { concatKeyValueWithEqual } from "../../../utils/params/params.util";
+import { generateFilterOptions } from "../../rca/top-contributors-table/top-contributors-table.utils";
+import { CohortTableRowData } from "./cohorts-table.interfaces";
+
+export const NAME_JOIN_KEY = " AND ";
+export const PERCENTAGE = "percentage";
+
+// Stringifies the dimension filter object for `queryData=` use
+export const getCohortTableRowFromData = <
+    T extends Pick<CohortResult, "dimensionFilters"> = CohortTableRowData
+>(
+    cohortItem: T
+): T & { name: string } => {
+    const copied: T & { name: string } = { ...cohortItem, name: "" };
+
+    const values: string[] = [];
+    const columnKeys: string[] = [];
+    Object.keys(cohortItem.dimensionFilters).forEach((dimensionColumn) => {
+        values.push(cohortItem.dimensionFilters[dimensionColumn]);
+        columnKeys.push(dimensionColumn);
+    });
+
+    copied.name = generateFilterOptions(values, columnKeys, [])
+        .map((item) => concatKeyValueWithEqual(item, true))
+        .sort()
+        .join(NAME_JOIN_KEY);
+
+    return copied;
+};

--- a/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.component.tsx
+++ b/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.component.tsx
@@ -61,7 +61,6 @@ export const DatasetDetails: FunctionComponent<DatasetDetailsProps> = ({
     initialSelectedDataset,
     initialSelectedDatasource,
     initialSelectedAggregationFunc,
-    initialQuery,
 }) => {
     const {
         datasources,
@@ -103,7 +102,10 @@ export const DatasetDetails: FunctionComponent<DatasetDetailsProps> = ({
             initialSelectedAggregationFunc ?? MetricAggFunction.SUM
         );
     const [selectedDimensions, setSelectedDimensions] = useState<string[]>([]);
-    const [queryValue, setQueryValue] = useState<string>(initialQuery || "");
+    const [queryValue, setQueryValue] = useSessionStorage<string>(
+        SessionStorageKeys.QueryFilterOnAlertFlow,
+        ""
+    );
 
     useEffect(() => {
         getDatasets();

--- a/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.component.tsx
+++ b/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.component.tsx
@@ -40,6 +40,10 @@ import {
     STAR_COLUMN,
 } from "../../../utils/datasources/datasources.util";
 import { generateDateRangeMonthsFromNow } from "../../../utils/routes/routes.util";
+import {
+    SessionStorageKeys,
+    useSessionStorage,
+} from "../../../utils/storage/use-session-storage";
 import { useAlertWizardV2Styles } from "../../alert-wizard-v2/alert-wizard-v2.styles";
 import { InputSection } from "../../form-basics/input-section/input-section.component";
 import { LoadingErrorStateSwitch } from "../../page-states/loading-error-state-switch/loading-error-state-switch.component";
@@ -105,6 +109,22 @@ export const DatasetDetails: FunctionComponent<DatasetDetailsProps> = ({
         getMetrics();
         getDatasources();
     }, []);
+
+    // Store the selected dimensions till the flow is completed ...or the session is ended.
+    const [storedDimensions, setStoredDimensions] = useSessionStorage<string[]>(
+        SessionStorageKeys.SelectedDimensionsOnAlertFlow,
+        []
+    );
+
+    useEffect(() => {
+        if (selectedTable && storedDimensions.length > 0) {
+            const dimensionsInTable = storedDimensions.filter((dim) =>
+                selectedTable.dimensions.includes(dim)
+            );
+            setSelectedDimensions(dimensionsInTable);
+            setStoredDimensions(dimensionsInTable);
+        }
+    }, [selectedTable]);
 
     // Build the table configuration tree
     useEffect(() => {
@@ -454,6 +474,10 @@ export const DatasetDetails: FunctionComponent<DatasetDetailsProps> = ({
                                 value={selectedDimensions}
                                 onChange={(_, dimensions) => {
                                     setSelectedDimensions(dimensions || []);
+
+                                    // Update selection in storage as well in case the
+                                    // user returns to this page in the same flow
+                                    setStoredDimensions(dimensions || []);
                                 }}
                             />
                         }

--- a/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.component.tsx
+++ b/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.component.tsx
@@ -61,6 +61,7 @@ export const DatasetDetails: FunctionComponent<DatasetDetailsProps> = ({
     initialSelectedDataset,
     initialSelectedDatasource,
     initialSelectedAggregationFunc,
+    initialQuery,
 }) => {
     const {
         datasources,
@@ -102,7 +103,7 @@ export const DatasetDetails: FunctionComponent<DatasetDetailsProps> = ({
             initialSelectedAggregationFunc ?? MetricAggFunction.SUM
         );
     const [selectedDimensions, setSelectedDimensions] = useState<string[]>([]);
-    const [queryValue, setQueryValue] = useState<string>("");
+    const [queryValue, setQueryValue] = useState<string>(initialQuery || "");
 
     useEffect(() => {
         getDatasets();

--- a/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.interfaces.ts
+++ b/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.interfaces.ts
@@ -34,5 +34,4 @@ export interface DatasetDetailsProps {
     initialSelectedDataset?: string;
     initialSelectedDatasource?: string;
     initialSelectedAggregationFunc?: MetricAggFunction;
-    initialQuery?: string;
 }

--- a/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.interfaces.ts
+++ b/thirdeye-ui/src/app/components/cohort-detector/dataset-details/dataset-details.interfaces.ts
@@ -34,4 +34,5 @@ export interface DatasetDetailsProps {
     initialSelectedDataset?: string;
     initialSelectedDatasource?: string;
     initialSelectedAggregationFunc?: MetricAggFunction;
+    initialQuery?: string;
 }

--- a/thirdeye-ui/src/app/pages/alerts-create-guided-page/setup-dimension-groups/setup-dimension-groups-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-guided-page/setup-dimension-groups/setup-dimension-groups-page.component.tsx
@@ -146,7 +146,7 @@ export const SetupDimensionGroupsPage: FunctionComponent = () => {
         onAlertPropertyChange({
             templateProperties: {
                 ...alert.templateProperties,
-                queryFilters: cohortsResponse?.where || "${queryFilters}",
+                queryFilters: "${queryFilters}",
                 enumerationItems: enumerationItemConfiguration,
             },
         });
@@ -169,9 +169,6 @@ export const SetupDimensionGroupsPage: FunctionComponent = () => {
                 </Grid>
                 <Grid item xs={12}>
                     <DatasetDetails
-                        initialQuery={
-                            alert.templateProperties.queryFilters as string
-                        }
                         initialSelectedAggregationFunc={
                             alert.templateProperties
                                 .aggregationFunction as MetricAggFunction

--- a/thirdeye-ui/src/app/pages/alerts-create-guided-page/setup-dimension-groups/setup-dimension-groups-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-guided-page/setup-dimension-groups/setup-dimension-groups-page.component.tsx
@@ -146,7 +146,7 @@ export const SetupDimensionGroupsPage: FunctionComponent = () => {
         onAlertPropertyChange({
             templateProperties: {
                 ...alert.templateProperties,
-                queryFilters: "${queryFilters}",
+                queryFilters: cohortsResponse?.where || "${queryFilters}",
                 enumerationItems: enumerationItemConfiguration,
             },
         });
@@ -169,6 +169,9 @@ export const SetupDimensionGroupsPage: FunctionComponent = () => {
                 </Grid>
                 <Grid item xs={12}>
                     <DatasetDetails
+                        initialQuery={
+                            alert.templateProperties.queryFilters as string
+                        }
                         initialSelectedAggregationFunc={
                             alert.templateProperties
                                 .aggregationFunction as MetricAggFunction

--- a/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import { AxiosError } from "axios/index";
 import React, { FunctionComponent, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -25,11 +26,14 @@ import { handleCreateAlertClickGenerator } from "../../utils/anomalies/anomalies
 import { notifyIfErrors } from "../../utils/notifications/notifications.util";
 import { getErrorMessages } from "../../utils/rest/rest.util";
 import { getAlertsAlertPath } from "../../utils/routes/routes.util";
+import {
+    SessionStorageKeys,
+    useSessionStorage,
+} from "../../utils/storage/use-session-storage";
 import { createEmptySubscriptionGroup } from "../../utils/subscription-groups/subscription-groups.util";
 import { AlertsEditCreateBasePageComponent } from "../alerts-edit-create-common/alerts-edit-create-base-page.component";
 import { QUERY_PARAM_KEY_ANOMALIES_RETRY } from "../alerts-view-page/alerts-view-page.utils";
 import { AlertsCreatePageProps } from "./alerts-create-page.interfaces";
-import { AxiosError } from "axios/index";
 
 export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
     startingAlertConfiguration,
@@ -41,6 +45,10 @@ export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
         SubscriptionGroup[]
     >([]);
     const [isEditRequestInFlight, setIsEditRequestInFlight] = useState(false);
+    const [, , clearSelectedDimensions] = useSessionStorage<string[]>(
+        SessionStorageKeys.SelectedDimensionsOnAlertFlow,
+        []
+    );
 
     const [singleNewSubscriptionGroup, setSingleNewSubscriptionGroup] =
         useState<SubscriptionGroup>(createEmptySubscriptionGroup());
@@ -50,6 +58,9 @@ export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
             const searchParams = new URLSearchParams([
                 [QUERY_PARAM_KEY_ANOMALIES_RETRY, "true"],
             ]);
+            // Guided alert flow sets the selected dimensions as cache. Clear them since
+            // the alert has been created and the user will not go back from here.
+            clearSelectedDimensions();
             navigate(getAlertsAlertPath(savedAlert.id, searchParams));
         });
     }, [navigate, notify, t]);

--- a/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
@@ -49,6 +49,10 @@ export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
         SessionStorageKeys.SelectedDimensionsOnAlertFlow,
         []
     );
+    const [, , clearQueryFilter] = useSessionStorage<string>(
+        SessionStorageKeys.QueryFilterOnAlertFlow,
+        ""
+    );
 
     const [singleNewSubscriptionGroup, setSingleNewSubscriptionGroup] =
         useState<SubscriptionGroup>(createEmptySubscriptionGroup());
@@ -58,9 +62,10 @@ export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
             const searchParams = new URLSearchParams([
                 [QUERY_PARAM_KEY_ANOMALIES_RETRY, "true"],
             ]);
-            // Guided alert flow sets the selected dimensions as cache. Clear them since
-            // the alert has been created and the user will not go back from here.
+            // Guided alert flow sets the selected dimensions and applied query filter as cache.
+            // Clear them since the alert has been created and the user will not go back from here.
             clearSelectedDimensions();
+            clearQueryFilter();
             navigate(getAlertsAlertPath(savedAlert.id, searchParams));
         });
     }, [navigate, notify, t]);

--- a/thirdeye-ui/src/app/rest/dto/rca.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/rca.interfaces.ts
@@ -162,6 +162,7 @@ export interface CohortDetectionResponse {
     maxDepth: number;
     resultSize: number;
     results: CohortResult[];
+    where: string; // For queryFilter value
 }
 
 export interface CohortResult {

--- a/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
+++ b/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { useState } from "react";
+
+export type UseSessionStorageReturn<T> = [T, (newVal: T) => void];
+
+const getDefaultStoredValue = <T>(
+    keyName: SessionStorageKeys,
+    defaultValue: T
+): T => {
+    try {
+        const value = window.sessionStorage.getItem(keyName);
+
+        if (value) {
+            return JSON.parse(value) as unknown as T;
+        } else {
+            window.sessionStorage.setItem(
+                keyName,
+                JSON.stringify(defaultValue)
+            );
+
+            return defaultValue;
+        }
+    } catch (err) {
+        return defaultValue;
+    }
+};
+
+export const useSessionStorage = <T = string>(
+    keyName: SessionStorageKeys,
+    defaultValue: T
+): UseSessionStorageReturn<T> => {
+    const [storedValue, setStoredValue] = useState<T>(
+        getDefaultStoredValue(keyName, defaultValue)
+    );
+
+    const setValue = (newValue: T): void => {
+        try {
+            window.sessionStorage.setItem(keyName, JSON.stringify(newValue));
+        } catch (err) {
+            console.error(`Unable to save new value for ${keyName} to storage`);
+        }
+        setStoredValue(newValue);
+    };
+
+    return [storedValue, setValue];
+};
+
+// Add keys here to use this hook. This centralized store ensures
+// that values aren't unintentionally read / overwritten
+export enum SessionStorageKeys {
+    SelectedDimensionsOnAlertFlow = "SelectedDimensionsOnAlertFlow",
+}

--- a/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
+++ b/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
@@ -59,7 +59,7 @@ export const useSessionStorage = <T = string>(
         try {
             window.sessionStorage.removeItem(keyName);
         } catch (err) {
-            console.error(`Unable to delete value for ${keyName} from`);
+            console.error(`Unable to delete value for ${keyName} from storage`);
         }
     };
 

--- a/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
+++ b/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
@@ -70,4 +70,5 @@ export const useSessionStorage = <T = string>(
 // that values aren't unintentionally read / overwritten
 export enum SessionStorageKeys {
     SelectedDimensionsOnAlertFlow = "SelectedDimensionsOnAlertFlow",
+    QueryFilterOnAlertFlow = "QueryFilterOnAlertFlow",
 }

--- a/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
+++ b/thirdeye-ui/src/app/utils/storage/use-session-storage.ts
@@ -14,7 +14,7 @@
  */
 import { useState } from "react";
 
-export type UseSessionStorageReturn<T> = [T, (newVal: T) => void];
+export type UseSessionStorageReturn<T> = [T, (newVal: T) => void, () => void];
 
 const getDefaultStoredValue = <T>(
     keyName: SessionStorageKeys,
@@ -55,7 +55,15 @@ export const useSessionStorage = <T = string>(
         setStoredValue(newValue);
     };
 
-    return [storedValue, setValue];
+    const deleteValue = (): void => {
+        try {
+            window.sessionStorage.removeItem(keyName);
+        } catch (err) {
+            console.error(`Unable to delete value for ${keyName} from`);
+        }
+    };
+
+    return [storedValue, setValue, deleteValue];
 };
 
 // Add keys here to use this hook. This centralized store ensures


### PR DESCRIPTION
#### Issue(s)

[TE-2049](https://startree.atlassian.net/browse/TE-2049)

#### Description

- Adds a `useSessionStorage` hook.
- Retains the `selectedDimensions` selection on the `Multi-dimension setup` page until the user completes the wizard ...or closes the browser session.
  - Also shows the previously selected cohorts
  - The entered custom `queryFilter` is also updated and retained.

#### Screenshots


https://github.com/startreedata/thirdeye/assets/20799363/d2bc18d4-ef33-4922-b196-39661ab8d9ba

