### PR TITLE
fix(ui): TE-2319 fix insights endpoint on view anomaly new UI

### DIFF
--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-container-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-container-page.component.tsx
@@ -57,6 +57,7 @@ export const AnomaliesViewContainerPage: FunctionComponent = () => {
 
     useEffect(() => {
         !!fetchedAnomaly &&
+            fetchedAnomaly.alert?.id &&
             getAlertInsight({ alertId: fetchedAnomaly.alert.id });
     }, [fetchedAnomaly]);
 

--- a/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-v1-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-view-page/anomalies-view-v1-page.component.tsx
@@ -137,7 +137,9 @@ export const AnomaliesViewV1Page: FunctionComponent = () => {
             anomaly.enumerationItem &&
             getEnumerationItem(anomaly.enumerationItem.id);
 
-        !!anomaly && getAlertInsight({ alertId: anomaly.alert.id });
+        !!anomaly &&
+            anomaly.alert?.id &&
+            getAlertInsight({ alertId: anomaly.alert.id });
     }, [anomaly]);
 
     useEffect(() => {


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2319

#### Description

- Added a null safety check to make sure the alert id of an anomaly is sent correctly to the /insights endpoint, customer reported that he's been seeing some 400 errors (malformed request) which means that in some cases the alert id is not attached correctly

#### Screenshots

![image](https://github.com/startreedata/thirdeye/assets/67183907/53b677dd-1498-4244-aaab-e746f1467a93)


Attach screenshots of UI/UX changes, if applicable.

#### How to test

- Keep switching between old and new UI for the view anomaly page

List steps to reproduce the issue(s) and test the change, if required.
