### PR TITLE
[notification] Add zero anomalies check for notifications

### DIFF
--- a/thirdeye-plugins/thirdeye-notification-email/src/main/java/ai/startree/thirdeye/plugins/notification/email/EmailSendgridNotificationService.java
+++ b/thirdeye-plugins/thirdeye-notification-email/src/main/java/ai/startree/thirdeye/plugins/notification/email/EmailSendgridNotificationService.java
@@ -48,9 +48,13 @@ public class EmailSendgridNotificationService implements NotificationService {
 
   @Override
   public void notify(final NotificationPayloadApi api) throws ThirdEyeException {
+    if (api.getAnomalyReports().isEmpty()) {
+      LOG.debug("No new anomalies to notify");
+      return;
+    }
+
     try {
       final EmailContent emailContent = new EmailContentBuilder().build(api);
-
       sendEmail(emailContent);
     } catch (final Exception e) {
       throw new ThirdEyeException(e, ERR_NOTIFICATION_DISPATCH, "sendgrid dispatch failed!");

--- a/thirdeye-plugins/thirdeye-notification-email/src/main/java/ai/startree/thirdeye/plugins/notification/email/EmailSmtpNotificationService.java
+++ b/thirdeye-plugins/thirdeye-notification-email/src/main/java/ai/startree/thirdeye/plugins/notification/email/EmailSmtpNotificationService.java
@@ -69,11 +69,14 @@ public class EmailSmtpNotificationService implements NotificationService {
 
   @Override
   public void notify(final NotificationPayloadApi api) throws ThirdEyeException {
+    if (api.getAnomalyReports().isEmpty()) {
+      LOG.debug("No new anomalies to notify");
+      return;
+    }
+
     final EmailContentBuilder emailContentBuilder = new EmailContentBuilder();
     try {
-      final EmailContent emailContent = emailContentBuilder.build(api
-      );
-
+      final EmailContent emailContent = emailContentBuilder.build(api);
       final HtmlEmail email = buildHtmlEmail(emailContent);
       sendEmail(email);
     } catch (final Exception e) {


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2197

#### Description

0 anomalies emails are being sent in few cases. This happens when have 0 anomalies and non-zero completed anomalies.

In [[worker] Feat: Completed Anomalies. Adding filtering logic stub for getting completed anomalies.](https://github.com/startreedata/thirdeye/commit/00b3e83bb256459b5e3933c2944d51db9a3335de#diff-8cf81be035b197f50b6eb9c91f626782d8dfd128424f49db76a2e7333c624bb7), concept of completed anomalies was introduced to the NotificationTaskRunner

Along with computing anomalies to be reported, we started computing completed anomalies that may be reported in addition. The preliminary check to decide whether notification should be dispatched or not, was changed to check for both anomalies and completed anomalies. 

Hence, if either of non-zero anomalies or non-zero completed anomalies is present, notification dispatcher would be run, thereby triggering notification services (email, slack, pagerduty, etc)

![Screenshot 2024-08-13 at 1 28 52 PM](https://github.com/user-attachments/assets/d6ed36f8-203a-42e5-8633-d81db1c04fe9)

Since now, dispatcher -> notification service, can be executed even in case of zero anomalies (when non-zero completed anomalies are present). We need explicit checks to ensure no notification is sent for zero anomalies

This check is already present in [PagerDutyNoticiationService](https://github.com/startreedata/startree-thirdeye/blob/main/startree-thirdeye-plugins/startree-thirdeye-notification-pagerduty/src/main/java/ai/startree/thirdeye/plugins/notification/pagerduty/PagerDutyNotificationService.java#L64) and [SlackNotificationService
](https://github.com/startreedata/startree-thirdeye/blob/main/startree-thirdeye-plugins/startree-thirdeye-notification-slack/src/main/java/ai/startree/thirdeye/plugins/notification/slack/SlackNotificationService.java#L211) but not in [EmailSendgridNotificationService](https://github.com/startreedata/thirdeye/blob/master/thirdeye-plugins/thirdeye-notification-email/src/main/java/ai/startree/thirdeye/plugins/notification/email/EmailSendgridNotificationService.java#L50) and [EmailSmtpNotificationService](https://github.com/startreedata/thirdeye/blob/master/thirdeye-plugins/thirdeye-notification-email/src/main/java/ai/startree/thirdeye/plugins/notification/email/EmailSmtpNotificationService.java#L71), thereby resulting in zero anomalies email being sent

This PR adds those explicit zero anomalies check to notify methods of EmailSendgridNotificationService and EmailSmtpNotificationService