### PR TITLE
fix(ui): TE-2418 fix preview load alert with single enum item

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/chart-content/chart-content.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/chart-content/chart-content.component.tsx
@@ -193,8 +193,7 @@ export const ChartContent: FunctionComponent<ChartContentProps> = ({
                     )}
 
                 {workingDetectionEvaluations &&
-                    (workingDetectionEvaluations.length > 1 ||
-                        workingDetectionEvaluations[0]?.enumerationItem) && (
+                    workingDetectionEvaluations[0]?.enumerationItem && (
                         <Box marginTop={1}>
                             <EnumerationItemsTable
                                 alert={alert}

--- a/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/chart-content/chart-content.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v3/preview-chart/chart-content/chart-content.component.tsx
@@ -193,7 +193,8 @@ export const ChartContent: FunctionComponent<ChartContentProps> = ({
                     )}
 
                 {workingDetectionEvaluations &&
-                    workingDetectionEvaluations.length > 1 && (
+                    (workingDetectionEvaluations.length > 1 ||
+                        workingDetectionEvaluations[0]?.enumerationItem) && (
                         <Box marginTop={1}>
                             <EnumerationItemsTable
                                 alert={alert}


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2418

#### Description

When creating multi dimensional alert, preview chart was not loading if there is only one enumeration item. This PR fixes that

#### Screenshots

https://github.com/user-attachments/assets/ba010bb3-c4a5-4953-86d3-1e2755efee82



#### How to test

1. Go to create multi dimensional alert.
2. Add one enumeration item only.
3. Click on load chart.
4. See that that alert chart loads.

