### PR TITLE
fix(ui): TE-2049 ensure the alert creation data does not persist beyond the flow

### DIFF
--- a/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-base-page.component.tsx
@@ -26,10 +26,6 @@ import { handleCreateAlertClickGenerator } from "../../utils/anomalies/anomalies
 import { notifyIfErrors } from "../../utils/notifications/notifications.util";
 import { getErrorMessages } from "../../utils/rest/rest.util";
 import { getAlertsAlertPath } from "../../utils/routes/routes.util";
-import {
-    SessionStorageKeys,
-    useSessionStorage,
-} from "../../utils/storage/use-session-storage";
 import { createEmptySubscriptionGroup } from "../../utils/subscription-groups/subscription-groups.util";
 import { AlertsEditCreateBasePageComponent } from "../alerts-edit-create-common/alerts-edit-create-base-page.component";
 import { QUERY_PARAM_KEY_ANOMALIES_RETRY } from "../alerts-view-page/alerts-view-page.utils";
@@ -45,14 +41,6 @@ export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
         SubscriptionGroup[]
     >([]);
     const [isEditRequestInFlight, setIsEditRequestInFlight] = useState(false);
-    const [, , clearSelectedDimensions] = useSessionStorage<string[]>(
-        SessionStorageKeys.SelectedDimensionsOnAlertFlow,
-        []
-    );
-    const [, , clearQueryFilter] = useSessionStorage<string>(
-        SessionStorageKeys.QueryFilterOnAlertFlow,
-        ""
-    );
 
     const [singleNewSubscriptionGroup, setSingleNewSubscriptionGroup] =
         useState<SubscriptionGroup>(createEmptySubscriptionGroup());
@@ -62,10 +50,6 @@ export const AlertsCreateBasePage: FunctionComponent<AlertsCreatePageProps> = ({
             const searchParams = new URLSearchParams([
                 [QUERY_PARAM_KEY_ANOMALIES_RETRY, "true"],
             ]);
-            // Guided alert flow sets the selected dimensions and applied query filter as cache.
-            // Clear them since the alert has been created and the user will not go back from here.
-            clearSelectedDimensions();
-            clearQueryFilter();
             navigate(getAlertsAlertPath(savedAlert.id, searchParams));
         });
     }, [navigate, notify, t]);


### PR DESCRIPTION
#### Issue(s)

[TE-2049](https://startree.atlassian.net/browse/TE-2049)

#### Description

Fixes the value persistence for state values for the alert creation flow. The values are cleared from session storage when the user enters / leaves the flow, instead of just on creation.

#### Screenshots

https://github.com/startreedata/thirdeye/assets/20799363/197cd445-ba4c-46a7-a4a8-4870245873fd

