### PR TITLE
fix(ui): TE-2131 fixing duplicate evaluate calls for anomaly heatmap

### DIFF
--- a/thirdeye-ui/src/app/components/rca/top-contributors-table/preview-chart/preview-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/top-contributors-table/preview-chart/preview-chart.component.tsx
@@ -191,7 +191,7 @@ export const PreviewChart: FunctionComponent<PreviewChartProps> = ({
 
     useEffect(() => {
         fetchFilteredAlertEvaluations();
-    }, [alertInsight, anomaly, startTime, endTime, dimensionCombinations]);
+    }, [alertInsight, anomaly, startTime, endTime]);
 
     return (
         <Grid container>


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2131

#### Description

Removed redundant API calls, API calls was going twice because of 
1. On filter change useEffect in preview chart was running again.
2. PreviewChart is getting remounted on filter change.
`dimensionCombinations` removed from dependancy array as because of step 2 it will again be remounted with proper props and value of `dimensionCombinations`

#### Screenshots

Attach screenshots of UI/UX changes, if applicable.

#### How to test

List steps to reproduce the issue(s) and test the change, if required.
