### PR TITLE
[server] Delete associated RCAInvestigations in Alert Delete Flow

### DIFF
--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/AlertResourceTest.java
@@ -44,6 +44,7 @@ import ai.startree.thirdeye.spi.datalayer.bao.AnomalyManager;
 import ai.startree.thirdeye.spi.datalayer.bao.DataSourceManager;
 import ai.startree.thirdeye.spi.datalayer.bao.DatasetConfigManager;
 import ai.startree.thirdeye.spi.datalayer.bao.EnumerationItemManager;
+import ai.startree.thirdeye.spi.datalayer.bao.RcaInvestigationManager;
 import ai.startree.thirdeye.spi.datalayer.bao.SubscriptionGroupManager;
 import ai.startree.thirdeye.spi.datalayer.bao.TaskManager;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
@@ -87,6 +88,7 @@ public class AlertResourceTest {
         mock(AlertInsightsProvider.class),
         mock(SubscriptionGroupManager.class),
         mock(EnumerationItemManager.class),
+        mock(RcaInvestigationManager.class),
         mock(TaskManager.class),
         new TimeConfiguration(),
         authorizationManager
@@ -264,6 +266,7 @@ public class AlertResourceTest {
         mock(AlertInsightsProvider.class),
         mock(SubscriptionGroupManager.class),
         mock(EnumerationItemManager.class),
+        mock(RcaInvestigationManager.class),
         mock(TaskManager.class),
         new TimeConfiguration(),
         newAuthorizationManager(mock(AlertTemplateManager.class),
@@ -300,6 +303,7 @@ public class AlertResourceTest {
         mock(AlertInsightsProvider.class),
         mock(SubscriptionGroupManager.class),
         mock(EnumerationItemManager.class),
+        mock(RcaInvestigationManager.class),
         mock(TaskManager.class),
         new TimeConfiguration(),
         newAuthorizationManager(mock(AlertTemplateManager.class),


### PR DESCRIPTION
#### Issue(s)

[RCA entities in inconsistent state in db when an alert is deleted](https://startree.atlassian.net/browse/TE-2440)

#### Description

When an alert is deleted, [associated entities are deleted](https://github.com/startreedata/thirdeye/blob/d8affb568fd3e8c7977be4208a9be6151591197b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/AlertService.java#L110): anomalies, enumeration items
But associated RCA Investigations are not deleted

This later causes issues because RCA investigation are parentless and breaks few APIs of RCA investigation

This PR introduces logic to delete associated RCAInvestigations in Alert delete flow

#### Testing

Tested locally by spawning service+UI and simulating delete alert flow

1. Create a RCA investigation corresponding to an anomaly
2. Delete associated alert of that anomaly
3. Verify that following APIs are behaving as expected before and after Deleting alert (Step 2)
    a. GET `/api/alerts`
    b. GET `/api/anomalies`
    c. GET `/api/rca/investigations`
