### PR TITLE
fix(ui): TE-2130 add checkbox to slack edit and view for subscription group spec

### DIFF
--- a/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
@@ -14,7 +14,7 @@
  */
 
 import { Icon } from "@iconify/react";
-import { Box } from "@material-ui/core";
+import { Box, Switch } from "@material-ui/core";
 import React from "react";
 import { TFunction } from "react-i18next";
 import { lightV1 } from "../../../platform/utils";
@@ -79,6 +79,20 @@ export const getCardProps = (
             cardProps.rows.push({
                 label: t("label.url"),
                 value: channel.params.webhookUrl,
+            });
+
+            cardProps.rows.push({
+                label: t("message.notify-when-the-anomaly-period-ends"),
+                value: (
+                    <Box clone ml={-1.25}>
+                        <Switch
+                            disabled
+                            checked={channel.params.notifyResolvedAnomalies}
+                            color="primary"
+                            size="small"
+                        />
+                    </Box>
+                ),
             });
 
             break;

--- a/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
@@ -14,7 +14,8 @@
  */
 
 import { Icon } from "@iconify/react";
-import { Box, Switch } from "@material-ui/core";
+import Box from "@material-ui/core/Box";
+import Checkbox from "@material-ui/core/Checkbox";
 import React from "react";
 import { TFunction } from "react-i18next";
 import { lightV1 } from "../../../platform/utils";
@@ -85,7 +86,7 @@ export const getCardProps = (
                 label: t("message.notify-when-the-anomaly-period-ends"),
                 value: (
                     <Box clone ml={-1.25}>
-                        <Switch
+                        <Checkbox
                             disabled
                             checked={channel.params.notifyResolvedAnomalies}
                             color="primary"

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/groups-editor.component.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/groups-editor.component.tsx
@@ -69,6 +69,7 @@ export const GroupsEditor: FunctionComponent<GroupsEditorProps> = ({
                             type: SpecType.Slack,
                             params: {
                                 webhookUrl: "",
+                                notifyResolvedAnomalies: false,
                             },
                         },
                     ];

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.component.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.component.tsx
@@ -167,10 +167,6 @@ export const Slack: FunctionComponent<SlackProps> = ({
                             <InputSection
                                 inputComponent={
                                     <FormControlLabel
-                                        // eslint-disable-next-line max-len
-                                        // `control` needs to be passed on differently for checkbox
-                                        // eslint-disable-next-line max-len
-                                        // https://stackoverflow.com/questions/62291962/react-hook-forms-material-ui-checkboxes
                                         checked={value}
                                         control={<Checkbox color="primary" />}
                                         label={

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.component.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.component.tsx
@@ -19,6 +19,8 @@ import {
     Button,
     Card,
     CardContent,
+    Checkbox,
+    FormControlLabel,
     FormHelperText,
     Grid,
     TextField,
@@ -26,7 +28,7 @@ import {
     useTheme,
 } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import { LocalThemeProviderV1 } from "../../../../../../platform/components";
@@ -48,6 +50,7 @@ export const Slack: FunctionComponent<SlackProps> = ({
     const {
         register,
         formState: { errors },
+        control,
     } = useForm<SlackFormEntries>({
         mode: "onChange",
         reValidateMode: "onChange",
@@ -58,6 +61,7 @@ export const Slack: FunctionComponent<SlackProps> = ({
                     .string()
                     .trim()
                     .required(t("message.url-required")),
+                notifyResolvedAnomalies: yup.boolean().optional(),
             })
         ),
     });
@@ -67,6 +71,15 @@ export const Slack: FunctionComponent<SlackProps> = ({
             ...configuration,
         };
         copied.params.webhookUrl = newValue;
+
+        onSpecChange(copied);
+    };
+
+    const handleNotifyResolvedAnomaliesChange = (newValue: boolean): void => {
+        const copied = {
+            ...configuration,
+        };
+        copied.params.notifyResolvedAnomalies = newValue;
 
         onSpecChange(copied);
     };
@@ -144,6 +157,40 @@ export const Slack: FunctionComponent<SlackProps> = ({
                             </>
                         }
                         label={t("label.slack-url")}
+                    />
+                </Grid>
+                <Grid container>
+                    <Controller
+                        control={control}
+                        name="notifyResolvedAnomalies"
+                        render={({ field: { name, value, onChange } }) => (
+                            <InputSection
+                                inputComponent={
+                                    <FormControlLabel
+                                        // eslint-disable-next-line max-len
+                                        // `control` needs to be passed on differently for checkbox
+                                        // eslint-disable-next-line max-len
+                                        // https://stackoverflow.com/questions/62291962/react-hook-forms-material-ui-checkboxes
+                                        checked={value}
+                                        control={<Checkbox color="primary" />}
+                                        label={
+                                            <Typography variant="body2">
+                                                {t(
+                                                    "message.notify-when-the-anomaly-period-ends"
+                                                )}
+                                            </Typography>
+                                        }
+                                        name={name}
+                                        onChange={(_e, checked) => {
+                                            onChange(checked);
+                                            handleNotifyResolvedAnomaliesChange(
+                                                checked
+                                            );
+                                        }}
+                                    />
+                                }
+                            />
+                        )}
                     />
                 </Grid>
             </CardContent>

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.interfaces.ts
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.interfaces.ts
@@ -22,4 +22,5 @@ export interface SlackProps {
 
 export interface SlackFormEntries {
     webhookUrl: string;
+    notifyResolvedAnomalies: boolean;
 }

--- a/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.test.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-wizard/subscription-group-details/recipient-details/groups-editor/slack/slack.test.tsx
@@ -98,5 +98,6 @@ const MOCK_CONFIGURATION: SlackSpec = {
     type: SpecType.Slack,
     params: {
         webhookUrl: INITIAL_URL,
+        notifyResolvedAnomalies: false,
     },
 };

--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -682,6 +682,7 @@
         "no-this-is-an-anomaly": "No, this is not an anomaly",
         "no-this-is-not-an-anomaly": "No, this is not an anomaly",
         "non-dimension-exploration-alert": "Not a dimension exploration alert",
+        "notify-when-the-anomaly-period-ends": "Notify when the anomaly period ends",
         "num-delete-error": "{{num}} {{entity}} experienced issues while attempting to delete",
         "num-delete-success": "{{num}} {{entity}} deleted successfully",
         "num-metrics": "{{num}} metrics",

--- a/thirdeye-ui/src/app/rest/dto/subscription-group.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/subscription-group.interfaces.ts
@@ -51,6 +51,7 @@ export interface SlackSpec extends SpecConfiguration {
     type: SpecType.Slack;
     params: {
         webhookUrl: string;
+        notifyResolvedAnomalies: boolean;
     };
 }
 


### PR DESCRIPTION
#### Issue(s)

[TE-2130](https://startree.atlassian.net/browse/TE-2130)
[UX Mocks](https://www.figma.com/file/9pj4WGZBSNweOeeRKGeSnF/Subscription-groups-%2F-New-feature-%2F-Notification-when-anomaly-is-over?type=design&node-id=612-31389&mode=design&t=iJ9ilvkcHaFldUWB-0)

#### Description

- Add a checkbox for `Notify when the anomaly period ends` for slack spec in subscription groups
- Show the corresponding value as readonly in spec view

#### Screenshots

![Screenshot 2024-03-12 at 19 22 58](https://github.com/startreedata/thirdeye/assets/20799363/77819fd5-3efc-4dcd-a83b-ba22b59b4202)

![Screenshot 2024-03-12 at 19 35 50](https://github.com/startreedata/thirdeye/assets/20799363/33e16b8b-7ed9-4d48-bb8e-60ce17e0d49e)
