### PR TITLE
feat(ui): TE-2442 show recommended datasources during onboarding

### DIFF
--- a/thirdeye-ui/src/app/locale/languages/en-us.json
+++ b/thirdeye-ui/src/app/locale/languages/en-us.json
@@ -39,6 +39,7 @@
         "object-unexpected": "Unexpected object encountered.",
         "offset-without-limit": "'Offset' value provided without 'limit' value.",
         "operation-unsupported": "Operation is not supported.",
+        "pinot-instance-not-created": "Failed to create a Pinot connection. Please provide a Pinot datasource configuration. Please reach out to support if you think this is an error",
         "pipeline-execution-failed": "Pipeline execution failed.",
         "template-missing-property": "Template property is missing.",
         "timeout": "Operation timed out.",
@@ -47,7 +48,8 @@
         "unknown-rca-algorithm": "Unknown error running the RCA algorithm."
     },
     "info": {
-        "notifyHistoricalAnomalies": "By default, notifications are only sent for anomalies detected on times greater than the alert creation time. If enabled, notifications will also be sent for anomalies detected on times less than the alert creation time."
+        "notifyHistoricalAnomalies": "By default, notifications are only sent for anomalies detected on times greater than the alert creation time. If enabled, notifications will also be sent for anomalies detected on times less than the alert creation time.",
+        "pinot-instance-not-detected": "Could not detect a Pinot instance automatically. Please provide a Pinot datasource configuration."
     },
     "label": {
         "1-minute": "1 Minute",
@@ -448,6 +450,7 @@
         "recent-task-statuses-for-subscription-group": "Recent task statuses for subscription group",
         "recipient-details": "Recipient Details",
         "recommended-algorithm": "Recommended algorithm",
+        "recommended-datasources": "Recommended datasources",
         "recommended-documentation": "Recommended Documentation",
         "recommended-type": "Recommended type",
         "reload": "Reload",

--- a/thirdeye-ui/src/app/rest/datasources/datasources.actions.ts
+++ b/thirdeye-ui/src/app/rest/datasources/datasources.actions.ts
@@ -20,6 +20,7 @@ import {
     GetDatasourceByName,
     GetDatasources,
     GetDatasourceStatus,
+    GetRecommendedDatasources,
     GetStatusResponse,
     GetTablesForDatasourceByName,
 } from "./datasources.interfaces";
@@ -27,6 +28,7 @@ import {
     getAllDatasources,
     getDatasourceByName as getDatasourceByNameREST,
     getDatasource as getDatasourceREST,
+    getRecommenedDatasources as getRecommenedDatasourcesREST,
     getStatusForDatasource,
     getTablesForDatasource,
 } from "./datasources.rest";
@@ -117,6 +119,23 @@ export const useGetTablesForDatasourceID = (): GetTablesForDatasourceByName => {
     return {
         tables: data,
         getTableForDatasourceID,
+        status,
+        errorMessages,
+        resetData,
+    };
+};
+
+export const useGetRecommendedDatasources = (): GetRecommendedDatasources => {
+    const { data, makeRequest, status, errorMessages, resetData } =
+        useHTTPAction<Datasource[]>(getRecommenedDatasourcesREST);
+
+    const getRecommendedDatasources = (): Promise<Datasource[] | undefined> => {
+        return makeRequest(name);
+    };
+
+    return {
+        recommendedDatasources: data,
+        getRecommendedDatasources,
         status,
         errorMessages,
         resetData,

--- a/thirdeye-ui/src/app/rest/datasources/datasources.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/datasources/datasources.interfaces.ts
@@ -36,6 +36,11 @@ export interface GetDatasources extends ActionHook {
     getDatasources: () => Promise<Datasource[] | undefined>;
 }
 
+export interface GetRecommendedDatasources extends ActionHook {
+    recommendedDatasources: Datasource[] | null;
+    getRecommendedDatasources: () => Promise<Datasource[] | undefined>;
+}
+
 export interface GetDatasource extends ActionHook {
     datasource: Datasource | null;
     getDatasource: (id: number) => Promise<Datasource | undefined>;

--- a/thirdeye-ui/src/app/rest/datasources/datasources.rest.ts
+++ b/thirdeye-ui/src/app/rest/datasources/datasources.rest.ts
@@ -111,3 +111,11 @@ export const getTablesForDatasource = async (
 
     return response.data;
 };
+
+export const getRecommenedDatasources = async (): Promise<Datasource[]> => {
+    const response = await axios.get(
+        `${BASE_URL_DATASOURCES}/data-sources/recommend`
+    );
+
+    return response.data;
+};


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2442

#### Description

In the welcome onboarding flow, if user doesn;t have any datasource configured, we will show them the ecommnded datasources which are returned via /api/data-sources/recommend endpoint


#### Screenshots
<img width="1133" alt="Screenshot 2024-10-17 at 5 26 41 PM" src="https://github.com/user-attachments/assets/4d039f78-8a9a-4bb4-b4be-c6481ea0b5c5">

<img width="1117" alt="Screenshot 2024-10-17 at 5 26 52 PM" src="https://github.com/user-attachments/assets/abc74c4f-7555-4922-a246-dbf8c66ce0a2">
<img width="1133" alt="Screenshot 2024-10-17 at 5 27 48 PM" src="https://github.com/user-attachments/assets/f042f8bd-b9a2-45b0-b960-1ddf36d1f43c">
