### PR TITLE
fix(ui): TE-2134 correct sensitivity range in filters page

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v3/anomalies-filter-panel/anomalies-filter-panel.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/anomalies-filter-panel/anomalies-filter-panel.component.tsx
@@ -107,22 +107,22 @@ export const AnomaliesFilterPanel: FunctionComponent<AnomaliesFilterPanelProps> 
                                                 }
                                                 marks={[
                                                     {
-                                                        value: -14,
+                                                        value: -26.2,
                                                         label: t("label.low"),
                                                     },
                                                     {
-                                                        value: 6,
+                                                        value: -5.65,
                                                         label: t(
                                                             "label.medium"
                                                         ),
                                                     },
                                                     {
-                                                        value: 26,
+                                                        value: 14.9,
                                                         label: t("label.high"),
                                                     },
                                                 ]}
-                                                max={26}
-                                                min={-14}
+                                                max={14.9}
+                                                min={-26.2}
                                                 step={1}
                                                 onChange={(_, value) => {
                                                     onAlertPropertyChange({

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/anomalies-filter-panel/anomalies-filter-panel.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/anomalies-filter-panel/anomalies-filter-panel.component.tsx
@@ -25,6 +25,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import React, { FunctionComponent, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { MetadataProperty } from "../../../rest/dto/alert-template.interfaces";
+import { SENSITIVITY_RANGE } from "../../../utils/constants/constants.util";
 import { AnomaliesFilterPanelProps } from "./anomalies-filter-panel.interfaces";
 import { FilterConfigurator } from "./filter-configurator/filter-configurator";
 
@@ -107,22 +108,22 @@ export const AnomaliesFilterPanel: FunctionComponent<AnomaliesFilterPanelProps> 
                                                 }
                                                 marks={[
                                                     {
-                                                        value: -26.2,
+                                                        value: SENSITIVITY_RANGE.LOW,
                                                         label: t("label.low"),
                                                     },
                                                     {
-                                                        value: -5.65,
+                                                        value: SENSITIVITY_RANGE.MEDIUM,
                                                         label: t(
                                                             "label.medium"
                                                         ),
                                                     },
                                                     {
-                                                        value: 14.9,
+                                                        value: SENSITIVITY_RANGE.HIGH,
                                                         label: t("label.high"),
                                                     },
                                                 ]}
-                                                max={14.9}
-                                                min={-26.2}
+                                                max={SENSITIVITY_RANGE.HIGH}
+                                                min={SENSITIVITY_RANGE.LOW}
                                                 step={1}
                                                 onChange={(_, value) => {
                                                     onAlertPropertyChange({

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/select-metric/select-metric.utils.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/select-metric/select-metric.utils.ts
@@ -23,6 +23,7 @@ import {
     TemplatePropertiesObject,
 } from "../../../rest/dto/alert.interfaces";
 import { Dataset } from "../../../rest/dto/dataset.interfaces";
+import { SENSITIVITY_RANGE } from "../../../utils/constants/constants.util";
 import { DatasetInfo } from "../../../utils/datasources/datasources.util";
 import {
     AlgorithmOptionInputFieldConfig,
@@ -81,8 +82,8 @@ const SUPPORTED_SIMPLE_MODE_PROPERTIES: {
         templatePropertyName: "sensitivity",
         label: i18n.t("label.sensitivity"),
         type: "slider",
-        min: -26,
-        max: 14,
+        min: SENSITIVITY_RANGE.LOW,
+        max: SENSITIVITY_RANGE.HIGH,
     },
     baselineOffset: {
         templatePropertyName: "baselineOffset",

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/threshold-setup/threshold-setup.utils.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/threshold-setup/threshold-setup.utils.ts
@@ -37,6 +37,7 @@ import {
 } from "../../../rest/dto/alert.interfaces";
 import { Dataset } from "../../../rest/dto/dataset.interfaces";
 import { MetricAggFunction } from "../../../rest/dto/metric.interfaces";
+import { SENSITIVITY_RANGE } from "../../../utils/constants/constants.util";
 import { DatasetInfo } from "../../../utils/datasources/datasources.util";
 import {
     AlgorithmOptionInputFieldConfig,
@@ -104,8 +105,8 @@ const SUPPORTED_SIMPLE_MODE_PROPERTIES: {
         templatePropertyName: "sensitivity",
         label: i18n.t("label.sensitivity"),
         type: "slider",
-        min: -26,
-        max: 14,
+        min: SENSITIVITY_RANGE.LOW,
+        max: SENSITIVITY_RANGE.HIGH,
     },
     baselineOffset: {
         templatePropertyName: "baselineOffset",

--- a/thirdeye-ui/src/app/utils/constants/constants.util.ts
+++ b/thirdeye-ui/src/app/utils/constants/constants.util.ts
@@ -24,3 +24,10 @@ export const THIRDEYE_DOC_LINK =
 export const QUERY_PARAM_KEYS: { [key: string]: string } = {
     SHOW_FIRST_ALERT_SUCCESS: "showFirstAlertSuccess",
 };
+
+// Sensitivity range for anomalies filter defined in the backend
+export const SENSITIVITY_RANGE = {
+    LOW: -26.2,
+    HIGH: 14.9,
+    MEDIUM: -5.65,
+};

--- a/thirdeye-ui/src/app/utils/constants/constants.util.ts
+++ b/thirdeye-ui/src/app/utils/constants/constants.util.ts
@@ -25,9 +25,9 @@ export const QUERY_PARAM_KEYS: { [key: string]: string } = {
     SHOW_FIRST_ALERT_SUCCESS: "showFirstAlertSuccess",
 };
 
-// Sensitivity range for anomalies filter defined in the backend
+// sensitivity range for ETS and other templates that use confidence-based sensitivity
 export const SENSITIVITY_RANGE = {
-    LOW: -26.2,
-    HIGH: 14.9,
-    MEDIUM: -5.65,
+    LOW: -26,
+    HIGH: 14,
+    MEDIUM: -6,
 };


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2134

#### Description

- Fixed the sensitivity slider values to respect the backend restrictions of `Sensitivity must be in [-26.2, 14.9]`

#### Screenshots

![image](https://github.com/startreedata/thirdeye/assets/67183907/372d05e4-6e41-4833-9e15-d2cafe446897)


#### How to test
- Adjust the sensitivity slider on the Filters page to "High" and check if 14.9 is sent as the sensitivity value when reloading the chart
