### PR TITLE
[spi] Add generateDatasourceConnection to ThirdEyeAuthorizer interface

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/ThirdEyeAuthorizerProvider.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/ThirdEyeAuthorizerProvider.java
@@ -15,6 +15,7 @@ package ai.startree.thirdeye.auth;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import ai.startree.thirdeye.spi.api.DataSourceApi;
 import ai.startree.thirdeye.spi.auth.AccessType;
 import ai.startree.thirdeye.spi.auth.ResourceIdentifier;
 import ai.startree.thirdeye.spi.auth.ThirdEyeAuthorizer;
@@ -89,6 +90,11 @@ public class ThirdEyeAuthorizerProvider implements ThirdEyeAuthorizer {
     return getAccessControl().listNamespaces(principal);
   }
 
+  @Override
+  public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+    return getAccessControl().generateDatasourceConnection(principal);
+  }
+
   @VisibleForTesting
   public static class AlwaysAllowAuthorizer implements ThirdEyeAuthorizer {
 
@@ -120,6 +126,11 @@ public class ThirdEyeAuthorizerProvider implements ThirdEyeAuthorizer {
       }
       return LIST_OF_NULL;
     }
+
+    @Override
+    public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+      return null;
+    }
   }
 
   private static class AlwaysDenyAuthorizer implements ThirdEyeAuthorizer {
@@ -133,6 +144,11 @@ public class ThirdEyeAuthorizerProvider implements ThirdEyeAuthorizer {
     @Override
     public @NonNull List<String> listNamespaces(final ThirdEyePrincipal principal) {
       return List.of();
+    }
+
+    @Override
+    public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+      return null;
     }
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/ThirdEyeAuthorizerProvider.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/ThirdEyeAuthorizerProvider.java
@@ -91,7 +91,7 @@ public class ThirdEyeAuthorizerProvider implements ThirdEyeAuthorizer {
   }
 
   @Override
-  public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+  public @Nullable DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
     return getAccessControl().generateDatasourceConnection(principal);
   }
 
@@ -128,7 +128,7 @@ public class ThirdEyeAuthorizerProvider implements ThirdEyeAuthorizer {
     }
 
     @Override
-    public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+    public @Nullable DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
       return null;
     }
   }
@@ -147,7 +147,7 @@ public class ThirdEyeAuthorizerProvider implements ThirdEyeAuthorizer {
     }
 
     @Override
-    public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+    public @Nullable DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
       return null;
     }
   }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleNamespaceAuthorizer.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleNamespaceAuthorizer.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.resources.testutils;
 
+import ai.startree.thirdeye.spi.api.DataSourceApi;
 import ai.startree.thirdeye.spi.auth.AccessType;
 import ai.startree.thirdeye.spi.auth.ResourceIdentifier;
 import ai.startree.thirdeye.spi.auth.ThirdEyeAuthorizer;
@@ -53,5 +54,10 @@ public class SingleNamespaceAuthorizer implements ThirdEyeAuthorizer {
   @Override
   public @NonNull List<String> listNamespaces(final ThirdEyePrincipal principal) {
     return Collections.singletonList(null);
+  }
+
+  @Override
+  public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+    return null;
   }
 }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleNamespaceAuthorizer.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleNamespaceAuthorizer.java
@@ -57,7 +57,7 @@ public class SingleNamespaceAuthorizer implements ThirdEyeAuthorizer {
   }
 
   @Override
-  public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+  public @Nullable DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
     return null;
   }
 }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleResourceAuthorizer.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleResourceAuthorizer.java
@@ -21,6 +21,7 @@ import ai.startree.thirdeye.spi.auth.ThirdEyePrincipal;
 import java.util.Collections;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SingleResourceAuthorizer implements ThirdEyeAuthorizer {
 
@@ -42,7 +43,7 @@ public class SingleResourceAuthorizer implements ThirdEyeAuthorizer {
   }
 
   @Override
-  public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+  public @Nullable DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
     return null;
   }
 }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleResourceAuthorizer.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/testutils/SingleResourceAuthorizer.java
@@ -13,6 +13,7 @@
  */
 package ai.startree.thirdeye.resources.testutils;
 
+import ai.startree.thirdeye.spi.api.DataSourceApi;
 import ai.startree.thirdeye.spi.auth.AccessType;
 import ai.startree.thirdeye.spi.auth.ResourceIdentifier;
 import ai.startree.thirdeye.spi.auth.ThirdEyeAuthorizer;
@@ -38,5 +39,10 @@ public class SingleResourceAuthorizer implements ThirdEyeAuthorizer {
   @Override
   public @NonNull List<String> listNamespaces(final ThirdEyePrincipal principal) {
     return Collections.singletonList(null);
+  }
+
+  @Override
+  public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+    return null;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/auth/ThirdEyeAuthorizer.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/auth/ThirdEyeAuthorizer.java
@@ -18,6 +18,7 @@ import ai.startree.thirdeye.spi.api.DataSourceApi;
 import java.util.List;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface ThirdEyeAuthorizer {
 
@@ -39,12 +40,17 @@ public interface ThirdEyeAuthorizer {
   @NonNull List<String> listNamespaces(final ThirdEyePrincipal principal);
 
   /**
-   * Generates the datasource connection configuration given principal
+   * Generates a recommended datasource configuration to use in the ThirdEye instance.
+   * Does not create the datasource.
+   *
+   * Example: an authorizer plugin could:
+   * 1. set up a service account to connect to Pinot
+   * 2. return a valid datasource configuration that uses the service account just created.
    *
    * @param principal the principal to generate datasource for
-   * @return DataSourceApi
+   * @return DataSourceApi -> Returns null if there is no recommended datasource configuration
    */
-  DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal);
+  @Nullable DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal);
 
   interface ThirdEyeAuthorizerFactory extends
       PluginServiceFactory<ThirdEyeAuthorizer, Map<String, Object>> {}

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/auth/ThirdEyeAuthorizer.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/auth/ThirdEyeAuthorizer.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.spi.auth;
 
 import ai.startree.thirdeye.spi.PluginServiceFactory;
+import ai.startree.thirdeye.spi.api.DataSourceApi;
 import java.util.List;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -36,6 +37,14 @@ public interface ThirdEyeAuthorizer {
 
   // if the implementation does not support multiple namespace, please return a list with the value null Collections.singletonList(null)
   @NonNull List<String> listNamespaces(final ThirdEyePrincipal principal);
+
+  /**
+   * Generates the datasource connection configuration given principal
+   *
+   * @param principal the principal to generate datasource for
+   * @return DataSourceApi
+   */
+  DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal);
 
   interface ThirdEyeAuthorizerFactory extends
       PluginServiceFactory<ThirdEyeAuthorizer, Map<String, Object>> {}


### PR DESCRIPTION
#### Issue(s)

[Pinot connection](https://startree.atlassian.net/browse/TE-2441)

#### Description

Adding generateDatasourceConnection method to ThirdEyeAuthorizer interface
The purpose of this method is to provide placeholder to implement one's own custom datasource connection

One can override the default implementation by using/implementing ThirdEyeAuthorizerPlugin

This method is not being used anywhere currently
It will be integrated into Authorization Manager in upcoming PR to be exposed as a new API

#### Testing
Existing Tests and CI
