### PR TITLE
[k8s] add accessControl to helm template

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -59,6 +59,9 @@ data:
     auth:
 {{ toYaml .Values.auth | indent 6 }}
 
+    accessControl:
+{{ toYaml .Values.accessControl | indent 6 }}
+
     database:
       # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 'mysql.port'
       url: jdbc:mysql://{{- if .Values.mysql.enabled -}}{{- include "thirdeye.mysql.fullname" . -}}{{- else -}}{{- .Values.mysql.url -}}:{{- .Values.mysql.port -}}{{- end -}}/{{- .Values.mysql.mysqlDatabase -}}?autoReconnect=true&{{ .Values.config.jdbcParameters }}

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -82,6 +82,9 @@ data:
     #    cache:
     #      size: 64
     #      ttl: 60000
+    
+    accessControl:
+      enabled: false
 
     database:
       # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 'mysql.port'

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -82,6 +82,9 @@ data:
     #    cache:
     #      size: 64
     #      ttl: 60000
+    
+    accessControl:
+      enabled: false
 
     database:
       # If internal MySQL is disabled, connection will be made to the provided 'mysql.url' on port 'mysql.port'

--- a/kubernetes/helm/startree-thirdeye/values.yaml
+++ b/kubernetes/helm/startree-thirdeye/values.yaml
@@ -171,6 +171,9 @@ auth:
     # set to true to enable the new namespace system
     requireNamespace: false
 
+accessControl:
+  enabled: false
+
 # Do not remove me.
 config:
   description: placeholder for common configs accross coordinator and worker


### PR DESCRIPTION
#### Issue(s)

[AccessControl Helm Changes](https://startree.atlassian.net/browse/TE-2438)

#### Description
Adding accessControl to helm template server yaml configuration
It is used to enable/disable the ThirdEyeAuthorizer Plugin (disabled by default)

#### How to test
Validate helm install locally
`cd kubernetes/helm/startree-thirdeye`
`helm install --generate-name . --debug --dry-run`

[helm-debug-output.log](https://github.com/user-attachments/files/17024047/helm-debug-output.log)

