### PR TITLE
fix(ui): TE-2474 show all template properties in advance create mode

### DIFF
--- a/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-wizard-v2/alert-template/alert-template-properties-builder/alert-template-sectioned-properties/alert-template-sectioned-properties.component.tsx
@@ -99,7 +99,7 @@ export const AlertTemplateSectionedProperties: FunctionComponent<AlertTemplateSe
                                     )
                                 )}
                                 {Object.keys(subStepMap)
-                                    .slice(1)
+                                    .filter((subStep) => subStep !== "DIRECT")
                                     .filter((cs) => subStepMap[cs].length > 0)
                                     .map((currentSubStep) => (
                                         <Grid


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2474

#### Description

In advance mode of alert creation, all properties of template were not showing. This was due to a bug in how we were filtering to show the properties in different sections. This PR fixes that

#### Screenshots


https://github.com/user-attachments/assets/2ee6cd2c-c976-424e-829b-a4bde3daad86


