### PR TITLE
feat(ui): TE-2334 fix type error on view subscription groups page

### DIFF
--- a/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
@@ -137,7 +137,7 @@ export const getCardProps = (
                 },
                 {
                     label: t("label.to"),
-                    value: channel.params.emailRecipients.to?.join(",") ?? "",
+                    value: channel.params.emailRecipients?.to?.join(",") ?? "",
                 }
             );
 

--- a/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
+++ b/thirdeye-ui/src/app/components/subscription-group-view/notification-channels-card/notification-channels-card.utils.tsx
@@ -137,7 +137,7 @@ export const getCardProps = (
                 },
                 {
                     label: t("label.to"),
-                    value: channel.params.emailRecipients.to.join(","),
+                    value: channel.params.emailRecipients.to?.join(",") ?? "",
                 }
             );
 


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2334

#### Description
- Possible fix for a type error on view subscriptions page

#### Screenshots
<img width="1728" alt="image" src="https://github.com/startreedata/thirdeye/assets/67183907/6e6ab7e2-ce31-44a1-b857-d0768b0b8009">


Attach screenshots of UI/UX changes, if applicable.

#### How to test
- Go to Configuration -> Subscription groups
