### PR TITLE
[server] Fix rca heatmap aggregation fn logic

### DIFF
--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-absolute-rule.json
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-absolute-rule.json
@@ -221,7 +221,8 @@
       "sqlFilter": "${rcaEventSqlFilter}"
     },
     "timezone": "${timezone}",
-    "granularity": "${monitoringGranularity}"
+    "granularity": "${monitoringGranularity}",
+    "detectionAggregationFunction": "${aggregationFunction}"
   },
   "properties": [
     {

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-mean-variance.json
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-mean-variance.json
@@ -207,7 +207,8 @@
       "sqlFilter": "${rcaEventSqlFilter}"
     },
     "timezone": "${timezone}",
-    "granularity": "${monitoringGranularity}"
+    "granularity": "${monitoringGranularity}",
+    "detectionAggregationFunction": "${aggregationFunction}"
   },
   "properties": [
     {

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-percentage-rule.json
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-percentage-rule.json
@@ -221,7 +221,8 @@
       "sqlFilter": "${rcaEventSqlFilter}"
     },
     "timezone": "${timezone}",
-    "granularity": "${monitoringGranularity}"
+    "granularity": "${monitoringGranularity}",
+    "detectionAggregationFunction": "${aggregationFunction}"
   },
   "properties": [
     {

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-threshold.json
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/resources/alert-templates/startree-threshold.json
@@ -189,7 +189,8 @@
       "sqlFilter": "${rcaEventSqlFilter}"
     },
     "timezone": "${timezone}",
-    "granularity": "${monitoringGranularity}"
+    "granularity": "${monitoringGranularity}",
+    "detectionAggregationFunction": "${aggregationFunction}"
   },
   "properties": [
     {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertMetadataApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertMetadataApi.java
@@ -30,6 +30,7 @@ public class AlertMetadataApi {
   private String granularity;
   private String timezone;
   private EventContextApi eventContext;
+  private String detectionAggregationFunction;
 
   public DataSourceApi getDatasource() {
     return datasource;
@@ -55,6 +56,16 @@ public class AlertMetadataApi {
 
   public AlertMetadataApi setMetric(final MetricApi metric) {
     this.metric = metric;
+    return this;
+  }
+
+  public String getDetectionAggregationFunction() {
+    return detectionAggregationFunction;
+  }
+
+  public AlertMetadataApi setDetectionAggregationFunction(
+      final String detectionAggregationFunction) {
+    this.detectionAggregationFunction = detectionAggregationFunction;
     return this;
   }
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertMetadataDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/AlertMetadataDTO.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import ai.startree.thirdeye.spi.api.AlertMetadataApi;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -30,6 +31,7 @@ public class AlertMetadataDTO {
   private String granularity;
   private String timezone;
   private EventContextDto eventContext;
+  private String detectionAggregationFunction;
 
   public DataSourceDTO getDatasource() {
     return datasource;
@@ -57,6 +59,16 @@ public class AlertMetadataDTO {
 
   public AlertMetadataDTO setMetric(final MetricConfigDTO metric) {
     this.metric = metric;
+    return this;
+  }
+
+  public String getDetectionAggregationFunction() {
+    return detectionAggregationFunction;
+  }
+
+  public AlertMetadataDTO setDetectionAggregationFunction(
+      final String detectionAggregationFunction) {
+    this.detectionAggregationFunction = detectionAggregationFunction;
     return this;
   }
 


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2382

#### Description

Aggregation function for RCA heatmap is resolved by following logic currently:
1. If custom RCA aggregation fn is provided, use it
2. if metric does not exists, default to COUNT 
3. else, use default aggregation fn of the metric

In cases 2 and 3, alert aggregation function should be used for RCA heatmap if custom rca aggregation fn is not present in template properties

This PR introduces changes to include a new metadata property in alert template - detectionAggregationFunction, which will be set to the alert aggregation function. It is being used to decide aggregation fn for rca heatmap if custom rca aggregation fn is not provided

#### Test
Scenario: An alert which is based on MAX aggregation function, but the metric's default aggregation fn is SUM

Before:
In absence of custom rca aggregation fn, we are using metric's default aggregation (SUM) for rca heatmap
![screencapture-localhost-7004-root-cause-analysis-v2-anomaly-56389-investigate-what-where-page-2024-08-09-13_21_22](https://github.com/user-attachments/assets/626c3b9d-2bdc-427f-b0be-5d11cedec805)

After:
In absence of custom rca aggregation fn, we will now use alert aggregation fn (MAX) for rca heatmap
![screencapture-localhost-7004-root-cause-analysis-v2-anomaly-56376-investigate-what-where-page-2024-08-09-13_04_10](https://github.com/user-attachments/assets/f0c2d76a-7d5b-492d-825b-8b0e85cc6508)


Note: 
this is a template breaking change for RCA.
All templates need to be updated. (see change in commit).