### PR TITLE
fix(ui): TE-2411 avoid passing alertId in evaluate call when updating alert

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/enumeration-items-table/enumeration-item-row/enumeration-item-row.component.tsx
@@ -41,6 +41,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getAlertEvaluation } from "../../../../../rest/alerts/alerts.rest";
 import { LoadingErrorStateSwitch } from "../../../../page-states/loading-error-state-switch/loading-error-state-switch.component";
 import { NoDataIndicator } from "../../../../no-data-indicator/no-data-indicator.component";
+import { cloneDeep } from "lodash";
 
 export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     detectionEvaluation,
@@ -67,11 +68,14 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
     const [timeSeriesData, setTimeSeriesData] = useState<any>();
     const [timeSeriesExpandedData, setTimeSeriesExpandedData] = useState<any>();
 
+    const alertParams = cloneDeep(alert);
+    delete (alertParams as any).id;
+
     const getEvaluationQuery = useQuery({
         enabled: false,
         queryKey: [
             "evaluation",
-            alert,
+            alertParams,
             detectionEvaluation.enumerationItem,
             evaluationTimeRange?.startTime,
             evaluationTimeRange?.endTime,
@@ -79,7 +83,7 @@ export const EnumerationItemRow: FunctionComponent<EnumerationItemRowProps> = ({
         queryFn: () => {
             return getAlertEvaluation(
                 {
-                    alert,
+                    alert: alertParams,
                     start: evaluationTimeRange?.startTime,
                     end: evaluationTimeRange?.endTime,
                 },


### PR DESCRIPTION
… alert

#### Issue(s)

https://startree.atlassian.net/browse/TE-2411

#### Description

When updating an alert which has enumeration items, we do not have to pass the alertId to the evaluate call 

#### Screenshots

https://github.com/user-attachments/assets/25c002b5-6eff-422c-89da-ddb0d98559b7



#### How to test

1. Go to any alert which has enumeration items.
2. Open the edit alert page.
3. Update any alert property.
4. Click on Load chart preview.
5. See in the evaluate api call in network tab that alertId is not being passed in the payload
