### PR TITLE
fix(ui): TE-2076 show error for invalid alert json

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-json/alert-json.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-json/alert-json.component.tsx
@@ -21,6 +21,7 @@ import { JSONEditorV1 } from "../../../platform/components";
 import { EditableAlert } from "../../../rest/dto/alert.interfaces";
 import { THIRDEYE_DOC_LINK } from "../../../utils/constants/constants.util";
 import { getAlertTemplatesAllPath } from "../../../utils/routes/routes.util";
+import { validateJSON } from "../../../utils/validation/validation.util";
 import { NavigateAlertCreationFlowsDropdown } from "../../alert-wizard-v3/navigate-alert-creation-flows-dropdown/navigate-alert-creation-flows-dropdown";
 import { useAlertWizardV2Styles } from "../alert-wizard-v2.styles";
 import { AlertJsonProps } from "./alert-json.interfaces";
@@ -34,13 +35,21 @@ export const AlertJson: FunctionComponent<AlertJsonProps> = ({
     // proxy the given alert so users can freely type in the json editor
     const [initialAlert] = useState<EditableAlert>(alert);
 
-    const handleJSONChange = (json: string): void => {
+    const [editedAlert, setEditedAlert] = useState<string>(
+        JSON.stringify(alert)
+    );
+
+    const handleJSONChange = (newJson: string): void => {
+        setEditedAlert(newJson);
+
         try {
-            onAlertPropertyChange(JSON.parse(json), true);
+            onAlertPropertyChange(JSON.parse(newJson), true);
         } catch {
             // do nothing if invalid JSON string
         }
     };
+
+    const isAlertValid = validateJSON(editedAlert).valid;
 
     return (
         <Grid container>
@@ -104,6 +113,20 @@ export const AlertJson: FunctionComponent<AlertJsonProps> = ({
                     onChange={handleJSONChange}
                 />
             </Grid>
+
+            {!isAlertValid && (
+                <Grid item xs={12}>
+                    <Alert
+                        icon={<InfoIcon />}
+                        severity="error"
+                        variant="outlined"
+                    >
+                        {t(
+                            "message.invalid-alert-configuration-please-fix-the-configuration"
+                        )}
+                    </Alert>
+                </Grid>
+            )}
         </Grid>
     );
 };

--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -622,6 +622,7 @@
         "how-often-pipeline-checks": "How often the pipeline checks for anomalies in the system",
         "how-to-action-entity": "How to {{action}} {{entity}}?",
         "in-order-to-continue-you-will-need-to-load": "In order to continue, you will need to load the default alert templates",
+        "invalid-alert-configuration-please-fix-the-configuration": "Invalid alert configuration, not saved. Please fix the configuration above to save the latest changes.",
         "invalid-cron-input-1": "Invalid cron input, See ",
         "invalid-cron-input-2": " for more details on the expected format",
         "invalid-email": "Invalid email",


### PR DESCRIPTION
#### Issue(s)

[TE-2076](https://startree.atlassian.net/browse/TE-2076)

#### Description

Show an error message below the alert json editor if the entered json is invalid.

> The current Alert (create / update) flow, by design, it only captures the last valid state of the JSON. This alert textbox will inform the user of that behavior.

The flow is unaffected, this change just shows an error.

#### Screenshots

![Screenshot 2024-04-19 at 01 44 12](https://github.com/startreedata/thirdeye/assets/20799363/fb72b294-b2fc-4cd2-8273-cbf11b87115f)
