### PR TITLE
fix(ui): TE-2175 improve onboarding datasource configuration

### DIFF
--- a/thirdeye-ui/src/app/rest/dto/datasource.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/datasource.interfaces.ts
@@ -13,11 +13,12 @@
  * the License.
  */
 export interface Datasource {
-    id: number;
+    id?: number;
     name: string;
     type: string;
     properties: DatasourceProperties;
     metaList?: DatasourceMetaList[];
+    defaultQueryOptions?: { [key: string]: string };
 }
 
 export interface DatasourceProperties {

--- a/thirdeye-ui/src/app/utils/datasources/datasources.util.test.ts
+++ b/thirdeye-ui/src/app/utils/datasources/datasources.util.test.ts
@@ -102,6 +102,7 @@ describe("Datasources Util", () => {
 const mockDefaultDatasource = {
     name: "mypinot",
     type: "pinot",
+    defaultQueryOptions: { timeoutMs: "30000" },
     properties: {
         brokerUrl: "localhost:8000",
         clusterName: "QuickStartCluster",

--- a/thirdeye-ui/src/app/utils/datasources/datasources.util.ts
+++ b/thirdeye-ui/src/app/utils/datasources/datasources.util.ts
@@ -30,6 +30,7 @@ export const createDefaultDatasource = (): Datasource => {
         return {
             name: "mypinot",
             type: "pinot",
+            defaultQueryOptions: { timeoutMs: "30000" },
             properties: {
                 zookeeperUrl: "localhost:2123",
                 clusterName: "QuickStartCluster",
@@ -44,6 +45,7 @@ export const createDefaultDatasource = (): Datasource => {
     return {
         name: "mypinot",
         type: "pinot",
+        defaultQueryOptions: { timeoutMs: "30000" },
         properties: {
             zookeeperUrl:
                 "pinot-zookeeper-headless.managed.svc.cluster.local:2181",
@@ -141,7 +143,7 @@ const getUiDatasourceInternal = (datasource: Datasource): UiDatasource => {
     uiDatasource.datasource = datasource;
 
     // Basic properties
-    uiDatasource.id = datasource.id;
+    uiDatasource.id = datasource.id || -1;
     uiDatasource.name = datasource.name || noDataMarker;
     uiDatasource.type = datasource.type || noDataMarker;
 


### PR DESCRIPTION
Add a custom query timeout to the default configuration provided by the frontend.

<img width="1476" alt="Screenshot 2024-03-05 at 17 48 49" src="https://github.com/startreedata/thirdeye/assets/27781189/677fc7fa-6b87-4087-b81f-997e8dda59ab">
