### PR TITLE
fix(ui): TE-2389 zIndex fix and redirect to home page if alerts exist in workspace

### DIFF
--- a/thirdeye-ui/src/app/components/admin-page/recent-failures/recent-failures.component.tsx
+++ b/thirdeye-ui/src/app/components/admin-page/recent-failures/recent-failures.component.tsx
@@ -29,8 +29,8 @@ import { LoadingErrorStateSwitch } from "../../page-states/loading-error-state-s
 import { TimeRangeQueryStringKey } from "../../time-range/time-range-provider/time-range-provider.interfaces";
 import { TimeRangeSelectorButton } from "../../time-range/v2/time-range-selector-button/time-range-selector-button.component";
 import { TaskRow } from "./task-row/task-row.component";
-import { useQuery } from "@tanstack/react-query";
 import { getTasks } from "../../../rest/tasks/tasks.rest";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 export const RecentFailures: FunctionComponent = () => {
     const { t } = useTranslation();
@@ -63,7 +63,7 @@ export const RecentFailures: FunctionComponent = () => {
         data: tasks,
         isLoading,
         isError,
-    } = useQuery({
+    } = useFetchQuery({
         queryKey: ["tasks", startTime, endTime],
         queryFn: () => {
             return getTasks({

--- a/thirdeye-ui/src/app/components/alert-view/alert-chart/alert-chart.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/alert-chart/alert-chart.component.tsx
@@ -21,7 +21,6 @@ import {
     Grid,
     Typography,
 } from "@material-ui/core";
-import { useQuery } from "@tanstack/react-query";
 import React, { FunctionComponent, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
@@ -47,6 +46,7 @@ import {
 import { TimeRangeQueryStringKey } from "../../time-range/time-range-provider/time-range-provider.interfaces";
 import { TimeSeriesChart } from "../../visualizations/time-series-chart/time-series-chart.component";
 import { AlertChartProps } from "./alert-chart.interfaces";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 export const AlertChart: FunctionComponent<AlertChartProps> = ({
     anomalies,
@@ -57,7 +57,7 @@ export const AlertChart: FunctionComponent<AlertChartProps> = ({
     const navigate = useNavigate();
     const { t } = useTranslation();
 
-    const getEvaluationQuery = useQuery({
+    const getEvaluationQuery = useFetchQuery({
         queryKey: ["evaluation", alertId, startTime, endTime],
         queryFn: () => {
             return getAlertEvaluation({

--- a/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
@@ -23,7 +23,6 @@ import {
 } from "@material-ui/core";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import { useQuery } from "@tanstack/react-query";
 import { DateTime } from "luxon";
 import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -55,6 +54,7 @@ import { TimeSeriesChart } from "../../../visualizations/time-series-chart/time-
 import { TimeSeriesChartProps } from "../../../visualizations/time-series-chart/time-series-chart.interfaces";
 import { EnumerationItemRowProps } from "./enumeration-item-row.interfaces";
 import { useEnumerationItemRowStyles } from "./enumeration-item-row.style";
+import { useFetchQuery } from "../../../../rest/hooks/useFetchQuery";
 
 export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     anomalies,
@@ -72,7 +72,7 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
         delay: 150,
     });
 
-    const getEvaluationQuery = useQuery({
+    const getEvaluationQuery = useFetchQuery({
         enabled: false,
         queryKey: [
             "evaluation",

--- a/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
@@ -15,7 +15,6 @@
 import { Box, Button, Grid, Typography, useTheme } from "@material-ui/core";
 import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import HighlightOffIcon from "@material-ui/icons/HighlightOff";
-import { useQuery } from "@tanstack/react-query";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -27,6 +26,7 @@ import { getAlertsUpdatePath } from "../../../utils/routes/routes.util";
 import { Modal } from "../../modal/modal.component";
 import { TimeRangeButtonWithContext } from "../../time-range/time-range-button-with-context/time-range-button.component";
 import { AlertViewSubHeaderProps } from "./alert-sub-header.interfaces";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 export const AlertViewSubHeader: FunctionComponent<AlertViewSubHeaderProps> = ({
     alert,
@@ -35,7 +35,7 @@ export const AlertViewSubHeader: FunctionComponent<AlertViewSubHeaderProps> = ({
     const { t } = useTranslation();
     const theme = useTheme();
 
-    const getAlertInsightQuery = useQuery({
+    const getAlertInsightQuery = useFetchQuery({
         queryKey: ["alertInsight", alert.id],
         queryFn: () => {
             return getAlertInsight({ alertId: alert.id });

--- a/thirdeye-ui/src/app/components/alert-view/subscription-groups-table/subscription-groups-table.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/subscription-groups-table/subscription-groups-table.component.tsx
@@ -24,7 +24,6 @@ import { useTranslation } from "react-i18next";
 import { SkeletonV1 } from "../../../platform/components";
 import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
 import { LoadingErrorStateSwitch } from "../../page-states/loading-error-state-switch/loading-error-state-switch.component";
-import { useQuery } from "@tanstack/react-query";
 import {
     getSubscriptionGroupsAllPath,
     getSubscriptionGroupsCreatePath,
@@ -49,6 +48,7 @@ import { useNavigate } from "react-router-dom";
 import { subscriptionGroupChannelIconsMap } from "../../subscription-group-view/notification-channels-card/notification-channels-card.utils";
 import { Icon } from "@iconify/react";
 import { EmptyStateSwitch } from "../../page-states/empty-state-switch/empty-state-switch.component";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 export const SubscriptionGroupsTable: FunctionComponent<SubscriptionGroupsTableProps> =
     ({ alertId, headerName }) => {
@@ -66,7 +66,7 @@ export const SubscriptionGroupsTable: FunctionComponent<SubscriptionGroupsTableP
             data: subscriptionGroups,
             isInitialLoading,
             isError,
-        } = useQuery<SubscriptionGroup[], AxiosError>({
+        } = useFetchQuery<SubscriptionGroup[], AxiosError>({
             queryKey: ["subscriptiongroups"],
             queryFn: () => {
                 return getAllSubscriptionGroups();

--- a/thirdeye-ui/src/app/components/alert-view/tasks-table/tasks-table.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/tasks-table/tasks-table.component.tsx
@@ -14,7 +14,6 @@
  */
 import { Box, Chip, Link, Typography } from "@material-ui/core";
 import { GridColumns, GridSortModel } from "@mui/x-data-grid";
-import { useQuery } from "@tanstack/react-query";
 import React, { FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -31,6 +30,7 @@ import { StyledDataGrid } from "../../data-grid/styled-data-grid.component";
 import { NoDataIndicator } from "../../no-data-indicator/no-data-indicator.component";
 import { LoadingErrorStateSwitch } from "../../page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { TaskTableProps } from "./task-table.interfaces";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 export const TasksTable: FunctionComponent<TaskTableProps> = ({
     alertId,
@@ -50,7 +50,7 @@ export const TasksTable: FunctionComponent<TaskTableProps> = ({
         data: tasks,
         isLoading,
         isError,
-    } = useQuery({
+    } = useFetchQuery({
         queryKey: ["tasks", "alert", alertId, start, end],
         queryFn: () => {
             return getTasks({

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
@@ -37,10 +37,10 @@ import {
 import { TimeSeriesChart } from "../../../../visualizations/time-series-chart/time-series-chart.component";
 import { EnumerationItemRowProps } from "./enumeration-item-row.interfaces";
 import { useInView } from "react-intersection-observer";
-import { useQuery } from "@tanstack/react-query";
 import { getAlertEvaluation } from "../../../../../rest/alerts/alerts.rest";
 import { LoadingErrorStateSwitch } from "../../../../page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { NoDataIndicator } from "../../../../no-data-indicator/no-data-indicator.component";
+import { useFetchQuery } from "../../../../../rest/hooks/useFetchQuery";
 
 export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     detectionEvaluation,
@@ -67,7 +67,7 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     const [timeSeriesData, setTimeSeriesData] = useState<any>();
     const [timeSeriesExpandedData, setTimeSeriesExpandedData] = useState<any>();
 
-    const getEvaluationQuery = useQuery({
+    const getEvaluationQuery = useFetchQuery({
         enabled: false,
         queryKey: [
             "evaluation",

--- a/thirdeye-ui/src/app/components/app-bar/app-header/app-header.styles.ts
+++ b/thirdeye-ui/src/app/components/app-bar/app-header/app-header.styles.ts
@@ -30,6 +30,7 @@ export const useAppHeaderStyles = (
             padding: "8px 16px",
             background: "#e1edff",
             display: "flex",
+            zIndex: 1,
             justifyContent: props.showWorkspaceSwitcher
                 ? "space-between"
                 : "end",

--- a/thirdeye-ui/src/app/components/app-bar/app-header/app-header.styles.ts
+++ b/thirdeye-ui/src/app/components/app-bar/app-header/app-header.styles.ts
@@ -30,7 +30,7 @@ export const useAppHeaderStyles = (
             padding: "8px 16px",
             background: "#e1edff",
             display: "flex",
-            zIndex: 1,
+            zIndex: 9999999,
             justifyContent: props.showWorkspaceSwitcher
                 ? "space-between"
                 : "end",

--- a/thirdeye-ui/src/app/components/home-page/recent-anomalies-v2/recent-anomalies-v2.component.tsx
+++ b/thirdeye-ui/src/app/components/home-page/recent-anomalies-v2/recent-anomalies-v2.component.tsx
@@ -15,7 +15,6 @@
 import { Box, Button, Grid, Link, Typography } from "@material-ui/core";
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
-import { useQuery } from "@tanstack/react-query";
 import { capitalize, sortBy } from "lodash";
 import { DateTime } from "luxon";
 import React, { FunctionComponent, useMemo } from "react";
@@ -32,6 +31,7 @@ import {
     TitleCardTableHead,
 } from "../title-card-table/title-card-table.component";
 import { AnomalyRowV2 } from "./anomaly-row-v2/anomaly-row-v2.component";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 export const RecentAnomaliesV2: FunctionComponent = () => {
     const { t } = useTranslation();
@@ -42,7 +42,7 @@ export const RecentAnomaliesV2: FunctionComponent = () => {
         .toMillis();
     const endTime = DateTime.local().endOf("hour").toMillis();
 
-    const getAnomaliesQuery = useQuery({
+    const getAnomaliesQuery = useFetchQuery({
         queryKey: ["anomalies", startTime, endTime],
         queryFn: () => {
             return getAnomalies({

--- a/thirdeye-ui/src/app/components/home-page/recent-anomalies/recent-anomalies.component.tsx
+++ b/thirdeye-ui/src/app/components/home-page/recent-anomalies/recent-anomalies.component.tsx
@@ -16,7 +16,6 @@ import { Box, Button, Grid, Table, Typography } from "@material-ui/core";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import { useQuery } from "@tanstack/react-query";
 import { capitalize, sortBy } from "lodash";
 import { DateTime } from "luxon";
 import React, { FunctionComponent, useMemo } from "react";
@@ -33,6 +32,7 @@ import { EmptyStateSwitch } from "../../page-states/empty-state-switch/empty-sta
 import { LoadingErrorStateSwitch } from "../../page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { Pluralize } from "../../pluralize/pluralize.component";
 import { AnomalyRow } from "./anomaly-row/anomaly-row.component";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 export const RecentAnomalies: FunctionComponent = () => {
     const { t } = useTranslation();
@@ -43,7 +43,7 @@ export const RecentAnomalies: FunctionComponent = () => {
         .toMillis();
     const endTime = DateTime.local().endOf("hour").toMillis();
 
-    const getAnomaliesQuery = useQuery({
+    const getAnomaliesQuery = useFetchQuery({
         queryKey: ["anomalies", startTime, endTime],
         queryFn: () => {
             return getAnomalies({
@@ -53,7 +53,7 @@ export const RecentAnomalies: FunctionComponent = () => {
         },
     });
 
-    const getAnomaliesCountQuery = useQuery({
+    const getAnomaliesCountQuery = useFetchQuery({
         queryKey: ["anomaliesCount"],
         queryFn: () => {
             return getAnomaliesCount();

--- a/thirdeye-ui/src/app/components/third-party-lib-setup-providers/analytics-and-error-reporting-provider-v1/analytics-and-error-reporting-provider-v1.component.tsx
+++ b/thirdeye-ui/src/app/components/third-party-lib-setup-providers/analytics-and-error-reporting-provider-v1/analytics-and-error-reporting-provider-v1.component.tsx
@@ -18,13 +18,13 @@
  * All rights reserved. Confidential and proprietary information of StarTree Inc.
  */
 import * as Sentry from "@sentry/react";
-import { useQuery } from "@tanstack/react-query";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useAuthProviderV1 } from "../../../platform/components";
 import { getAppConfiguration as getAppConfigurationRest } from "../../../rest/app-config/app-config.rest";
 import { getThirdEyeUiVersion } from "../../../utils/version/version.util";
 import { IntercomProvider } from "../intercom-provider/intercom-provider.component";
 import { AnalyticsAndErrorReportingProviderV1Props } from "./analytics-and-error-reporting-provider-v1.interfaces";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 const getEnvironmentFromHostname = (hostname: string): string => {
     return hostname.split(".").slice(1).join(".") || "production";
@@ -33,7 +33,7 @@ const getEnvironmentFromHostname = (hostname: string): string => {
 export const AnalyticsAndErrorReportingProviderV1: FunctionComponent<AnalyticsAndErrorReportingProviderV1Props> =
     ({ children }) => {
         const [isSentrySetup, setIsSentrySetup] = useState(false);
-        const { data: appConfig } = useQuery({
+        const { data: appConfig } = useFetchQuery({
             queryKey: ["appConfig"],
             queryFn: getAppConfigurationRest,
         });

--- a/thirdeye-ui/src/app/pages/alerts-all-page/alerts-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-all-page/alerts-all-page.component.tsx
@@ -41,11 +41,11 @@ import { UiAlert } from "../../rest/dto/ui-alert.interfaces";
 import { getUiAlerts } from "../../utils/alerts/alerts.util";
 import { notifyIfErrors } from "../../utils/notifications/notifications.util";
 import { getAlertsCreatePath } from "../../utils/routes/routes.util";
-import { useQuery } from "@tanstack/react-query";
 import { getAllSubscriptionGroups } from "../../rest/subscription-groups/subscription-groups.rest";
 import { getErrorMessages } from "../../utils/rest/rest.util";
 import { AxiosError } from "axios";
 import { SubscriptionGroup } from "../../rest/dto/subscription-group.interfaces";
+import { useFetchQuery } from "../../rest/hooks/useFetchQuery";
 
 export const AlertsAllPage: FunctionComponent = () => {
     const [uiAlerts, setUiAlerts] = useState<UiAlert[]>([]);
@@ -64,7 +64,7 @@ export const AlertsAllPage: FunctionComponent = () => {
         isInitialLoading: isGetAlertLoading,
         isError: isGetAlertError,
         error: getAlertsErrors,
-    } = useQuery<Alert[], AxiosError>({
+    } = useFetchQuery<Alert[], AxiosError>({
         queryKey: ["alerts"],
         queryFn: () => {
             return getAllAlerts();
@@ -76,7 +76,7 @@ export const AlertsAllPage: FunctionComponent = () => {
         isInitialLoading: isGetSubscriptionGroupsLoading,
         isError: isGetSubscriptionGroupsError,
         error: getSubscriptionGroupsErrors,
-    } = useQuery<SubscriptionGroup[], AxiosError>({
+    } = useFetchQuery<SubscriptionGroup[], AxiosError>({
         queryKey: ["subscriptiongroups"],
         queryFn: () => {
             return getAllSubscriptionGroups();

--- a/thirdeye-ui/src/app/pages/alerts-create-guided-page/setup-metric/setup-metric-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-guided-page/setup-metric/setup-metric-page.component.tsx
@@ -13,7 +13,6 @@
  * the License.
  */
 import { Box, Divider, Grid, Typography } from "@material-ui/core";
-import { useQuery } from "@tanstack/react-query";
 import { isEqual } from "lodash";
 import {
     default as React,
@@ -61,6 +60,7 @@ import {
 } from "../../../utils/routes/routes.util";
 import { AlertCreatedGuidedPageOutletContext } from "../alerts-create-guided-page.interfaces";
 import { DateTime, Duration } from "luxon";
+import { useFetchQuery } from "../../../rest/hooks/useFetchQuery";
 
 const ALERT_TEMPLATE_FOR_EVALUATE = "startree-threshold";
 const ALERT_TEMPLATE_FOR_EVALUATE_DX = "startree-threshold-dx";
@@ -136,7 +136,7 @@ export const SetupMetricPage: FunctionComponent = () => {
             return workingAlert;
         });
 
-    const { data: alertInsight } = useQuery({
+    const { data: alertInsight } = useFetchQuery({
         queryKey: [
             "alertInsight",
             alertConfigForPreview.templateProperties?.dataset,

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -22,7 +22,6 @@ import {
     Typography,
 } from "@material-ui/core";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
-import { useQuery } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import React, {
     FunctionComponent,
@@ -76,6 +75,7 @@ import {
     QUERY_PARAM_KEY_FOR_SORT,
     QUERY_PARAM_KEY_FOR_SORT_KEY,
 } from "./alerts-view-page.utils";
+import { useFetchQuery } from "../../rest/hooks/useFetchQuery";
 
 export const AlertsViewPage: FunctionComponent = () => {
     const { t } = useTranslation();
@@ -114,21 +114,21 @@ export const AlertsViewPage: FunctionComponent = () => {
         errorMessages: resetAlertRequestErrors,
     } = useResetAlert();
 
-    const getAlertQuery = useQuery({
+    const getAlertQuery = useFetchQuery({
         queryKey: ["alert", alertId],
         queryFn: () => {
             return getAlert(Number(alertId));
         },
     });
 
-    const getEnumerationItemsQuery = useQuery({
+    const getEnumerationItemsQuery = useFetchQuery({
         queryKey: ["enumerationItems", alertId],
         queryFn: () => {
             return getEnumerationItems({ alertId: Number(alertId) });
         },
     });
 
-    const getAnomaliesQuery = useQuery({
+    const getAnomaliesQuery = useFetchQuery({
         queryKey: ["anomalies", alertId, startTime, endTime],
         queryFn: () => {
             return getAnomalies({

--- a/thirdeye-ui/src/app/pages/anomalies-create-page/anomalies-create-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-create-page/anomalies-create-page.component.tsx
@@ -15,7 +15,6 @@
 
 import { Icon } from "@iconify/react";
 import { Box, Button, Divider, Grid, Typography } from "@material-ui/core";
-import { useQuery } from "@tanstack/react-query";
 import { AxiosError } from "axios/index";
 import React, { FunctionComponent, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -49,6 +48,7 @@ import {
     getAnomaliesCreatePath,
     getAnomaliesViewPath,
 } from "../../utils/routes/routes.util";
+import { useFetchQuery } from "../../rest/hooks/useFetchQuery";
 
 export const AnomaliesCreatePage: FunctionComponent = () => {
     const { t } = useTranslation();
@@ -58,7 +58,7 @@ export const AnomaliesCreatePage: FunctionComponent = () => {
         data: alerts,
         isInitialLoading: isGetAlertLoading,
         isError: isGetAlertError,
-    } = useQuery<Alert[], AxiosError>({
+    } = useFetchQuery<Alert[], AxiosError>({
         queryKey: ["alerts"],
         queryFn: () => {
             return getAllAlerts();

--- a/thirdeye-ui/src/app/pages/home-page/home-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/home-page/home-page.component.tsx
@@ -17,7 +17,6 @@ import DashboardIcon from "@material-ui/icons/Dashboard";
 import PersonAddIcon from "@material-ui/icons/PersonAdd";
 import PlaylistAddCheckIcon from "@material-ui/icons/PlaylistAddCheck";
 import ReportIcon from "@material-ui/icons/Report";
-import { useQuery } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { default as React, FunctionComponent, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -49,6 +48,7 @@ import {
     getAlertsAllPath,
 } from "../../utils/routes/routes.util";
 import { homePageTheme, useHomePageStyles } from "./home-page.styles";
+import { useFetchQuery } from "../../rest/hooks/useFetchQuery";
 
 export const HomePage: FunctionComponent = () => {
     const navigate = useNavigate();
@@ -57,13 +57,13 @@ export const HomePage: FunctionComponent = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const style = useHomePageStyles();
 
-    const getAlertsQuery = useQuery<Alert[], AxiosError>({
+    const getAlertsQuery = useFetchQuery<Alert[], AxiosError>({
         queryKey: ["alerts"],
         queryFn: () => {
             return getAllAlerts();
         },
     });
-    const getSubscriptionGroupsQuery = useQuery<
+    const getSubscriptionGroupsQuery = useFetchQuery<
         SubscriptionGroup[],
         AxiosError
     >({

--- a/thirdeye-ui/src/app/pages/welcome-page/landing/landing-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/welcome-page/landing/landing-page.component.tsx
@@ -31,19 +31,36 @@ import { useGetDatasets } from "../../../rest/datasets/datasets.actions";
 import {
     getConfigurationPath,
     getDataConfigurationCreatePath,
+    getHomePath,
     getWelcomeCreateAlert,
 } from "../../../utils/routes/routes.util";
+import { useGetAlertsCount } from "../../../rest/alerts/alerts.actions";
+import { useNavigate } from "react-router-dom";
+import { useAppBarConfigProvider } from "../../../components/app-bar/app-bar-config-provider/app-bar-config-provider.component";
 
 export const WelcomeLandingPage: FunctionComponent = () => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
+    const { setShowAppNavBar } = useAppBarConfigProvider();
 
     const { status, datasets, getDatasets } = useGetDatasets();
+    const { alertsCount, getAlertsCount } = useGetAlertsCount();
 
     const hasDatasets = !!(datasets && datasets.length > 0);
 
     useEffect(() => {
         getDatasets();
+        getAlertsCount();
     }, []);
+
+    useEffect(() => {
+        if (alertsCount?.count) {
+            setShowAppNavBar(true);
+            navigate(getHomePath());
+
+            return;
+        }
+    }, [alertsCount?.count]);
 
     return (
         <PageV1>

--- a/thirdeye-ui/src/app/rest/alerts/alerts.actions.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.actions.ts
@@ -18,6 +18,7 @@ import {
     AlertEvaluation,
     AlertInsight,
     AlertStats,
+    AlertsCount,
     EditableAlert,
 } from "../dto/alert.interfaces";
 import { EnumerationItem } from "../dto/enumeration-item.interfaces";
@@ -26,6 +27,7 @@ import {
     GetAlertEvaluationPayload,
     GetAlertInsight,
     GetAlerts,
+    GetAlertsCount,
     GetAlertStats,
     GetAlertStatsParams,
     GetEvaluation,
@@ -38,6 +40,7 @@ import {
     getAlertStats as getAlertStatsREST,
     getAllAlerts,
     resetAlert as resetAlertREST,
+    getAlertsCount as getAlertsCountREST,
 } from "./alerts.rest";
 
 export const useGetEvaluation = (): GetEvaluation => {
@@ -127,6 +130,23 @@ export const useGetAlertStats = (): GetAlertStats => {
     return {
         alertStats: data,
         getAlertStats,
+        status,
+        errorMessages,
+        resetData,
+    };
+};
+
+export const useGetAlertsCount = (): GetAlertsCount => {
+    const { data, makeRequest, status, errorMessages, resetData } =
+        useHTTPAction<AlertsCount>(getAlertsCountREST);
+
+    const getAlertsCount = (): Promise<AlertsCount | undefined> => {
+        return makeRequest();
+    };
+
+    return {
+        alertsCount: data,
+        getAlertsCount,
         status,
         errorMessages,
         resetData,

--- a/thirdeye-ui/src/app/rest/alerts/alerts.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.interfaces.ts
@@ -19,6 +19,7 @@ import {
     AlertInsight,
     AlertStats,
     EditableAlert,
+    AlertsCount,
 } from "../dto/alert.interfaces";
 import { EnumerationItemInEvaluation } from "../dto/detection.interfaces";
 import { EnumerationItem } from "../dto/enumeration-item.interfaces";
@@ -91,4 +92,9 @@ export interface GetAlertStatsParams {
     alertId: number;
     startTime?: number;
     endTime?: number;
+}
+
+export interface GetAlertsCount extends ActionHook {
+    alertsCount: AlertsCount | null;
+    getAlertsCount: () => Promise<AlertsCount | undefined>;
 }

--- a/thirdeye-ui/src/app/rest/alerts/alerts.rest.ts
+++ b/thirdeye-ui/src/app/rest/alerts/alerts.rest.ts
@@ -20,6 +20,7 @@ import type {
     AlertEvaluation,
     AlertInsight,
     AlertStats,
+    AlertsCount,
     EditableAlert,
 } from "../dto/alert.interfaces";
 import {
@@ -227,4 +228,10 @@ export const getAlertRecommendation = async (
     }
 
     return response.data.recommendations;
+};
+
+export const getAlertsCount = async (): Promise<AlertsCount> => {
+    const response = await axios.get(`${BASE_URL_ALERTS}/count`);
+
+    return response.data;
 };

--- a/thirdeye-ui/src/app/rest/dto/alert.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/dto/alert.interfaces.ts
@@ -162,3 +162,7 @@ export interface AlertStats {
     countWithFeedback: number;
     feedbackStats: Record<keyof typeof AnomalyFeedbackType, number>;
 }
+
+export interface AlertsCount {
+    count: number;
+}

--- a/thirdeye-ui/src/app/rest/hooks/fetch-query.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/hooks/fetch-query.interfaces.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export type QueryFn<T> = () => Promise<T>;
+
+export interface QueryConfig<T> {
+    enabled?: boolean;
+    queryKey: unknown[];
+    queryFn: QueryFn<T>;
+}

--- a/thirdeye-ui/src/app/rest/hooks/useFetchQuery.tsx
+++ b/thirdeye-ui/src/app/rest/hooks/useFetchQuery.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import { useAuthV1 } from "../../platform/stores/auth-v1/auth-v1.store";
+import { QueryConfig } from "./fetch-query.interfaces";
+
+export function useFetchQuery<T, E>({
+    enabled = true,
+    queryKey,
+    queryFn,
+}: QueryConfig<T>): UseQueryResult<T, E> {
+    const { workspace } = useAuthV1();
+    if (workspace.id) {
+        queryKey.push(workspace.id);
+    }
+
+    return useQuery({
+        enabled,
+        queryKey,
+        queryFn,
+    });
+}


### PR DESCRIPTION
… in workspace

#### Issue(s)

https://startree.atlassian.net/browse/TE-2389

#### Description

With the workspace switcher header, we have to make sure its sticky and content behind it, while scrolling the page is not visible.
This PR also fixes an issue where we want to redirect the user to home page from the welcome landing page, if the workspace they are in, already has alerts

#### Screenshots

Attach screenshots of UI/UX changes, if applicable.

https://github.com/user-attachments/assets/2e0be10e-7a72-4cee-98de-eefc847d6182


