### PR TITLE
chore(ui): TE-2060 fix failing test

### DIFF
--- a/thirdeye-ui/src/app/utils/subscription-groups/subscription-groups.util.test.ts
+++ b/thirdeye-ui/src/app/utils/subscription-groups/subscription-groups.util.test.ts
@@ -266,7 +266,6 @@ describe("Subscription Groups Util", () => {
 const mockEmptySubscriptionGroup = {
     name: "",
     cron: "0 */5 * * * ?",
-    alerts: [],
     alertAssociations: [] as AlertAssociation[],
 };
 

--- a/thirdeye-ui/src/app/utils/subscription-groups/subscription-groups.util.ts
+++ b/thirdeye-ui/src/app/utils/subscription-groups/subscription-groups.util.ts
@@ -31,6 +31,7 @@ export const createEmptySubscriptionGroup = (): SubscriptionGroup => {
     return {
         name: "",
         cron: "0 */5 * * * ?",
+        alerts: [] as Alert[],
         alertAssociations: [] as AlertAssociation[],
     } as SubscriptionGroup;
 };

--- a/thirdeye-ui/src/app/utils/subscription-groups/subscription-groups.util.ts
+++ b/thirdeye-ui/src/app/utils/subscription-groups/subscription-groups.util.ts
@@ -31,7 +31,6 @@ export const createEmptySubscriptionGroup = (): SubscriptionGroup => {
     return {
         name: "",
         cron: "0 */5 * * * ?",
-        alerts: [] as Alert[],
         alertAssociations: [] as AlertAssociation[],
     } as SubscriptionGroup;
 };


### PR DESCRIPTION
#### Issue(s)

[TE-2060](https://startree.atlassian.net/browse/TE-2060)

#### Description

Fix failing test in subscription group. `subscriptionGroup.alerts` is deprecated, but the test was still expecting it.

<img width="327" alt="Screenshot 2024-01-23 at 19 53 44" src="https://github.com/startreedata/thirdeye/assets/20799363/89df1c57-6d91-454e-b2c8-220aae32dcca">

