### PR TITLE
[worker] force in-order task execution and prevent concurrent tasks for a same entity 

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -43,9 +43,7 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -132,6 +130,11 @@ public class TaskManagerImpl implements TaskManager {
       return null;
     }
     return dtos.get(0);
+  }
+
+  @Override
+  public TaskDTO acquireTask(final TaskDTO taskDTO) {
+    return null;
   }
 
   @Override

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -41,6 +41,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -120,14 +121,17 @@ public class TaskManagerImpl implements TaskManager {
   }
 
   @Override
-  public List<TaskDTO> findByStatusOrderByCreateTime(final TaskStatus status, final int fetchSize,
-      final boolean asc) {
-    final Map<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put("status", status.toString());
-    final String queryClause = (asc)
-        ? FIND_BY_STATUS_ORDER_BY_CREATE_TIME_ASC + fetchSize
-        : FIND_BY_STATUS_ORDER_BY_CREATE_TIME_DESC + fetchSize;
-    return dao.executeParameterizedSQL(queryClause, parameterMap);
+  public TaskDTO findNextTaskToRun() {
+    final String queryClause = """
+        WHERE status = 'WAITING'
+        AND ref_id not in (select ref_id from task_entity where status = 'RUNNING')
+        ORDER BY create_time ASC LIMIT 1
+        """;
+    final List<TaskDTO> dtos = dao.executeParameterizedSQL(queryClause, Collections.emptyMap());
+    if (dtos.isEmpty()) {
+      return null;
+    }
+    return dtos.get(0);
   }
 
   @Override
@@ -276,29 +280,29 @@ public class TaskManagerImpl implements TaskManager {
     // deprecated - use thirdeye_tasks
     metricRegistry.register("taskCountTotal",
         new CachedGauge<Long>(METRICS_CACHE_TIMEOUT.toMinutes(), TimeUnit.MINUTES) {
-      @Override
-      protected Long loadValue() {
-        return count();
-      }
-    });
+          @Override
+          protected Long loadValue() {
+            return count();
+          }
+        });
 
     // deprecated - use thirdeye_task_latency
     metricRegistry.register("detectionTaskLatencyInMillis",
         new CachedGauge<Long>(METRICS_CACHE_TIMEOUT.toMinutes(), TimeUnit.MINUTES) {
-      @Override
-      protected Long loadValue() {
-        return getTaskLatency(TaskType.DETECTION);
-      }
-    });
+          @Override
+          protected Long loadValue() {
+            return getTaskLatency(TaskType.DETECTION);
+          }
+        });
 
     // deprecated - use thirdeye_task_latency
     metricRegistry.register("notificationTaskLatencyInMillis",
         new CachedGauge<Long>(METRICS_CACHE_TIMEOUT.toMinutes(), TimeUnit.MINUTES) {
-      @Override
-      protected Long loadValue() {
-        return getTaskLatency(TaskType.NOTIFICATION);
-      }
-    });
+          @Override
+          protected Long loadValue() {
+            return getTaskLatency(TaskType.NOTIFICATION);
+          }
+        });
 
     for (final TaskStatus status : TaskStatus.values()) {
       registerStatusMetric(status);

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
@@ -148,7 +148,7 @@ public class TaskDao {
       final TaskEntity entity = toEntity(pojo);
       return transactionService.executeTransaction(
           (connection) -> databaseService.update(entity, predicate, connection),
-          null);
+          0);
     } catch (JsonProcessingException | SQLException e) {
       LOG.error(e.getMessage(), e);
       return 0;

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/util/SqlQueryBuilder.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/util/SqlQueryBuilder.java
@@ -49,9 +49,8 @@ public class SqlQueryBuilder {
   private static final Logger LOG = LoggerFactory.getLogger(SqlQueryBuilder.class);
 
   private static final String NAME_REGEX = "[a-z][_a-z0-9]*";
-  private static final String PARAM_REGEX = ":(" + NAME_REGEX + ")";
   private static final Pattern PARAM_PATTERN =
-      Pattern.compile(PARAM_REGEX, Pattern.CASE_INSENSITIVE);
+      Pattern.compile(":(" + NAME_REGEX + ")", Pattern.CASE_INSENSITIVE);
   private static final Set<String> AUTO_UPDATE_COLUMN_SET =
       Sets.newHashSet("id", "last_modified");
   //insert sql per table

--- a/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -100,21 +100,21 @@ public class TestAnomalyTaskManager {
   }
 
   @Test(dependsOnMethods = {"testFindAll"})
-  public void testUpdateStatusAndWorkerId() {
+  public void testAcquireTaskToRun() {
     CLOCK.tick(1);
     Long workerId = 1L;
     TaskDTO taskDTO = taskDAO.findById(anomalyTaskId1);
-    boolean status =
-        taskDAO.updateStatusAndWorkerId(workerId, anomalyTaskId1, allowedOldTaskStatus,
-            taskDTO.getVersion());
+    final long currentVersion = taskDTO.getVersion();
+    boolean status = taskDAO.acquireTaskToRun(taskDTO, workerId);
+    // refetch task from the persistence layer and check its values
     TaskDTO anomalyTask = taskDAO.findById(anomalyTaskId1);
     Assert.assertTrue(status);
     Assert.assertEquals(anomalyTask.getStatus(), TaskStatus.RUNNING);
     Assert.assertEquals(anomalyTask.getWorkerId(), workerId);
-    Assert.assertEquals(anomalyTask.getVersion(), taskDTO.getVersion() + 1);
+    Assert.assertEquals(anomalyTask.getVersion(), currentVersion + 1);
   }
 
-  @Test(dependsOnMethods = {"testUpdateStatusAndWorkerId"})
+  @Test(dependsOnMethods = {"testAcquireTaskToRun"})
   public void testFindNextTaskToRun() {
     TaskDTO anomalyTask = taskDAO.findNextTaskToRun();
     assertThat(anomalyTask).isNotNull();

--- a/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -116,9 +116,8 @@ public class TestAnomalyTaskManager {
 
   @Test(dependsOnMethods = {"testUpdateStatusAndWorkerId"})
   public void testFindByStatusOrderByCreationTimeAsc() {
-    List<TaskDTO> anomalyTasks =
-        taskDAO.findByStatusOrderByCreateTime(TaskStatus.WAITING, Integer.MAX_VALUE, true);
-    Assert.assertEquals(anomalyTasks.size(), 1);
+    TaskDTO anomalyTask = taskDAO.findNextTaskToRun();
+    assertThat(anomalyTask).isNotNull();
   }
 
   @Test(dependsOnMethods = {"testFindByStatusOrderByCreationTimeAsc"})

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
@@ -34,7 +34,7 @@ public interface TaskManager extends AbstractManager<TaskDTO> {
 
   List<TaskDTO> findTimeoutTasksWithinDays(int days, long maxTaskTime);
 
-  List<TaskDTO> findByStatusOrderByCreateTime(TaskStatus status, int fetchSize, boolean asc);
+  TaskDTO findNextTaskToRun();
 
   List<TaskDTO> findByStatusAndWorkerId(Long workerId, TaskStatus status);
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
@@ -35,6 +35,8 @@ public interface TaskManager extends AbstractManager<TaskDTO> {
   List<TaskDTO> findTimeoutTasksWithinDays(int days, long maxTaskTime);
 
   TaskDTO findNextTaskToRun();
+  
+  TaskDTO acquireTask(TaskDTO taskDTO);
 
   List<TaskDTO> findByStatusAndWorkerId(Long workerId, TaskStatus status);
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
@@ -36,7 +36,7 @@ public interface TaskManager extends AbstractManager<TaskDTO> {
 
   TaskDTO findNextTaskToRun();
   
-  TaskDTO acquireTask(TaskDTO taskDTO);
+  boolean acquireTaskToRun(TaskDTO taskDTO, final long workerId);
 
   List<TaskDTO> findByStatusAndWorkerId(Long workerId, TaskStatus status);
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.util.List;
-import java.util.Set;
 
 public interface TaskManager extends AbstractManager<TaskDTO> {
 
@@ -39,9 +38,6 @@ public interface TaskManager extends AbstractManager<TaskDTO> {
   boolean acquireTaskToRun(TaskDTO taskDTO, final long workerId);
 
   List<TaskDTO> findByStatusAndWorkerId(Long workerId, TaskStatus status);
-
-  boolean updateStatusAndWorkerId(Long workerId, Long id, Set<TaskStatus> allowedOldStatus,
-      int expectedVersion);
 
   void updateStatusAndTaskEndTime(Long id, TaskStatus oldStatus, TaskStatus newStatus,
       Long taskEndTime, String message);

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/health/DetectionTaskStatus.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/detection/health/DetectionTaskStatus.java
@@ -16,7 +16,6 @@ package ai.startree.thirdeye.spi.detection.health;
 import ai.startree.thirdeye.spi.datalayer.dto.TaskDTO;
 import ai.startree.thirdeye.spi.task.TaskStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -46,11 +45,12 @@ public class DetectionTaskStatus {
 
   // the counting for detection task status
   @JsonProperty
-  private final Map<TaskStatus, Long> taskCounts = new HashMap<TaskStatus, Long>() {{
+  private final Map<TaskStatus, Long> taskCounts = new HashMap<>() {{
     put(TaskStatus.COMPLETED, 0L);
     put(TaskStatus.FAILED, 0L);
     put(TaskStatus.WAITING, 0L);
     put(TaskStatus.TIMEOUT, 0L);
+    put(TaskStatus.RUNNING, 0L);
   }};
 
   // the list of tasks for the detection config
@@ -67,14 +67,6 @@ public class DetectionTaskStatus {
     this.tasks = tasks;
     this.taskCounts.putAll(counts);
     this.lastTaskExecutionTime = lastTaskExecutionTime;
-  }
-
-  // default constructor for deserialization
-  public DetectionTaskStatus() {
-    this.taskSuccessRate = Double.NaN;
-    this.healthStatus = HealthStatus.UNKNOWN;
-    this.tasks = Collections.emptyList();
-    this.lastTaskExecutionTime = -1L;
   }
 
   public double getTaskSuccessRate() {

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -116,11 +116,10 @@ public class TaskDriverRunnable implements Runnable {
     while (!isShutdown()) {
       // select a task to execute, and update it to RUNNING
       final TaskDTO taskDTO = waitForTask();
-      if (taskDTO == null || isShutdown()) {
+      if (taskDTO == null) {
         continue;
       }
-
-      // a task has acquired and we must finish executing it before termination
+      // a task was acquired - try to finish executing it before termination
       taskRunningTimer.time(() -> runTask(taskDTO));
     }
     LOG.info(String.format("TaskDriverRunnable safely quitting. name: %s",
@@ -214,7 +213,6 @@ public class TaskDriverRunnable implements Runnable {
         break;
       }
       try {
-        // FIXME CYRIL I AM HERE - replace updateStatusAndWorkerId in tests
         boolean success = taskManager.acquireTaskToRun(nextTask, workerId);
         if (success) {
           final long waitTime = System.currentTimeMillis() - nextTask.getCreateTime().getTime();

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -24,14 +24,12 @@ import ai.startree.thirdeye.spi.task.TaskType;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Singleton;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer.Sample;
 import java.io.IOException;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -44,10 +42,6 @@ public class TaskDriverRunnable implements Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskDriverRunnable.class);
   private static final Random RANDOM = new Random();
-  private static final Set<TaskStatus> ALLOWED_OLD_TASK_STATUS = ImmutableSet.of(
-      TaskStatus.FAILED,
-      TaskStatus.WAITING
-  );
 
   private final TaskManager taskManager;
   private final TaskContext taskContext;

--- a/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
+++ b/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
@@ -16,7 +16,6 @@ package ai.startree.thirdeye.worker.task;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -36,7 +35,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Timestamp;
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -99,8 +97,7 @@ public class HeartbeatTest {
   public void heartbeatPulseCheck() {
     final Timestamp startTime = new Timestamp(System.currentTimeMillis());
     final TaskDTO taskDTO = newTask();
-    when(taskManager.findByStatusOrderByCreateTime(eq(TaskStatus.WAITING), anyInt(), anyBoolean()))
-        .thenAnswer(i -> pollingCount++ == 0? List.of(taskDTO) : List.of());
+    when(taskManager.findNextTaskToRun()).thenAnswer(i -> pollingCount++ == 0? taskDTO : null);
 
     doAnswer(invocation -> {
       taskDTO.setStatus(TaskStatus.COMPLETED);

--- a/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
+++ b/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
@@ -16,9 +16,7 @@ package ai.startree.thirdeye.worker.task;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -73,7 +71,7 @@ public class HeartbeatTest {
         .setHeartbeatInterval(HEARTBEAT_INTERVAL);
 
     taskManager = Mockito.mock(TaskManager.class);
-    when(taskManager.updateStatusAndWorkerId(anyLong(), anyLong(), anySet(), anyInt()))
+    when(taskManager.acquireTaskToRun(any(), anyLong()))
         .thenReturn(true);
 
     doNothing().when(taskManager)


### PR DESCRIPTION
- **[spi] clean DetectionTaskStatus**
- **always run tasks in order**
- **fetch tasks in order and without concurrency between refs**
