### PR TITLE
fix(ui): TE-2112 ux feedback improvements for rca page

### DIFF
--- a/thirdeye-ui/src/app/components/rca/top-contributors-section/top-contributors-section.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/top-contributors-section/top-contributors-section.component.tsx
@@ -12,21 +12,21 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import Accordion from "@material-ui/core/Accordion";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import every from "lodash/every";
 import isEmpty from "lodash/isEmpty";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useOutletContext, useParams } from "react-router-dom";
-import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
-import { EmptyStateSwitch } from "../../page-states/empty-state-switch/empty-state-switch.component";
-import { LoadingErrorStateSwitch } from "../../page-states/loading-error-state-switch/loading-error-state-switch.component";
-import { AnomalyFilterOption } from "../anomaly-dimension-analysis/anomaly-dimension-analysis.interfaces";
-import { PreviewChart } from "../top-contributors-table/preview-chart/preview-chart.component";
-import { TopContributorsTable } from "../top-contributors-table/top-contributors-table.component";
+import { InvestigationContext } from "../../../pages/rca/investigation-state-tracker-container-page/investigation-state-tracker.interfaces";
+import { RootCauseAnalysisForAnomalyPageParams } from "../../../pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.interfaces";
 import {
     SkeletonV1,
     useNotificationProviderV1,
@@ -40,18 +40,17 @@ import { areFiltersEqual } from "../../../utils/anomaly-dimension-analysis/anoma
 import { getFromSavedInvestigationOrDefault } from "../../../utils/investigation/investigation.util";
 import { notifyIfErrors } from "../../../utils/notifications/notifications.util";
 import { serializeKeyValuePair } from "../../../utils/params/params.util";
-import { RootCauseAnalysisForAnomalyPageParams } from "../../../pages/root-cause-analysis-for-anomaly-page/root-cause-analysis-for-anomaly-page.interfaces";
-import { InvestigationContext } from "../../../pages/rca/investigation-state-tracker-container-page/investigation-state-tracker.interfaces";
+import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
+import { EmptyStateSwitch } from "../../page-states/empty-state-switch/empty-state-switch.component";
+import { LoadingErrorStateSwitch } from "../../page-states/loading-error-state-switch/loading-error-state-switch.component";
+import { AnomalyFilterOption } from "../anomaly-dimension-analysis/anomaly-dimension-analysis.interfaces";
+import { PreviewChart } from "../top-contributors-table/preview-chart/preview-chart.component";
+import { TopContributorsTable } from "../top-contributors-table/top-contributors-table.component";
 import { TopContributorsSectionProps } from "./top-contributors-section.interfaces";
-import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
-} from "@material-ui/core";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 export const TopContributorsSection: FunctionComponent<TopContributorsSectionProps> =
     ({ comparisonOffset, anomalyDimensionAnalysisFetch }) => {
+        const [expanded, setExpanded] = useState(true);
         const { notify } = useNotificationProviderV1();
         const { t } = useTranslation();
         const { id: anomalyId } =
@@ -90,6 +89,18 @@ export const TopContributorsSection: FunctionComponent<TopContributorsSectionPro
                     entity: t("label.dimension-analysis-data"),
                 })
             );
+
+            // Collapse the accordion if there is an error OR there is no data to show
+            if (anomalyDimensionAnalysisReqStatus === ActionStatus.Error) {
+                setExpanded(false);
+            }
+
+            if (
+                anomalyDimensionAnalysisReqStatus === ActionStatus.Done &&
+                isEmpty(anomalyDimensionAnalysisData?.responseRows)
+            ) {
+                setExpanded(false);
+            }
         }, [anomalyDimensionAnalysisReqStatus]);
 
         const handleRemoveBtnClick = (idx: number): void => {
@@ -140,7 +151,12 @@ export const TopContributorsSection: FunctionComponent<TopContributorsSectionPro
         };
 
         return (
-            <Accordion defaultExpanded square variant="outlined">
+            <Accordion
+                square
+                expanded={expanded}
+                variant="outlined"
+                onChange={(_e, val) => setExpanded(val)}
+            >
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                     <Typography variant="h5">
                         {t("label.top-contributors")}

--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -723,6 +723,7 @@
         "review-and-configure-data": "Review and configure data",
         "review-anomaly-decision": "Review anomaly decision",
         "review-the-recommended-dimension-combinations": "Review the recommended dimension combinations below determined by ThirdEye based on the time duration in the past used as the comparison. Expand to see more details on why ThirdEye determined them to be a dimension combination of interest. Note that the baseline used for a past date will be different than the \"predicted\" value for the date of the anomaly.",
+        "scroll-down-to-view-heatmap-and-dimension-investigation-preview": "Scroll down to view heatmap and dimension investigation preview",
         "select-a-datasource-to-view-available-datasets-to": "Select a datasource to view available datasets to onboard",
         "select-a-date-range-to-filter-data-by": "Select a date range to filter the data by",
         "select-a-dimension-to-generate-the-anomaly-preview": "Select a dimension to generate the anomaly preview",

--- a/thirdeye-ui/src/app/pages/rca/what-where-page/what-where-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/rca/what-where-page/what-where-page.component.tsx
@@ -12,19 +12,20 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { Grid, Typography } from "@material-ui/core";
+import { Box, Grid, Typography } from "@material-ui/core";
+import { InfoOutlined } from "@material-ui/icons";
 import React, { FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useOutletContext, useSearchParams } from "react-router-dom";
-import { InvestigationPreview } from "../../../components/rca/investigation-preview/investigation-preview.component";
-import { WizardBottomBar } from "../../../components/welcome-onboard-datasource/wizard-bottom-bar/wizard-bottom-bar.component";
-import { AppRouteRelative } from "../../../utils/routes/routes.util";
-import { InvestigationContext } from "../investigation-state-tracker-container-page/investigation-state-tracker.interfaces";
-import { TopContributorsSection } from "../../../components/rca/top-contributors-section/top-contributors-section.component";
-import { HeatMapSection } from "../../../components/rca/heat-map-section/heat-map-section.component";
 import { BaselineOffsetSelection } from "../../../components/rca/analysis-tabs/baseline-offset-selection/baseline-offset-selection.component";
+import { HeatMapSection } from "../../../components/rca/heat-map-section/heat-map-section.component";
+import { InvestigationPreview } from "../../../components/rca/investigation-preview/investigation-preview.component";
+import { TopContributorsSection } from "../../../components/rca/top-contributors-section/top-contributors-section.component";
+import { WizardBottomBar } from "../../../components/welcome-onboard-datasource/wizard-bottom-bar/wizard-bottom-bar.component";
 import { PageContentsCardV1 } from "../../../platform/components";
 import { useGetAnomalyDimensionAnalysis } from "../../../rest/rca/rca.actions";
+import { AppRouteRelative } from "../../../utils/routes/routes.util";
+import { InvestigationContext } from "../investigation-state-tracker-container-page/investigation-state-tracker.interfaces";
 
 export const WhatWherePage: FunctionComponent = () => {
     const { t } = useTranslation();
@@ -64,9 +65,27 @@ export const WhatWherePage: FunctionComponent = () => {
                                 justifyContent="space-between"
                             >
                                 <Grid item>
-                                    {t(
-                                        "message.select-the-top-contributors-to-see-the-dimensions"
-                                    )}
+                                    <Typography variant="body2">
+                                        {t(
+                                            "message.select-the-top-contributors-to-see-the-dimensions"
+                                        )}
+                                    </Typography>
+                                    <Box
+                                        alignItems="center"
+                                        display="flex"
+                                        gridGap={4}
+                                        mt={0.5}
+                                    >
+                                        <InfoOutlined
+                                            color="secondary"
+                                            fontSize="small"
+                                        />
+                                        <Typography variant="caption">
+                                            {t(
+                                                "message.scroll-down-to-view-heatmap-and-dimension-investigation-preview"
+                                            )}
+                                        </Typography>
+                                    </Box>
                                 </Grid>
 
                                 <Grid item>


### PR DESCRIPTION
#### Issue(s)

[TE-2112](https://startree.atlassian.net/browse/TE-2112)

#### Description

- Add an info message `Scroll down to view heatmap and dimension investigation preview` to the top of the page to help users since the page length is usually large

#### Screenshots
![Screenshot 2024-03-22 at 14 49 36](https://github.com/startreedata/thirdeye/assets/20799363/8a9593af-948e-4a09-81aa-70b4291e1381)
Video of two rca pages (as detailed below)

https://github.com/startreedata/thirdeye/assets/20799363/3117893c-f374-4744-b7dc-483541d891dc

#### How to test
1. Go to rca page where top contributors has no value ([example link](https://thirdeye.demo.teprod.startree.cloud/root-cause-analysis/v2/anomaly/358371/investigate/what-where-page?startTime=1700697600000&endTime=1703376000000))
> The `Top Contributors` section should collapse when API fetch is resolved
2. Go to rca page where top contributors has valid data to show ([example link](https://thirdeye.demo.teprod.startree.cloud/root-cause-analysis/v2/anomaly/358500/investigate/what-where-page?startTime=1584144000000&endTime=1586736000000))
> The `Top Contributors` section should stay open and show the data
3. There should be a info message on the top `Scroll down to view heatmap and dimension investigation preview`
