### PR TITLE
fix(ui): TE-2278 add a column and sort by percent change in the top contributors table

### DIFF
--- a/thirdeye-ui/src/app/components/rca/top-contributors-table/top-contributors-row.component.tsx
+++ b/thirdeye-ui/src/app/components/rca/top-contributors-table/top-contributors-row.component.tsx
@@ -37,10 +37,11 @@ import { TopContributorsRowExpanded } from "./top-contributors-row-expanded.comp
 import { useAlgorithmRowExpandedStyles } from "./top-contributors-row-expanded.styles";
 import { TopContributorsRowProps } from "./top-contributors-table.interfaces";
 import {
+    SERVER_VALUE_FOR_OTHERS,
     generateFilterOptions,
     generateName,
     generateOtherDimensionTooltipString,
-    SERVER_VALUE_FOR_OTHERS,
+    isValidChangePercentage,
 } from "./top-contributors-table.utils";
 
 const SCORE_INDICATOR_HEIGHT = 30;
@@ -160,6 +161,47 @@ export const TopContributorsRow: FunctionComponent<TopContributorsRowProps> = ({
                                             )
                                         )}
                                         %
+                                    </Box>
+                                </Grid>
+                            </Grid>
+                        </Box>
+                    </Box>
+                </TableCell>
+                <TableCell>
+                    <Box position="relative">
+                        <ScoreIndicator
+                            value={
+                                isValidChangePercentage(row.changePercentage)
+                                    ? row.changePercentage
+                                    : 0
+                            }
+                            variant="determinate"
+                        />
+                        <Box position="absolute" top={0}>
+                            <Grid container spacing={1}>
+                                {isValidChangePercentage(
+                                    row.changePercentage
+                                ) ? (
+                                    <Grid item>
+                                        <Box mt="3px">
+                                            {row.names.length > 0 && isDown && (
+                                                <ArrowDownwardIcon />
+                                            )}
+                                            {row.names.length > 0 &&
+                                                !isDown && <ArrowUpwardIcon />}
+                                        </Box>
+                                    </Grid>
+                                ) : null}
+                                <Grid item>
+                                    <Box mt="4px">
+                                        {formatLargeNumberV1(
+                                            Number(row.changePercentage)
+                                        )}
+                                        {isValidChangePercentage(
+                                            row.changePercentage
+                                        )
+                                            ? "%"
+                                            : ""}
                                     </Box>
                                 </Grid>
                             </Grid>

--- a/thirdeye-ui/src/app/components/rca/top-contributors-table/top-contributors-table.interfaces.ts
+++ b/thirdeye-ui/src/app/components/rca/top-contributors-table/top-contributors-table.interfaces.ts
@@ -63,3 +63,8 @@ export interface ExtraDataForAnomalyDimensionAnalysisData {
     anomalyStart: number;
     anomalyEnd: number;
 }
+
+export enum TopContributorsTableChangePercentSort {
+    ASC = "asc",
+    DESC = "desc",
+}

--- a/thirdeye-ui/src/app/components/rca/top-contributors-table/top-contributors-table.utils.tsx
+++ b/thirdeye-ui/src/app/components/rca/top-contributors-table/top-contributors-table.utils.tsx
@@ -434,3 +434,7 @@ export const generateFilterStrings = (
         .map((item) => concatKeyValueWithEqual(item, false))
         .sort();
 };
+
+export const isValidChangePercentage = (
+    changePercentage: string | number
+): boolean => typeof changePercentage === "number";

--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -85,6 +85,7 @@
         "cancel": "Cancel",
         "cant-find-an-event": "Can’t find an event?",
         "change": "Change",
+        "change-percentage": "Change %",
         "channels": "Channels",
         "chart": "Chart",
         "chart-data": "Chart Data",

--- a/thirdeye-ui/src/app/platform/utils/number/number.util.ts
+++ b/thirdeye-ui/src/app/platform/utils/number/number.util.ts
@@ -64,7 +64,7 @@ export const formatLargeNumberV1 = (
     mantissa: number = MANTISSA_DEFAULT,
     optionalMantissa: boolean = OPTIONAL_MANTISSA_DEFAULT
 ): string => {
-    if (isNil(num)) {
+    if (isNil(num) || isNaN(num)) {
         return "";
     }
 


### PR DESCRIPTION


#### Issue(s)

https://startree.atlassian.net/browse/TE-2278

#### Description

- Added a column for "Change %" to the "Top Contributors" table when investigating an anomaly

#### Screenshots
<img width="1245" alt="image" src="https://github.com/startreedata/thirdeye/assets/67183907/0f33e23c-6220-41bd-917a-6c5f7b67ad77">

#### How to test
- Try toggling the sort for the "Change %" column of the "Top Contributors" section when investigating an anomaly
