### PR TITLE
[mvn] Upgrade jackson to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <guava.version>32.1.3-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hsqldb.version>2.7.1</hsqldb.version>
-    <jackson.version>2.13.5</jackson.version>
+    <jackson.version>2.17.2</jackson.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jodatime.version>2.12.5</jodatime.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
@@ -89,6 +89,7 @@
     <sendgrid.version>4.0.1</sendgrid.version>
     <slack.version>1.29.2</slack.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
+    <snakeyaml.version>2.2</snakeyaml.version>
     <swagger.version>2.1.6-1</swagger.version>
     <testcontainers.version>1.19.3</testcontainers.version>
     <micrometer.version>1.11.4</micrometer.version>
@@ -901,6 +902,17 @@
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-babel</artifactId>
         <version>${calcite.version}</version>
+      </dependency>
+      <!--
+      Force upgrading snakeyaml version due to conflicts from latest jackson dependency
+      snakeyaml upgraded from v2.16. see: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.16
+      This dependency conflicts with snakeyaml versions from pinot and swagger in several modules
+      Remove this when swagger and pinot are upgraded to latest versions with required snakeyaml dep
+      -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${snakeyaml.version}</version>
       </dependency>
 
       <!-- test dependencies -->


### PR DESCRIPTION
#### Issue(s)
[SECURITY - upgrade jackson to latest version](https://startree.atlassian.net/browse/TE-2383)

#### Description
Upgrading Jackson to the latest version to fix [DoS vulnerability](https://github.com/startreedata/thirdeye/pull/1504)