### PR TITLE
[persistence] fix limit not applied correctly in task purge

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
@@ -34,8 +34,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import org.apache.commons.collections4.CollectionUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -205,24 +205,18 @@ public class TaskDao {
     requireNonNull(daoFilter.getPredicate(),
         "If the predicate is null, you can just do "
             + "getAll() which doesn't need to fetch IDs first");
-    return get(daoFilter.getPredicate());
-  }
-
-  public List<TaskDTO> get(final Map<String, Object> filterParams) {
-    final Predicate[] childPredicates = new Predicate[filterParams.size()];
-    int index = 0;
-    for (final Entry<String, Object> entry : filterParams.entrySet()) {
-      childPredicates[index] = Predicate.EQ(entry.getKey(), entry.getValue());
-      index = index + 1;
-    }
-    return get(Predicate.AND(childPredicates));
+    return get(daoFilter.getPredicate(), daoFilter.getLimit());
   }
 
   public List<TaskDTO> get(final Predicate predicate) {
+    return get(predicate, null);
+  }
+  
+  public List<TaskDTO> get(final Predicate predicate, @Nullable Long limit) {
     try {
       final List<TaskEntity> entities = databaseClient.executeTransaction(
           (connection) -> databaseOrm.findAll(
-              predicate, null, null, TaskEntity.class, connection),
+              predicate, limit, null, TaskEntity.class, connection),
           Collections.emptyList());
       return toDto(entities);
     } catch (final JsonProcessingException | SQLException e) {

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/taskcleanup/TaskCleanUpConfiguration.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/taskcleanup/TaskCleanUpConfiguration.java
@@ -13,11 +13,13 @@
  */
 package ai.startree.thirdeye.scheduler.taskcleanup;
 
+import static ai.startree.thirdeye.spi.Constants.TASK_MAX_DELETES_PER_CLEANUP;
+
 public class TaskCleanUpConfiguration {
 
   private Integer intervalInMinutes = 5;
   private Integer retentionInDays = 30;
-  private Integer maxEntriesToDelete = 5000;
+  private Integer maxEntriesToDelete = TASK_MAX_DELETES_PER_CLEANUP;
   private Integer orphanIntervalInSeconds = 30;
 
   public Integer getIntervalInMinutes() {

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/taskcleanup/TaskCleanUpConfiguration.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/taskcleanup/TaskCleanUpConfiguration.java
@@ -17,7 +17,7 @@ public class TaskCleanUpConfiguration {
 
   private Integer intervalInMinutes = 5;
   private Integer retentionInDays = 30;
-  private Integer maxEntriesToDelete = 1000;
+  private Integer maxEntriesToDelete = 5000;
   private Integer orphanIntervalInSeconds = 30;
 
   public Integer getIntervalInMinutes() {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
@@ -54,7 +54,7 @@ public interface Constants {
   String NOTIFICATIONS_PERCENTAGE_FORMAT = "%.2f %%";
 
   Duration TASK_EXPIRY_DURATION = Duration.ofDays(30);
-  int TASK_MAX_DELETES_PER_CLEANUP = 10000;
+  int TASK_MAX_DELETES_PER_CLEANUP = 5000;
 
   /*
    * Dataframe related constants


### PR DESCRIPTION
- **[scheduler] raise default max number of task delete per run to 5000**
- **[persistence] fix limit not applied correctly in task get method**
