### PR TITLE
[server] Delete associated RCAInvestigations in Alert Reset Flow

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/AlertService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/AlertService.java
@@ -308,7 +308,9 @@ public class AlertService extends CrudService<AlertApi, AlertDTO> {
      * with subscription groups. This is taken care automatically after the reset when the pipeline
      * is executed and the enumerator operator cleans the existing enumeration items
      */
+    deleteAssociatedRcaInvestigations(dto.getId());
     deleteAssociatedAnomalies(dto.getId());
+
     // reset lastTimestamp
     dto.setLastTimestamp(minimumLastTimestamp(principal, dto));
     dtoManager.update(dto);


### PR DESCRIPTION
#### Issue(s)

[RCA entities in inconsistent state in db when an alert is deleted](https://startree.atlassian.net/browse/TE-2440)

#### Description

When an alert is reset, [associated anomalies are deleted](https://github.com/startreedata/thirdeye/blob/d8affb568fd3e8c7977be4208a9be6151591197b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/AlertService.java#L303)
but rca investigations corresponding to those anomalies are not deleted

This later causes issues because RCA investigation are parentless and breaks few APIs of RCA investigation

This PR introduces logic to delete associated RCAInvestigations in Alert reset flow

#### Testing

Tested locally by spawning service+UI and simulating reset alert flow

1. Create RCA investigation(s) corresponding to anomalies of a specific alert from UI
2. Reset anomalies of that alert, either from UI or `/api/alerts/{alert_id}/reset` API
3. Verify that following APIs are behaving as expected before and after Deleting alert (Step 2)
    a. GET `/api/alerts` -> should still return same set of alerts
    b. GET `/api/anomalies` -> old anomalies of reset alert should be removed and new ones should be created
    c. GET `/api/rca/investigations` -> associated rca investigations of the alert should be deleted 
