### PR TITLE
fix(ui): TE-2212 search by subscription group for anomalies bug fix

### DIFF
--- a/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
@@ -145,7 +145,11 @@ export const AnomaliesAllPage: FunctionComponent = () => {
                             subscriptionGroup.alertAssociations.forEach(
                                 (association) => {
                                     associatedAlertsEnumerationKey.push(
-                                        `${association.alert.id}-${association?.enumerationItem?.id}`
+                                        `${association.alert.id}${
+                                            association?.enumerationItem?.id
+                                                ? `-${association?.enumerationItem?.id}`
+                                                : ""
+                                        }`
                                     );
                                 }
                             );
@@ -154,8 +158,22 @@ export const AnomaliesAllPage: FunctionComponent = () => {
 
                 filteredAnomalies = anomaliesRequestDataResponse.filter(
                     (anomaly) => {
-                        return associatedAlertsEnumerationKey.includes(
-                            `${anomaly.alert.id}-${anomaly?.enumerationItem?.id}`
+                        return associatedAlertsEnumerationKey.some(
+                            (k: string) => {
+                                const hasEnumerationId = k.includes("-");
+                                if (hasEnumerationId) {
+                                    const [alertId, enumerationId] =
+                                        k.split("-");
+
+                                    return (
+                                        anomaly.alert.id === Number(alertId) &&
+                                        anomaly.enumerationItem?.id ===
+                                            Number(enumerationId)
+                                    );
+                                }
+
+                                return Number(k) === anomaly.alert.id;
+                            }
                         );
                     }
                 );

--- a/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
@@ -41,6 +41,7 @@ import { Anomaly } from "../../rest/dto/anomaly.interfaces";
 import { UiAnomaly } from "../../rest/dto/ui-anomaly.interfaces";
 import { useGetEnumerationItems } from "../../rest/enumeration-items/enumeration-items.actions";
 import { useGetSubscriptionGroups } from "../../rest/subscription-groups/subscription-groups.actions";
+import { filterAnomaliesBySubscriptionGroup } from "../../utils/anomalies/anomalies.util";
 import {
     makeDeleteRequest,
     promptDeleteConfirmation,
@@ -136,48 +137,11 @@ export const AnomaliesAllPage: FunctionComponent = () => {
             anomaliesRequestDataResponse &&
             anomaliesRequestDataResponse.length > 0
         ) {
-            if (subscriptionGroups && subscriptionGroupFilter.length > 0) {
-                const associatedAlertsEnumerationKey: string[] = [];
+            filteredAnomalies = filterAnomaliesBySubscriptionGroup(
+                anomaliesRequestDataResponse,
+                subscriptionGroupFilter,
                 subscriptionGroups
-                    .filter((s) => subscriptionGroupFilter.includes(s.id))
-                    .forEach((subscriptionGroup) => {
-                        if (subscriptionGroup.alertAssociations) {
-                            subscriptionGroup.alertAssociations.forEach(
-                                (association) => {
-                                    associatedAlertsEnumerationKey.push(
-                                        `${association.alert.id}${
-                                            association?.enumerationItem?.id
-                                                ? `-${association?.enumerationItem?.id}`
-                                                : ""
-                                        }`
-                                    );
-                                }
-                            );
-                        }
-                    });
-
-                filteredAnomalies = anomaliesRequestDataResponse.filter(
-                    (anomaly) => {
-                        return associatedAlertsEnumerationKey.some(
-                            (k: string) => {
-                                const hasEnumerationId = k.includes("-");
-                                if (hasEnumerationId) {
-                                    const [alertId, enumerationId] =
-                                        k.split("-");
-
-                                    return (
-                                        anomaly.alert.id === Number(alertId) &&
-                                        anomaly.enumerationItem?.id ===
-                                            Number(enumerationId)
-                                    );
-                                }
-
-                                return Number(k) === anomaly.alert.id;
-                            }
-                        );
-                    }
-                );
-            }
+            );
         }
 
         setAnomalies(filteredAnomalies);

--- a/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
+++ b/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
@@ -636,3 +636,48 @@ export const getMetricString = (
 
     return "";
 };
+
+export const filterAnomaliesBySubscriptionGroup = (
+    anomalies: Anomaly[],
+    subscriptionGroupFilter: number[],
+    subscriptionGroups: SubscriptionGroup[] | null
+): Anomaly[] => {
+    let filteredAnomalies = [...anomalies];
+    if (subscriptionGroups && subscriptionGroupFilter.length > 0) {
+        const associatedAlertsEnumerationKey: Array<{
+            alertId: number;
+            enumerationItemId?: number;
+        }> = [];
+        subscriptionGroups
+            .filter((s) => subscriptionGroupFilter.includes(s.id))
+            .forEach((subscriptionGroup) => {
+                if (subscriptionGroup.alertAssociations) {
+                    subscriptionGroup.alertAssociations.forEach(
+                        (association) => {
+                            associatedAlertsEnumerationKey.push({
+                                alertId: association.alert.id,
+                                enumerationItemId:
+                                    association.enumerationItem?.id,
+                            });
+                        }
+                    );
+                }
+            });
+
+        filteredAnomalies = anomalies.filter((anomaly) => {
+            return associatedAlertsEnumerationKey.some(
+                (k: { alertId: number; enumerationItemId?: number }) => {
+                    return (
+                        k.alertId === anomaly.alert.id &&
+                        (k.enumerationItemId === undefined ||
+                            k.enumerationItemId === anomaly.enumerationItem?.id)
+                    );
+                }
+            );
+        });
+
+        return filteredAnomalies;
+    }
+
+    return anomalies;
+};


### PR DESCRIPTION
#### Issue(s)

List links to the issues being addressed.
https://startree.atlassian.net/browse/TE-2212
#### Description
- For subscription groups with dx alerts that have no `enumerationItem` attached to them, the filtering algorithm on the UI had to be changed
- The algorithm now supports filtering across all types of alerts
Describe the changes being introduced.

#### Screenshots
<img width="1512" alt="image" src="https://github.com/startreedata/thirdeye/assets/67183907/6d03108d-2e3b-419e-aad6-8b11ffd7bd84">

Attach screenshots of UI/UX changes, if applicable.

#### How to test
- Try filtering through various subscription groups on anomalies list page with subscription to simple and dx alerts with and without `enumerationItem` attached to them
List steps to reproduce the issue(s) and test the change, if required.
