### PR TITLE
fix(ui): TE-2236 fix condition for showing dimension for a dx alert

### DIFF
--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -362,6 +362,10 @@ export const AlertsViewPage: FunctionComponent = () => {
         // fetchData();
     };
 
+    const isDxAlert =
+        getAlertQuery.data?.templateProperties?.enumerationItems ||
+        getAlertQuery?.data?.templateProperties.enumeratorQuery;
+
     return (
         <PageV1>
             <PageHeader
@@ -511,8 +515,7 @@ export const AlertsViewPage: FunctionComponent = () => {
                             </Card>
                         }
                     >
-                        {getAlertQuery.data?.templateProperties
-                            ?.enumerationItems ? (
+                        {isDxAlert ? (
                             <EnumerationItemsTable
                                 alertId={Number(alertId)}
                                 anomalies={getAnomaliesQuery.data || []}


### PR DESCRIPTION
#### Issue(s)
https://startree.atlassian.net/browse/TE-2236

#### Description

- Fixed the condition that shows the dimension charts for dx alerts when viewing an alert

Describe the changes being introduced.

#### Screenshots
![image](https://github.com/startreedata/thirdeye/assets/67183907/011870ef-2489-4559-8ff1-1134d175e689)


#### How to test
- Try viewing multiple DX alerts and check if the dimension charts are visible
