### PR TITLE
 fix(ui): TE-2281 fix datasource name on datasets selection page of onboarding

### DIFF
--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -603,6 +603,7 @@
         "entity-id-verbose-header": "{{entity}} ID",
         "error-encountered-while-fetching-datasource-status": "An issue was experienced when trying to validate datasource.",
         "error-while-fetching": "An issue was experienced while retrieving {{entity}} data",
+        "error-while-fetching-datasource": "An issue was experienced while retrieving datasource details",
         "event-end-time-required": "End time is required",
         "event-name-required": "Name is required",
         "event-start-time-required": "Start time is required",

--- a/thirdeye-ui/src/app/pages/welcome-page/create-datasource/onboard-datasets/onboard-datasets-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/welcome-page/create-datasource/onboard-datasets/onboard-datasets-page.component.tsx
@@ -43,7 +43,10 @@ import {
 } from "../../../../platform/components";
 import { ActionStatus } from "../../../../rest/actions.interfaces";
 import { onBoardDataset } from "../../../../rest/datasets/datasets.rest";
-import { useGetTablesForDatasourceID } from "../../../../rest/datasources/datasources.actions";
+import {
+    useGetDatasource,
+    useGetTablesForDatasourceID,
+} from "../../../../rest/datasources/datasources.actions";
 import { notifyIfErrors } from "../../../../utils/notifications/notifications.util";
 import { getErrorMessages } from "../../../../utils/rest/rest.util";
 import {
@@ -66,6 +69,13 @@ export const WelcomeSelectDatasets: FunctionComponent = () => {
         errorMessages,
     } = useGetTablesForDatasourceID();
 
+    const {
+        getDatasource,
+        datasource,
+        status: getDataSourceStatus,
+        errorMessages: getDatSourceErrorMessages,
+    } = useGetDatasource();
+
     const handleToggleCheckbox = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>): void => {
             const { name, checked } = event.target;
@@ -87,6 +97,7 @@ export const WelcomeSelectDatasets: FunctionComponent = () => {
 
     useEffect(() => {
         if (datasourceId) {
+            getDatasource(Number(datasourceId));
             getTableForDatasourceID(Number(datasourceId)).then((datasets) => {
                 if (!datasets) {
                     return;
@@ -107,6 +118,15 @@ export const WelcomeSelectDatasets: FunctionComponent = () => {
             t("message.error-while-fetching", {
                 entity: t("label.datasets"),
             })
+        );
+    }, [getTablesStatus]);
+
+    useEffect(() => {
+        notifyIfErrors(
+            getDataSourceStatus,
+            getDatSourceErrorMessages,
+            notify,
+            t("message.error-while-fetching-datasource")
         );
     }, [getTablesStatus]);
 
@@ -186,7 +206,7 @@ export const WelcomeSelectDatasets: FunctionComponent = () => {
                                     {t(
                                         "message.onboard-datasource-onboard-datasets-for",
                                         {
-                                            datasetName: datasourceId,
+                                            datasetName: datasource?.name,
                                         }
                                     )}
                                 </Typography>


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2281

#### Description

- The datasets selection page of the onboarding wizard would show the datasource ID instead of the name

#### Screenshots

![image](https://github.com/startreedata/thirdeye/assets/67183907/295731b8-8366-47ee-a256-2af16526d754)


#### How to test
- When onboarding, select a datasource
- Go to the dataset selections page and observe the name of the selected datasource

List steps to reproduce the issue(s) and test the change, if required.
