### PR TITLE
[helm] Add flag to toggle holiday calendar events

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -157,6 +157,7 @@ data:
       detectionAlert: true
 
       holidayEvents:
+        {{- if .Values.config.loadCalendarEvents }}
         enabled: {{ not .Values.secrets.holidayLoaderKey | ternary "false" "true" }}
         calendars:
         {{- if .Values.config.calendars }}
@@ -202,3 +203,7 @@ data:
         {{- end }}
         holidayLoadRange: 2592000000
         runFrequency: 1  # in Days
+        {{- else }}
+        enabled: false
+        calendars: []
+        {{- end }}

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -156,6 +156,7 @@ data:
       detectionAlert: true
 
       holidayEvents:
+        {{- if .Values.config.loadCalendarEvents }}
         enabled: {{ not .Values.secrets.holidayLoaderKey | ternary "false" "true" }}
         calendars:
         {{- if .Values.config.calendars }}
@@ -201,4 +202,9 @@ data:
         {{- end }}
         holidayLoadRange: 2592000000
         runFrequency: 1  # in Days
+        {{- else }}
+        enabled: false
+        calendars: []
+        {{- end }}
+
 {{ end }}

--- a/kubernetes/helm/startree-thirdeye/values.yaml
+++ b/kubernetes/helm/startree-thirdeye/values.yaml
@@ -178,6 +178,7 @@ accessControl:
 config:
   description: placeholder for common configs accross coordinator and worker
   jdbcParameters: allowPublicKeyRetrieval=true&sslMode=DISABLED
+  loadCalendarEvents: true
 
 # Section for dynamic secret generation
 secrets:


### PR DESCRIPTION
#### Issue(s)

[Change TE Helm Template to allow disabling Calendar Events](https://startree.atlassian.net/browse/TE-2457)

#### Description
There are few cases where we would want to disable calendar events explicitly for a certain environment
currently, there's no way to pass empty calendars list

Hence adding new flag to allow disabling calendar events
By default, it will be set to true in values.yaml, exhibiting the current behaviour
One can pass config.loadCalendarEvents as false in chart values to disable holiday events loading

#### Testing
Ran helm install locally and compared changes before and after the PR

##### Scenario 1:
No explicit chart value passed
`helm install startree-thirdeye startree-thirdeye --dry-run`

Before:
[before.txt](https://github.com/user-attachments/files/17129341/before.txt)
After:
[after-loadCalendarEvents-true.txt](https://github.com/user-attachments/files/17129342/after-loadCalendarEvents-true.txt)

Diff:
```diff
diff -u before/before.yaml after/after-loadCalendarEvents-true.yaml
--- before/before.yaml  2024-09-25 15:44:55
+++ after/after-loadCalendarEvents-true.yaml    2024-09-25 15:46:37
@@ -1,5 +1,5 @@
 NAME: startree-thirdeye
-LAST DEPLOYED: Wed Sep 25 15:39:28 2024
+LAST DEPLOYED: Wed Sep 25 15:46:21 2024
 NAMESPACE: default
 STATUS: pending-install
 REVISION: 1
@@ -1966,3 +1966,4 @@
 # See the License for the specific language governing permissions and limitations under
 # the License.
 #
+
```

##### Scenario 2:
Pass loadCalendarEvents explicitly as false
`helm install startree-thirdeye startree-thirdeye --dry-run --set config.loadCalendarEvents=false`

Before:
[before.txt](https://github.com/user-attachments/files/17129341/before.txt)
After:
[after-loadCalendarEvents-false.txt](https://github.com/user-attachments/files/17129371/after-loadCalendarEvents-false.txt)

Diff:
```diff
diff -u before/before.yaml after/after-loadCalendarEvents-false.yaml
--- before/before.yaml  2024-09-25 15:44:55
+++ after/after-loadCalendarEvents-false.yaml   2024-09-25 15:46:53
@@ -1,5 +1,5 @@
 NAME: startree-thirdeye
-LAST DEPLOYED: Wed Sep 25 15:39:28 2024
+LAST DEPLOYED: Wed Sep 25 15:46:41 2024
 NAMESPACE: default
 STATUS: pending-install
 REVISION: 1
@@ -316,46 +316,7 @@
 
       holidayEvents:
         enabled: false
-        calendars:
-          - en.australian#holiday@group.v.calendar.google.com
-          - en.austrian#holiday@group.v.calendar.google.com
-          - en.brazilian#holiday@group.v.calendar.google.com
-          - en.canadian#holiday@group.v.calendar.google.com
-          - en.china#holiday@group.v.calendar.google.com
-          - en.christian#holiday@group.v.calendar.google.com
-          - en.danish#holiday@group.v.calendar.google.com
-          - en.dutch#holiday@group.v.calendar.google.com
-          - en.finnish#holiday@group.v.calendar.google.com
-          - en.french#holiday@group.v.calendar.google.com
-          - en.german#holiday@group.v.calendar.google.com
-          - en.greek#holiday@group.v.calendar.google.com
-          - en.hong_kong#holiday@group.v.calendar.google.com
-          - en.indian#holiday@group.v.calendar.google.com
-          - en.indonesian#holiday@group.v.calendar.google.com
-          - en.irish#holiday@group.v.calendar.google.com
-          - en.islamic#holiday@group.v.calendar.google.com
-          - en.italian#holiday@group.v.calendar.google.com
-          - en.japanese#holiday@group.v.calendar.google.com
-          - en.jewish#holiday@group.v.calendar.google.com
-          - en.malaysia#holiday@group.v.calendar.google.com
-          - en.mexican#holiday@group.v.calendar.google.com
-          - en.new_zealand#holiday@group.v.calendar.google.com
-          - en.norwegian#holiday@group.v.calendar.google.com
-          - en.philippines#holiday@group.v.calendar.google.com
-          - en.polish#holiday@group.v.calendar.google.com
-          - en.portuguese#holiday@group.v.calendar.google.com
-          - en.russian#holiday@group.v.calendar.google.com
-          - en.singapore#holiday@group.v.calendar.google.com
-          - en.sa#holiday@group.v.calendar.google.com
-          - en.south_korea#holiday@group.v.calendar.google.com
-          - en.spain#holiday@group.v.calendar.google.com
-          - en.swedish#holiday@group.v.calendar.google.com
-          - en.taiwan#holiday@group.v.calendar.google.com
-          - en.uk#holiday@group.v.calendar.google.com
-          - en.usa#holiday@group.v.calendar.google.com
-          - en.vietnamese#holiday@group.v.calendar.google.com
-        holidayLoadRange: 2592000000
-        runFrequency: 1  # in Days
+        calendars: []
 ---
 # Source: startree-thirdeye/templates/scheduler/scheduler-config.yaml
 #
@@ -505,46 +466,7 @@
 
       holidayEvents:
         enabled: false
-        calendars:
-          - en.australian#holiday@group.v.calendar.google.com
-          - en.austrian#holiday@group.v.calendar.google.com
-          - en.brazilian#holiday@group.v.calendar.google.com
-          - en.canadian#holiday@group.v.calendar.google.com
-          - en.china#holiday@group.v.calendar.google.com
-          - en.christian#holiday@group.v.calendar.google.com
-          - en.danish#holiday@group.v.calendar.google.com
-          - en.dutch#holiday@group.v.calendar.google.com
-          - en.finnish#holiday@group.v.calendar.google.com
-          - en.french#holiday@group.v.calendar.google.com
-          - en.german#holiday@group.v.calendar.google.com
-          - en.greek#holiday@group.v.calendar.google.com
-          - en.hong_kong#holiday@group.v.calendar.google.com
-          - en.indian#holiday@group.v.calendar.google.com
-          - en.indonesian#holiday@group.v.calendar.google.com
-          - en.irish#holiday@group.v.calendar.google.com
-          - en.islamic#holiday@group.v.calendar.google.com
-          - en.italian#holiday@group.v.calendar.google.com
-          - en.japanese#holiday@group.v.calendar.google.com
-          - en.jewish#holiday@group.v.calendar.google.com
-          - en.malaysia#holiday@group.v.calendar.google.com
-          - en.mexican#holiday@group.v.calendar.google.com
-          - en.new_zealand#holiday@group.v.calendar.google.com
-          - en.norwegian#holiday@group.v.calendar.google.com
-          - en.philippines#holiday@group.v.calendar.google.com
-          - en.polish#holiday@group.v.calendar.google.com
-          - en.portuguese#holiday@group.v.calendar.google.com
-          - en.russian#holiday@group.v.calendar.google.com
-          - en.singapore#holiday@group.v.calendar.google.com
-          - en.sa#holiday@group.v.calendar.google.com
-          - en.south_korea#holiday@group.v.calendar.google.com
-          - en.spain#holiday@group.v.calendar.google.com
-          - en.swedish#holiday@group.v.calendar.google.com
-          - en.taiwan#holiday@group.v.calendar.google.com
-          - en.uk#holiday@group.v.calendar.google.com
-          - en.usa#holiday@group.v.calendar.google.com
-          - en.vietnamese#holiday@group.v.calendar.google.com
-        holidayLoadRange: 2592000000
-        runFrequency: 1  # in Days
+        calendars: []
 ---
 # Source: startree-thirdeye/templates/worker/worker-config.yaml
 #
```

