### PR TITLE
fix(ui): TE-2426 fix scroll in subscription group in create alert flow

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-notifications/subscription-groups/subscription-groups.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-notifications/subscription-groups/subscription-groups.component.tsx
@@ -175,7 +175,7 @@ export const SubscriptionGroups: FunctionComponent<SubscriptionGroupsProps> = ({
                             </Grid>
                             <Grid container item xs={12}>
                                 <Grid item lg={5} md={6} xs={12}>
-                                    <Box height={300}>
+                                    <Box height={300} overflow="auto">
                                         <DataGridV1<SubscriptionGroup>
                                             hideBorder
                                             hideToolbar


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2426

#### Description

User was not able to scroll through subscription groups in the create alert flow, which has been fixed via this PR

#### Screenshots


https://github.com/user-attachments/assets/9e0dfff6-fc1f-40be-8b04-e254ca41c2fb


