### PR TITLE
fix(ui): TE-2373 display all properties while creating alert in advanced mode

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.component.tsx
@@ -34,7 +34,7 @@ const StyledGrid = withStyles((theme) => ({
 export const AlertTemplateSectionedProperties: FunctionComponent<AlertTemplateSectionedPropertiesProps> =
     ({ groupedProperties, handlePropertyValueChange }) => {
         const { t } = useTranslation();
-        const ordeeredGroupedProperties: Record<
+        const orderedGroupedProperties: Record<
             string,
             Record<string, PropertyRenderConfig[]>
         > = {};
@@ -46,7 +46,7 @@ export const AlertTemplateSectionedProperties: FunctionComponent<AlertTemplateSe
         ALERT_PROPERTIES_DEFAULT_ORDER.forEach((alertProperty) => {
             if (alertProperty !== ALERT_PROPERTIES_DEFAULT_STEP.STEP) {
                 if (groupedProperties[alertProperty]) {
-                    ordeeredGroupedProperties[alertProperty] =
+                    orderedGroupedProperties[alertProperty] =
                         groupedProperties[alertProperty];
                 }
             }
@@ -56,17 +56,17 @@ export const AlertTemplateSectionedProperties: FunctionComponent<AlertTemplateSe
         );
         if (!isEmpty(keysNotInDefaultOrder)) {
             keysNotInDefaultOrder.forEach((key) => {
-                ordeeredGroupedProperties[key] = groupedProperties[key];
+                orderedGroupedProperties[key] = groupedProperties[key];
             });
         }
         if (groupedProperties[ALERT_PROPERTIES_DEFAULT_STEP.STEP]) {
-            ordeeredGroupedProperties[ALERT_PROPERTIES_DEFAULT_STEP.STEP] =
+            orderedGroupedProperties[ALERT_PROPERTIES_DEFAULT_STEP.STEP] =
                 groupedProperties[ALERT_PROPERTIES_DEFAULT_STEP.STEP];
         }
 
         return (
             <StyledGrid container>
-                {Object.keys(ordeeredGroupedProperties).map((step, stepIdx) => {
+                {Object.keys(orderedGroupedProperties).map((step, stepIdx) => {
                     const subStepMap = groupedProperties[step];
 
                     return (

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.component.tsx
@@ -16,12 +16,14 @@ import { Box, Grid, Typography, withStyles } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import {
-    existingPropertySteps,
-    isStepEmpty,
-    propertyStepNameMap,
+    extendablePropertyStepNameMap,
+    ALERT_PROPERTIES_DEFAULT_ORDER,
+    ALERT_PROPERTIES_DEFAULT_STEP,
 } from "../../../../../utils/alerts/alerts.util";
 import { AlertTemplateFormField } from "../../alert-template-form-field/alert-template-form-field.component";
 import { AlertTemplateSectionedPropertiesProps } from "./alert-template-sectioned-properties.interfaces";
+import { PropertyRenderConfig } from "../alert-template-properties-builder.interfaces";
+import { isEmpty } from "lodash";
 
 const StyledGrid = withStyles((theme) => ({
     root: {
@@ -32,107 +34,125 @@ const StyledGrid = withStyles((theme) => ({
 export const AlertTemplateSectionedProperties: FunctionComponent<AlertTemplateSectionedPropertiesProps> =
     ({ groupedProperties, handlePropertyValueChange }) => {
         const { t } = useTranslation();
+        const ordeeredGroupedProperties: Record<
+            string,
+            Record<string, PropertyRenderConfig[]>
+        > = {};
+        /* The idea is to display properties in a specifc order. We have that order pre-defined.
+            In case there is a property that belongs to a step that is not in pre-defined order,
+            we push it at the second last place, just before the properties of "OTHER" step
+        */
+        const keysPresent = Object.keys(groupedProperties);
+        ALERT_PROPERTIES_DEFAULT_ORDER.forEach((alertProperty) => {
+            if (alertProperty !== ALERT_PROPERTIES_DEFAULT_STEP.STEP) {
+                if (groupedProperties[alertProperty]) {
+                    ordeeredGroupedProperties[alertProperty] =
+                        groupedProperties[alertProperty];
+                }
+            }
+        });
+        const keysNotInDefaultOrder = keysPresent.filter(
+            (key) => !ALERT_PROPERTIES_DEFAULT_ORDER.includes(key)
+        );
+        if (!isEmpty(keysNotInDefaultOrder)) {
+            keysNotInDefaultOrder.forEach((key) => {
+                ordeeredGroupedProperties[key] = groupedProperties[key];
+            });
+        }
+        if (groupedProperties[ALERT_PROPERTIES_DEFAULT_STEP.STEP]) {
+            ordeeredGroupedProperties[ALERT_PROPERTIES_DEFAULT_STEP.STEP] =
+                groupedProperties[ALERT_PROPERTIES_DEFAULT_STEP.STEP];
+        }
 
         return (
             <StyledGrid container>
-                {existingPropertySteps
-                    .filter((s) => !isStepEmpty(s, groupedProperties))
-                    .map((step, stepIdx) => {
-                        const subStepMap = groupedProperties[step];
+                {Object.keys(ordeeredGroupedProperties).map((step, stepIdx) => {
+                    const subStepMap = groupedProperties[step];
 
-                        return (
-                            <Grid item key={`existing-${step}`} xs={12}>
-                                <Box paddingBottom={2}>
-                                    <Typography variant="h5">
-                                        {propertyStepNameMap[step]}
-                                    </Typography>
-                                    {subStepMap?.["DIRECT"]?.map(
-                                        (directSubStep, directSubStepIdx) => (
-                                            <AlertTemplateFormField
-                                                defaultValue={
-                                                    directSubStep.metadata
-                                                        .defaultValue
-                                                }
-                                                item={directSubStep}
-                                                key={directSubStep.key}
-                                                tabIndex={directSubStepIdx + 1}
-                                                tooltipText={
-                                                    directSubStep.metadata
-                                                        .description
-                                                }
-                                                onChange={(selected) =>
-                                                    handlePropertyValueChange(
-                                                        directSubStep.key,
-                                                        selected
-                                                    )
-                                                }
-                                            />
-                                        )
-                                    )}
-                                    {Object.keys(subStepMap)
-                                        .slice(1)
-                                        .filter(
-                                            (cs) => subStepMap[cs].length > 0
-                                        )
-                                        .map((currentSubStep) => (
-                                            <Grid
-                                                item
-                                                key={`required-${step}-${currentSubStep}`}
-                                                xs={12}
+                    return (
+                        <Grid item key={`existing-${step}`} xs={12}>
+                            <Box paddingBottom={2}>
+                                <Typography variant="h5">
+                                    {extendablePropertyStepNameMap[step]}
+                                </Typography>
+                                {subStepMap?.["DIRECT"]?.map(
+                                    (directSubStep, directSubStepIdx) => (
+                                        <AlertTemplateFormField
+                                            defaultValue={
+                                                directSubStep.metadata
+                                                    .defaultValue
+                                            }
+                                            item={directSubStep}
+                                            key={directSubStep.key}
+                                            tabIndex={directSubStepIdx + 1}
+                                            tooltipText={
+                                                directSubStep.metadata
+                                                    .description
+                                            }
+                                            onChange={(selected) =>
+                                                handlePropertyValueChange(
+                                                    directSubStep.key,
+                                                    selected
+                                                )
+                                            }
+                                        />
+                                    )
+                                )}
+                                {Object.keys(subStepMap)
+                                    .slice(1)
+                                    .filter((cs) => subStepMap[cs].length > 0)
+                                    .map((currentSubStep) => (
+                                        <Grid
+                                            item
+                                            key={`required-${step}-${currentSubStep}`}
+                                            xs={12}
+                                        >
+                                            <Box
+                                                paddingBottom={2}
+                                                paddingTop={2}
                                             >
-                                                <Box
-                                                    paddingBottom={2}
-                                                    paddingTop={2}
-                                                >
-                                                    <Typography variant="h6">
-                                                        {currentSubStep}
-                                                    </Typography>
-                                                    {subStepMap[
-                                                        currentSubStep
-                                                    ].map(
-                                                        (
-                                                            property,
-                                                            propertyIdx
-                                                        ) => (
-                                                            <AlertTemplateFormField
-                                                                item={property}
-                                                                key={
-                                                                    property.key
+                                                <Typography variant="h6">
+                                                    {currentSubStep}
+                                                </Typography>
+                                                {subStepMap[currentSubStep].map(
+                                                    (property, propertyIdx) => (
+                                                        <AlertTemplateFormField
+                                                            item={property}
+                                                            key={property.key}
+                                                            placeholder={t(
+                                                                "label.add-property-value",
+                                                                {
+                                                                    key: property.key,
                                                                 }
-                                                                placeholder={t(
-                                                                    "label.add-property-value",
-                                                                    {
-                                                                        key: property.key,
-                                                                    }
-                                                                )}
-                                                                tabIndex={
-                                                                    propertyIdx +
-                                                                    1 +
-                                                                    stepIdx
-                                                                }
-                                                                tooltipText={
-                                                                    property
-                                                                        .metadata
-                                                                        .description
-                                                                }
-                                                                onChange={(
+                                                            )}
+                                                            tabIndex={
+                                                                propertyIdx +
+                                                                1 +
+                                                                stepIdx
+                                                            }
+                                                            tooltipText={
+                                                                property
+                                                                    .metadata
+                                                                    .description
+                                                            }
+                                                            onChange={(
+                                                                selected
+                                                            ) =>
+                                                                handlePropertyValueChange(
+                                                                    property.key,
                                                                     selected
-                                                                ) =>
-                                                                    handlePropertyValueChange(
-                                                                        property.key,
-                                                                        selected
-                                                                    )
-                                                                }
-                                                            />
-                                                        )
-                                                    )}
-                                                </Box>
-                                            </Grid>
-                                        ))}
-                                </Box>
-                            </Grid>
-                        );
-                    })}
+                                                                )
+                                                            }
+                                                        />
+                                                    )
+                                                )}
+                                            </Box>
+                                        </Grid>
+                                    ))}
+                            </Box>
+                        </Grid>
+                    );
+                })}
             </StyledGrid>
         );
     };

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.interfaces.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.interfaces.ts
@@ -14,14 +14,10 @@
  */
 
 import { DebouncedFunc } from "lodash";
-import { MetadataPropertyStep } from "../../../../../rest/dto/alert-template.interfaces";
 import { PropertyRenderConfig } from "../alert-template-properties-builder.interfaces";
 
 export interface AlertTemplateSectionedPropertiesProps {
-    groupedProperties: Record<
-        MetadataPropertyStep,
-        Record<string, PropertyRenderConfig[]>
-    >;
+    groupedProperties: Record<string, Record<string, PropertyRenderConfig[]>>;
     handlePropertyValueChange: DebouncedFunc<
         (key: unknown, value: unknown) => void
     >;

--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template.utils.ts
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template.utils.ts
@@ -85,8 +85,18 @@ export function determinePropertyFieldConfiguration(
     const metadata: {
         [key: string]: AlertTemplatePropertyParsedMetadata;
     } = {};
-
-    // This is the old way of figuring out if a field is required or not
+    /* This is the old way of figuring out if a field is required or not.
+    We allow users to add placeholders of variale in the template without any entry
+    in the properties key. For eg they can just put this in template,
+    "dataSource: ${dataSource}".
+    We have to show this field for the user to add value into, even if its not defined
+    in the proerties key of the template.
+    Bottomline is we have to always show inout box for any variable mentioned in any of the
+    template properties. The properties key is to provide extra information about the variable,
+    based on which we categorise them under different steps. As of now if the key just exists
+    in the property section, even though we show an inpput box for it, it wont have any
+    impact as there is no mapping for this variable to any template property.
+    */
     determinePropertyFieldConfigurationFromDefaultFields(
         alertTemplate,
         alertTemplate.defaultProperties ?? {}

--- a/thirdeye-ui/src/app/rest/dto/alert-template.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/alert-template.interfaces.ts
@@ -15,16 +15,6 @@
 
 import { PropertyConfigValueTypes } from "./alert.interfaces";
 
-export enum MetadataPropertyStep {
-    DATA = "DATA",
-    PREPROCESS = "PREPROCESS",
-    DETECTION = "DETECTION",
-    FILTER = "FILTER",
-    POSTPROCESS = "POSTPROCESS",
-    RCA = "RCA",
-    OTHER = "OTHER",
-}
-
 export interface MetadataProperty {
     name: string;
     description?: string;
@@ -55,7 +45,7 @@ export interface MetadataProperty {
      *
      * See introduction PR https://github.com/startreedata/thirdeye/pull/974
      */
-    step?: MetadataPropertyStep;
+    step?: string;
     /**
      * A free string subStep. Used to group properties belonging to the same
      * step in smaller groups.

--- a/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
+++ b/thirdeye-ui/src/app/utils/alerts/alerts.util.ts
@@ -16,7 +16,6 @@ import i18n from "i18next";
 import { cloneDeep, isEmpty, kebabCase, omit } from "lodash";
 import { PropertyRenderConfig } from "../../components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-properties-builder.interfaces";
 import { GetAlertEvaluationPayload } from "../../rest/alerts/alerts.interfaces";
-import { MetadataPropertyStep } from "../../rest/dto/alert-template.interfaces";
 import {
     Alert,
     AlertAnomalyDetectorNode,
@@ -460,48 +459,49 @@ export const shouldHideTimeInDatetimeFormat = (
     return false;
 };
 
-export const propertyStepNameMap: Record<MetadataPropertyStep, string> = {
-    [MetadataPropertyStep.DATA]: "Data",
-    [MetadataPropertyStep.PREPROCESS]: "Preprocessing",
-    [MetadataPropertyStep.DETECTION]: "Detection",
-    [MetadataPropertyStep.FILTER]: "Filtering",
-    [MetadataPropertyStep.POSTPROCESS]: "Postprocessing",
-    [MetadataPropertyStep.RCA]: "Root Cause Analysis",
-    [MetadataPropertyStep.OTHER]: "Other",
+export const extendablePropertyStepNameMap: Record<string, string> = {
+    DATA: "Data",
+    PREPROCESS: "Preprocessing",
+    DETECTION: "Detection",
+    DIMENSION_EXPLORATION: "Dimension Exploration",
+    FILTER: "Filtering",
+    POSTPROCESS: "Postprocessing",
+    RCA: "Root Cause Analysis",
+    OTHER: "Other",
 };
 
-export const existingPropertySteps: MetadataPropertyStep[] = [
-    MetadataPropertyStep.DATA,
-    MetadataPropertyStep.PREPROCESS,
-    MetadataPropertyStep.DETECTION,
-    MetadataPropertyStep.FILTER,
-    MetadataPropertyStep.POSTPROCESS,
-    MetadataPropertyStep.RCA,
-    MetadataPropertyStep.OTHER,
+export enum ALERT_PROPERTIES_DEFAULT_STEP {
+    STEP = "OTHER",
+    SUBSTEP = "DIRECT",
+}
+
+export const ALERT_PROPERTIES_DEFAULT_ORDER = [
+    "DATA",
+    "DIMENSION_EXPLORATION",
+    "PREPROCESS",
+    "DETECTION",
+    "FILTER",
+    "POSTPROCESS",
+    "RCA",
+    "OTHER",
 ];
 
 export const groupPropertyByStepAndSubStep = (
     properties: PropertyRenderConfig[]
-): Record<MetadataPropertyStep, Record<string, PropertyRenderConfig[]>> => {
+): Record<string, Record<string, PropertyRenderConfig[]>> => {
     const groupedProperties: Record<
-        MetadataPropertyStep,
+        string,
         Record<string, PropertyRenderConfig[]>
-    > = {
-        [MetadataPropertyStep.DATA]: {},
-        [MetadataPropertyStep.PREPROCESS]: {},
-        [MetadataPropertyStep.DETECTION]: {},
-        [MetadataPropertyStep.FILTER]: {},
-        [MetadataPropertyStep.POSTPROCESS]: {},
-        [MetadataPropertyStep.RCA]: {},
-        [MetadataPropertyStep.OTHER]: {},
-    };
+    > = {};
 
     for (const property of properties) {
-        const step = property.metadata.step || MetadataPropertyStep.OTHER;
+        const step =
+            property.metadata.step || ALERT_PROPERTIES_DEFAULT_STEP.STEP;
         if (!groupedProperties[step]) {
             groupedProperties[step] = {};
         }
-        const subStep = property.metadata.subStep || "DIRECT";
+        const subStep =
+            property.metadata.subStep || ALERT_PROPERTIES_DEFAULT_STEP.SUBSTEP;
         if (!groupedProperties?.[step]?.[subStep]) {
             groupedProperties[step][subStep] = [];
         }
@@ -510,20 +510,4 @@ export const groupPropertyByStepAndSubStep = (
     }
 
     return groupedProperties;
-};
-
-export const isStepEmpty = (
-    step: MetadataPropertyStep,
-    groupedProperties: Record<
-        MetadataPropertyStep,
-        Record<string, PropertyRenderConfig[]>
-    >
-): boolean => {
-    for (const subStep in groupedProperties[step]) {
-        if (groupedProperties[step][subStep].length > 0) {
-            return false;
-        }
-    }
-
-    return true;
 };


### PR DESCRIPTION


#### Issue(s)
https://startree.atlassian.net/browse/TE-2373

#### Description
The properties that we display while creating alert in advanced mode are grouped in sections based on their step property.
However as of now, those step names are hardcoded in the UI, and because of which if there is a step that isn't there in that hardcoded list, is getting filtered out and not shown on the UI.
What we are doing with the changes of this PR is that we will be grouping the properties based on their steps dynamically, that way if there is a new category of step introduced, we wont have to make any changes and it will work and show up automatically on the UI grouped together with other properties of the same step.

#### Screenshots

Attach screenshots of UI/U

https://github.com/user-attachments/assets/1c5c3538-4d3f-49de-937c-e6f216f803a2

X changes, if applicable.

#### How to test

List steps to reproduce the issue(s) and test the change, if required.
1. Create an alert in advance mode, and see that all the properties are being displayed. You can verify the properties against the template in configuration -> alert template -> go the the specific alert template
