### PR TITLE
fix(ui): TE-2471 close sections in swagger ui by default

### DIFF
--- a/thirdeye-ui/src/app/pages/swagger/index.tsx
+++ b/thirdeye-ui/src/app/pages/swagger/index.tsx
@@ -53,7 +53,7 @@ export const SwaggerDocs = (): JSX.Element => {
 
     return (
         <div>
-            <SwaggerUI url="/openapi.json" {...swaggerOptions} />
+            <SwaggerUI url="/openapi.json" docExpansion={"none"} {...swaggerOptions} />
         </div>
     );
 };


### PR DESCRIPTION
before: opened by default
<img width="1482" alt="Screenshot 2024-10-04 at 11 04 20" src="https://github.com/user-attachments/assets/dafbcfab-a63c-4e78-8124-bfb0806f6eca">

after: closed by default
<img width="1483" alt="Screenshot 2024-10-04 at 11 04 49" src="https://github.com/user-attachments/assets/9adc55bb-0d3c-4bd3-b175-90ff22d48f09">

would like to get this merged before sharing a new version with on-premise customers