### PR TITLE
[notification] add anomaly minimum length filter

### DIFF
--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/notification/NotificationTaskFilterIntegrationTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/notification/NotificationTaskFilterIntegrationTest.java
@@ -298,7 +298,7 @@ public class NotificationTaskFilterIntegrationTest {
     assertThat(instance.filterAnomalies(sg, POINT_IN_TIME).isEmpty()).isTrue();
 
     // this anomaly should be notified - long enough
-    final AnomalyDTO anomaly2 = persist(anomalyWithCreateTime(minutesAgo(4))
+    final AnomalyDTO anomaly0 = persist(anomalyWithCreateTime(minutesAgo(4))
         .setDetectionConfigId(alert.getId())
         // 3 days
         .setStartTime(minutesAgo(60 * 24 * 4))
@@ -314,15 +314,17 @@ public class NotificationTaskFilterIntegrationTest {
     );
 
     assertThat(collectIds(instance.filterAnomalies(sg, System.currentTimeMillis())))
-        .isEqualTo(collectIds(Set.of(anomaly2)));
+        .isEqualTo(collectIds(Set.of(anomaly0)));
 
-    watermarkManager.updateWatermarks(sg, List.of(anomaly2));
-    assertThat(sg.getVectorClocks().get(alert.getId())).isEqualTo(anomaly2.getCreateTime().getTime());
+    watermarkManager.updateWatermarks(sg, List.of(anomaly0));
+    assertThat(sg.getVectorClocks().get(alert.getId())).isEqualTo(anomaly0.getCreateTime().getTime());
 
     // anomaly 1 is now of length >=3 days
     anomaly1.setEndTime(minutesAgo(0));
     persist(anomaly1);
     assertThat(collectIds(instance.filterAnomalies(sg, System.currentTimeMillis())))
         .isEqualTo(collectIds(Set.of(anomaly1)));
+    watermarkManager.updateWatermarks(sg, List.of(anomaly1));
+    assertThat(sg.getVectorClocks().get(alert.getId())).isEqualTo(anomaly1.getCreateTime().getTime());
   }
 }

--- a/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationTaskFilter.java
+++ b/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationTaskFilter.java
@@ -132,11 +132,7 @@ public class NotificationTaskFilter {
    *     subscription group, anomalies, completed anomalies and other metadata
    */
   public NotificationTaskFilterResult filter(final SubscriptionGroupDTO sg, final long endTime) {
-    // hack to support minimum anomaly length --> assuming endTime is always System.now(), if the minimum anomaly length is 2 days,
-    // then the endTime - which corresponds to to a createTime<endTime filter must be <now-2 days  
-    // TODO cyril redesign vector clocks to maintain enumeration item in all cases to rewrite this  
-    final long correctedEndTime = endTime - isoPeriod(sg.getMinimumAnomalyLength(), Period.ZERO).toStandardDuration().getMillis();
-    final Set<AnomalyDTO> anomalies = filterAnomalies(sg, correctedEndTime);
+    final Set<AnomalyDTO> anomalies = filterAnomalies(sg, endTime);
 
     final var ids = anomalies.stream()
         .map(AnomalyDTO::getId)

--- a/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationTaskPostProcessor.java
+++ b/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationTaskPostProcessor.java
@@ -66,9 +66,9 @@ public class NotificationTaskPostProcessor {
     this.alertTemplateRenderer = alertTemplateRenderer;
   }
 
-  private static Map<Long, Long> buildVectorClock(final Collection<AnomalyDTO> anomalies) {
+  private static Map<Long, Long> buildVectorClock(final Collection<AnomalyDTO> notifiedAnomalies) {
     final Map<Long, Long> alertIdToAnomalyCreateTimeMax = new HashMap<>();
-    for (final AnomalyDTO a : anomalies) {
+    for (final AnomalyDTO a : notifiedAnomalies) {
       final Long alertId = a.getDetectionConfigId();
       if (alertId == null) {
         continue;
@@ -150,14 +150,15 @@ public class NotificationTaskPostProcessor {
 
   @VisibleForTesting
   protected void updateWatermarks(final SubscriptionGroupDTO sg,
-      final Collection<AnomalyDTO> anomalies) {
-    if (anomalies.isEmpty()) {
+      final Collection<AnomalyDTO> notifiedAnomalies) {
+    if (notifiedAnomalies.isEmpty()) {
       return;
     }
-    final var merged = mergeWatermarks(sg.getVectorClocks(), buildVectorClock(anomalies));
+    final Map<Long, Long> merged = mergeWatermarks(sg.getVectorClocks(), buildVectorClock(notifiedAnomalies));
     sg.setVectorClocks(merged);
 
     LOG.info("Updating watermarks for subscription config : {}", sg.getId());
     subscriptionGroupManager.save(sg);
+    
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/SubscriptionGroupApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/SubscriptionGroupApi.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.Date;
 import java.util.List;
+import org.joda.time.Period;
 
 @JsonInclude(Include.NON_NULL)
 public class SubscriptionGroupApi implements ThirdEyeCrudApi<SubscriptionGroupApi> {
@@ -43,6 +44,8 @@ public class SubscriptionGroupApi implements ThirdEyeCrudApi<SubscriptionGroupAp
   private TimeWindowSuppressorApi alertSuppressors;
 
   private Boolean notifyHistoricalAnomalies;
+
+  private String minimumAnomalyLength; 
 
   public Long getId() {
     return id;
@@ -182,6 +185,15 @@ public class SubscriptionGroupApi implements ThirdEyeCrudApi<SubscriptionGroupAp
   public SubscriptionGroupApi setAuth(
       final AuthorizationConfigurationApi auth) {
     this.auth = auth;
+    return this;
+  }
+
+  public String getMinimumAnomalyLength() {
+    return minimumAnomalyLength;
+  }
+
+  public SubscriptionGroupApi setMinimumAnomalyLength(final String minimumAnomalyLength) {
+    this.minimumAnomalyLength = minimumAnomalyLength;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/SubscriptionGroupDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/SubscriptionGroupDTO.java
@@ -18,6 +18,7 @@ import com.google.common.base.Objects;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import org.joda.time.Period;
 
 public class SubscriptionGroupDTO extends AbstractDTO {
 
@@ -52,6 +53,11 @@ public class SubscriptionGroupDTO extends AbstractDTO {
    * before the association with the alert was created will not be notified.
    */
   private Boolean notifyHistoricalAnomalies;
+
+  /**
+   * If set, don't notify the anomalies of length < minimumAnomalyLength.
+   */
+  private String minimumAnomalyLength;
 
   public boolean isActive() {
     return active;
@@ -243,6 +249,15 @@ public class SubscriptionGroupDTO extends AbstractDTO {
   @Override
   public SubscriptionGroupDTO setId(final Long id) {
     super.setId(id);
+    return this;
+  }
+
+  public String getMinimumAnomalyLength() {
+    return minimumAnomalyLength;
+  }
+
+  public SubscriptionGroupDTO setMinimumAnomalyLength(final String minimumAnomalyLength) {
+    this.minimumAnomalyLength = minimumAnomalyLength;
     return this;
   }
 }

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import ai.startree.thirdeye.notification.NotificationDispatcher;
 import ai.startree.thirdeye.notification.NotificationPayloadBuilder;
 import ai.startree.thirdeye.notification.NotificationTaskFilter;
+import ai.startree.thirdeye.notification.NotificationTaskFilterResult;
 import ai.startree.thirdeye.notification.NotificationTaskPostProcessor;
 import ai.startree.thirdeye.spi.Constants;
 import ai.startree.thirdeye.spi.api.NotificationPayloadApi;
@@ -115,7 +116,7 @@ public class NotificationTaskRunner implements TaskRunner {
     requireNonNull(sg, "subscription Group is null");
 
     final long now = System.currentTimeMillis();
-    final var result = notificationTaskFilter.filter(sg, now);
+    final NotificationTaskFilterResult result = notificationTaskFilter.filter(sg, now);
 
     /* Dispatch notifications */
     final NotificationPayloadApi payload = notificationPayloadBuilder.build(result);


### PR DESCRIPTION
**Issue:** 
https://startree.atlassian.net/browse/TE-2342 

**Description:**
This PR adds support for a new parameter `minimumAnomalyLength` in the SubscriptionGroup configuration. 
Only anomalies of length >= minimumAnomalyLength are notified.

**Testing:**
- [X] integration tests (limited) 
- [ ] manual local test (Cyril)