### PR TITLE
fix(ui): TE-2076 improve error messaging in JSON editor

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-json/alert-json.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-json/alert-json.component.tsx
@@ -15,7 +15,7 @@
 import { Box, Divider, Grid, Link, Typography } from "@material-ui/core";
 import InfoIcon from "@material-ui/icons/Info";
 import Alert from "@material-ui/lab/Alert";
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { JSONEditorV1 } from "../../../platform/components";
 import { EditableAlert } from "../../../rest/dto/alert.interfaces";
@@ -29,6 +29,7 @@ import { AlertJsonProps } from "./alert-json.interfaces";
 export const AlertJson: FunctionComponent<AlertJsonProps> = ({
     alert,
     onAlertPropertyChange,
+    setIsAlertValid,
 }) => {
     const { t } = useTranslation();
     const classes = useAlertWizardV2Styles();
@@ -50,6 +51,10 @@ export const AlertJson: FunctionComponent<AlertJsonProps> = ({
     };
 
     const isAlertValid = validateJSON(editedAlert).valid;
+
+    useEffect(() => {
+        setIsAlertValid(isAlertValid);
+    }, [editedAlert]);
 
     return (
         <Grid container>

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-json/alert-json.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-json/alert-json.interfaces.ts
@@ -16,6 +16,7 @@ import { EditableAlert } from "../../../rest/dto/alert.interfaces";
 
 export interface AlertJsonProps {
     alert: EditableAlert;
+    setIsAlertValid: (isValid: boolean) => void;
     onAlertPropertyChange: (
         contents: Partial<EditableAlert>,
         fullReplace: boolean

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.component.tsx
@@ -52,6 +52,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
     alert,
     onChartDataLoadSuccess,
     hideCallToActionPrompt,
+    disableReload,
 }) => {
     const { t } = useTranslation();
     const [searchParams, setSearchParams] = useSearchParams();
@@ -224,6 +225,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
             {/** Header Section **/}
             <PreviewChartHeader
                 alertInsight={alertInsight}
+                disableReload={disableReload}
                 getEvaluationStatus={getEvaluationStatus}
                 showConfigurationNotReflective={
                     !isEqual(alertForCurrentEvaluation, alert) &&

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/preview-chart/preview-chart.interfaces.ts
@@ -18,6 +18,7 @@ export interface PreviewChartProps {
     alert: EditableAlert;
     onChartDataLoadSuccess?: () => void;
     hideCallToActionPrompt?: boolean;
+    disableReload?: boolean;
     onAlertPropertyChange: (
         contents: Partial<EditableAlert>,
         isTotalReplace?: boolean

--- a/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-json-page/alerts-create-json-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-json-page/alerts-create-json-page.component.tsx
@@ -46,6 +46,8 @@ export const AlertsCreateJSONPage: FunctionComponent = () => {
         onPageExit,
     } = useOutletContext<AlertsSimpleAdvancedJsonContainerPageOutletContextProps>();
 
+    const [isAlertValid, setIsAlertValid] = React.useState(false);
+
     const availableFields = useMemo(() => {
         if (selectedAlertTemplate) {
             return determinePropertyFieldConfiguration(selectedAlertTemplate);
@@ -71,6 +73,7 @@ export const AlertsCreateJSONPage: FunctionComponent = () => {
                     <PageContentsCardV1>
                         <AlertJson
                             alert={alert}
+                            setIsAlertValid={setIsAlertValid}
                             onAlertPropertyChange={onAlertPropertyChange}
                         />
                         <Box marginBottom={3} marginTop={3}>
@@ -79,6 +82,7 @@ export const AlertsCreateJSONPage: FunctionComponent = () => {
                         <Box>
                             <PreviewChart
                                 alert={alert}
+                                disableReload={!isAlertValid}
                                 hideCallToActionPrompt={areBasicFieldsFilled}
                                 onAlertPropertyChange={onAlertPropertyChange}
                             />
@@ -99,7 +103,9 @@ export const AlertsCreateJSONPage: FunctionComponent = () => {
                     backButtonLabel={t("label.cancel")}
                     handleBackClick={onPageExit}
                     handleNextClick={() => handleSubmitAlertClick(alert)}
-                    nextButtonIsDisabled={isEditRequestInFlight}
+                    nextButtonIsDisabled={
+                        isEditRequestInFlight || !isAlertValid
+                    }
                     nextButtonLabel={t("label.create-entity", {
                         entity: t("label.alert"),
                     })}

--- a/thirdeye-ui/src/app/pages/alerts-update-page/alerts-update-json-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-update-page/alerts-update-json-page.component.tsx
@@ -39,6 +39,7 @@ export const AlertsUpdateJSONPage: FunctionComponent = () => {
         })
     );
     const [isSubmitBtnEnabled, setIsSubmitBtnEnabled] = useState(false);
+    const [isAlertValid, setIsAlertValid] = useState(true);
     const {
         alert,
         handleAlertPropertyChange: onAlertPropertyChange,
@@ -63,6 +64,7 @@ export const AlertsUpdateJSONPage: FunctionComponent = () => {
                     <PageContentsCardV1>
                         <AlertJson
                             alert={alert}
+                            setIsAlertValid={setIsAlertValid}
                             onAlertPropertyChange={onAlertPropertyChange}
                         />
                         <Box marginBottom={3} marginTop={3}>
@@ -71,6 +73,7 @@ export const AlertsUpdateJSONPage: FunctionComponent = () => {
                         <Box>
                             <PreviewChart
                                 alert={alert}
+                                disableReload={!isAlertValid}
                                 onAlertPropertyChange={onAlertPropertyChange}
                                 onChartDataLoadSuccess={() => {
                                     setIsSubmitBtnEnabled(true);
@@ -102,7 +105,9 @@ export const AlertsUpdateJSONPage: FunctionComponent = () => {
                     handleBackClick={onPageExit}
                     handleNextClick={() => handleSubmitAlertClick(alert)}
                     nextButtonIsDisabled={
-                        !isSubmitBtnEnabled || isEditRequestInFlight
+                        !isSubmitBtnEnabled ||
+                        isEditRequestInFlight ||
+                        !isAlertValid
                     }
                     nextButtonLabel={submitBtnLabel}
                 />


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2076

#### Description

- If the JSON editor was erroring out on syntax, the Update / Save CTAs should be disabled along with disabling Chart Preview Reload

#### Screenshots

https://github.com/startreedata/thirdeye/assets/67183907/5942ccbc-11b1-4474-b83a-52583849f8ff
#### How to test
- Try adding / editing an alert and enter invalid JSON
- The "Update" / "Create" CTAs should be disabled along with the Preview Reload button within the chart