### PR TITLE
[server] Add recommend API to datasource resource

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -207,6 +207,10 @@ public class AuthorizationManager {
         relatedId -> ensureCanAccess(principal, relatedId, AccessType.READ));
   }
 
+  public DataSourceApi generateDatasourceConnection(final ThirdEyePrincipal principal) {
+    return thirdEyeAuthorizer.generateDatasourceConnection(principal);
+  }
+
   private void ensureCanAccess(final ThirdEyePrincipal principal,
       final ResourceIdentifier identifier, final AccessType accessType) {
     if (!canAccess(principal, identifier, accessType)) {

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DataSourceResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DataSourceResource.java
@@ -133,6 +133,16 @@ public class DataSourceResource extends CrudResource<DataSourceApi, DataSourceDT
     return respondOk(onboarded);
   }
 
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Path("recommend")
+  @Timed(percentiles = {0.5, 0.75, 0.90, 0.95, 0.98, 0.99, 0.999})
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response recommendConfiguration(
+      @Parameter(hidden = true) @Auth ThirdEyeServerPrincipal principal) {
+    return respondOk(dataSourceService.recommend(principal));
+  }
+
   @DELETE
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   @Path("offboard-all")

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DataSourceResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DataSourceResource.java
@@ -134,7 +134,6 @@ public class DataSourceResource extends CrudResource<DataSourceApi, DataSourceDT
   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   @Path("recommend")
   @Timed(percentiles = {0.5, 0.75, 0.90, 0.95, 0.98, 0.99, 0.999})
   @Produces(MediaType.APPLICATION_JSON)

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DataSourceService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DataSourceService.java
@@ -49,6 +49,7 @@ public class DataSourceService extends CrudService<DataSourceApi, DataSourceDTO>
   private final DataSourceCache dataSourceCache;
   private final DataSourceOnboarder dataSourceOnboarder;
   private final DatasetConfigManager datasetConfigDAO;
+  private final AuthorizationManager authorizationManager;
 
   @Inject
   public DataSourceService(
@@ -61,6 +62,7 @@ public class DataSourceService extends CrudService<DataSourceApi, DataSourceDTO>
     this.dataSourceCache = dataSourceCache;
     this.dataSourceOnboarder = dataSourceOnboarder;
     this.datasetConfigDAO = datasetConfigDAO;
+    this.authorizationManager = authorizationManager;
   }
 
   @Override
@@ -174,5 +176,9 @@ public class DataSourceService extends CrudService<DataSourceApi, DataSourceDTO>
     checkArgument(dataSourceDto != null, "Could not find datasource with id %s", id);
     authorizationManager.ensureCanRead(principal, dataSourceDto);
     return dataSourceCache.getDataSource(dataSourceDto).validate();
+  }
+
+  public DataSourceApi recommend(final ThirdEyePrincipal principal) {
+    return authorizationManager.generateDatasourceConnection(principal);
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DataSourceService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DataSourceService.java
@@ -33,6 +33,7 @@ import ai.startree.thirdeye.spi.datalayer.Predicate;
 import ai.startree.thirdeye.spi.datalayer.bao.DataSourceManager;
 import ai.startree.thirdeye.spi.datalayer.bao.DatasetConfigManager;
 import ai.startree.thirdeye.spi.datalayer.dto.AbstractDTO;
+import ai.startree.thirdeye.spi.datalayer.dto.AuthorizationConfigurationDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DataSourceDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.DatasetConfigDTO;
 import ai.startree.thirdeye.spi.datasource.ThirdEyeDataSource;
@@ -179,6 +180,13 @@ public class DataSourceService extends CrudService<DataSourceApi, DataSourceDTO>
   }
 
   public DataSourceApi recommend(final ThirdEyePrincipal principal) {
+    final String namespace = authorizationManager.currentNamespace(principal);
+
+    // verify that user has read access to data sources in given namespace
+    DataSourceDTO sampleDataset = new DataSourceDTO();
+    sampleDataset.setAuth(new AuthorizationConfigurationDTO().setNamespace(namespace));
+    authorizationManager.ensureCanRead(principal, sampleDataset);
+
     return authorizationManager.generateDatasourceConnection(principal);
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DataSourceService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DataSourceService.java
@@ -183,7 +183,7 @@ public class DataSourceService extends CrudService<DataSourceApi, DataSourceDTO>
     final String namespace = authorizationManager.currentNamespace(principal);
 
     // verify that user has read access to data sources in given namespace
-    DataSourceDTO sampleDataset = new DataSourceDTO();
+    final DataSourceDTO sampleDataset = new DataSourceDTO();
     sampleDataset.setAuth(new AuthorizationConfigurationDTO().setNamespace(namespace));
     authorizationManager.ensureCanRead(principal, sampleDataset);
 

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
@@ -25,6 +25,7 @@ import ai.startree.thirdeye.datasource.DataSourceOnboarder;
 import ai.startree.thirdeye.datasource.cache.DataSourceCache;
 import ai.startree.thirdeye.service.DataSourceService;
 import ai.startree.thirdeye.spi.ThirdEyeStatus;
+import ai.startree.thirdeye.spi.api.DataSourceApi;
 import ai.startree.thirdeye.spi.api.StatusApi;
 import ai.startree.thirdeye.spi.api.StatusListApi;
 import ai.startree.thirdeye.spi.auth.AuthenticationType;
@@ -106,5 +107,12 @@ public class DataSourceResourceTest {
 
     final StatusApi statusApi = entity.getList().get(0);
     assertThat(statusApi.getCode()).isEqualTo(ThirdEyeStatus.ERR_DATASOURCE_VALIDATION_FAILED);
+  }
+
+  @Test
+  public void testRecommend() {
+    final Response response = dataSourceResource.recommendConfiguration(principal);
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat((DataSourceApi) response.getEntity()).isNull();
   }
 }


### PR DESCRIPTION
#### Issue(s)

[Pinot connection](https://startree.atlassian.net/browse/TE-2441)

#### Description

Adding new API `api/data-sources/recommend`
It will be used in datasource onboarding UI flow to generate recommended datasource connection config 
(importantly for Shared SaaS setup)

Depends on https://github.com/startreedata/thirdeye/pull/1584

#### Testing
UTs and
Sanity swagger test (should return 200 response with null body due to default implementation)
