### PR TITLE
[bootstrap] add template configuration to namespace configuration

### DIFF
--- a/config/server.yaml
+++ b/config/server.yaml
@@ -106,14 +106,14 @@ rca:
     algorithm: simple
     params: {}
 
-## deprecated - please use defaultWorkspaceConfiguration
+## DEPRECATED - please use defaultWorkspaceConfiguration below
 time:
   # notification timezone
   timezone: UTC
   # notification time format pattern - see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html 
   dateTimePattern: "MMM dd, yyyy HH:mm"
   # Limit onboarding alert replay back to JAN_1_2000_UTC
-  minimumOnboardingStartTime: 946684800001
+  minimumOnboardingStartTime: 946684800000
   
 defaultWorkspaceConfiguration:
   timeConfiguration:
@@ -122,7 +122,7 @@ defaultWorkspaceConfiguration:
     # notification time format pattern - see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html 
     dateTimePattern: "MMM dd, yyyy HH:mm"
     # Limit onboarding alert replay back to JAN_1_2000_UTC
-    minimumOnboardingStartTime: 946684800013
+    minimumOnboardingStartTime: 946684800000
   templateConfiguration:
     # alert templates generate queries with a LIMIT statement - this is the default value of the limit statement
     sqlLimitStatement: 100_000_001

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -106,13 +106,26 @@ rca:
     algorithm: simple
     params: {}
 
+## deprecated - please use defaultWorkspaceConfiguration
 time:
   # notification timezone
   timezone: UTC
   # notification time format pattern - see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html 
   dateTimePattern: "MMM dd, yyyy HH:mm"
   # Limit onboarding alert replay back to JAN_1_2000_UTC
-  minimumOnboardingStartTime: 946684800000
+  minimumOnboardingStartTime: 946684800001
+  
+defaultWorkspaceConfiguration:
+  timeConfiguration:
+    # notification timezone
+    timezone: UTC
+    # notification time format pattern - see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html 
+    dateTimePattern: "MMM dd, yyyy HH:mm"
+    # Limit onboarding alert replay back to JAN_1_2000_UTC
+    minimumOnboardingStartTime: 946684800013
+  templateConfiguration:
+    # alert templates generate queries with a LIMIT statement - this is the default value of the limit statement
+    sqlLimitStatement: 100_000_001
 
 mockEvents:
   enabled: false

--- a/thirdeye-benchmarks/src/main/java/org/sample/LoadTemplatesBenchmark.java
+++ b/thirdeye-benchmarks/src/main/java/org/sample/LoadTemplatesBenchmark.java
@@ -16,6 +16,7 @@ package org.sample;
 import ai.startree.thirdeye.plugins.bootstrap.opencore.OpenCoreBoostrapResourcesProvider;
 import ai.startree.thirdeye.spi.Constants;
 import ai.startree.thirdeye.spi.api.AlertTemplateApi;
+import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.util.List;
@@ -49,22 +50,25 @@ public class LoadTemplatesBenchmark {
   int numNamespaces;
 
   OpenCoreBoostrapResourcesProvider openCoreBoostrapResourcesProvider;
+  
+  TemplateConfigurationDTO templateConfiguration;
 
   @Setup
   public void setup() {
     openCoreBoostrapResourcesProvider = new OpenCoreBoostrapResourcesProvider();
+    templateConfiguration = new TemplateConfigurationDTO();
   }
 
   @Benchmark
   public void loadWithNoCache(Blackhole blackhole) throws IOException {
     for (int i = 0; i < numNamespaces; i++) {
-      blackhole.consume(openCoreBoostrapResourcesProvider.getAlertTemplates());
+      blackhole.consume(openCoreBoostrapResourcesProvider.getAlertTemplates(templateConfiguration));
     }
   }
 
   @Benchmark
   public void loadWithCacheAndCopy(Blackhole blackhole) throws IOException {
-    final List<AlertTemplateApi> alertTemplates = openCoreBoostrapResourcesProvider.getAlertTemplates();
+    final List<AlertTemplateApi> alertTemplates = openCoreBoostrapResourcesProvider.getAlertTemplates(templateConfiguration);
     for (int i = 0; i < numNamespaces; i++) {
       blackhole.consume(copy((alertTemplates)));
     }

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/ThirdEyeCoreModule.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/ThirdEyeCoreModule.java
@@ -25,9 +25,15 @@ import ai.startree.thirdeye.spi.datasource.loader.AggregationLoader;
 import ai.startree.thirdeye.spi.datasource.loader.MinMaxTimeLoader;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
+import com.google.inject.util.Providers;
+import java.security.Provider;
 import org.apache.tomcat.jdbc.pool.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ThirdEyeCoreModule extends AbstractModule {
+  
+  private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeCoreModule.class);
 
   private final DataSource dataSource;
   private final RcaConfiguration rcaConfiguration;
@@ -57,7 +63,12 @@ public class ThirdEyeCoreModule extends AbstractModule {
 
     bind(RcaConfiguration.class).toInstance(rcaConfiguration);
     bind(UiConfiguration.class).toInstance(uiConfiguration);
-    bind(TimeConfiguration.class).toInstance(timeConfiguration);
+    if (timeConfiguration != null) {
+      LOG.warn("Using the time configuration. This is deprecated. Please use defaultWorkspaceConfiguration.timeConfiguration instead.");
+      bind(TimeConfiguration.class).toInstance(timeConfiguration);
+    } else {
+      bind(TimeConfiguration.class).toProvider(Providers.of(null));
+    }
     bind(NamespaceConfigurationDTO.class).toInstance(defaultNamespaceConfiguration);
   }
 }

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/ThirdEyeCoreModule.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/ThirdEyeCoreModule.java
@@ -18,7 +18,9 @@ import ai.startree.thirdeye.datalayer.ThirdEyePersistenceModule;
 import ai.startree.thirdeye.datasource.loader.DefaultAggregationLoader;
 import ai.startree.thirdeye.datasource.loader.DefaultMinMaxTimeLoader;
 import ai.startree.thirdeye.rootcause.configuration.RcaConfiguration;
+import ai.startree.thirdeye.spi.api.NamespaceConfigurationApi;
 import ai.startree.thirdeye.spi.config.TimeConfiguration;
+import ai.startree.thirdeye.spi.datalayer.dto.NamespaceConfigurationDTO;
 import ai.startree.thirdeye.spi.datasource.loader.AggregationLoader;
 import ai.startree.thirdeye.spi.datasource.loader.MinMaxTimeLoader;
 import com.google.inject.AbstractModule;
@@ -31,16 +33,19 @@ public class ThirdEyeCoreModule extends AbstractModule {
   private final RcaConfiguration rcaConfiguration;
   private final UiConfiguration uiConfiguration;
   private final TimeConfiguration timeConfiguration;
+  private final NamespaceConfigurationDTO defaultNamespaceConfiguration;
 
   public ThirdEyeCoreModule(final DataSource dataSource,
       final RcaConfiguration rcaConfiguration,
       final UiConfiguration uiConfiguration,
-      final TimeConfiguration timeConfiguration) {
+      final TimeConfiguration timeConfiguration,
+      final NamespaceConfigurationDTO defaultNamespaceConfiguration) {
     this.dataSource = dataSource;
 
     this.rcaConfiguration = rcaConfiguration;
     this.uiConfiguration = uiConfiguration;
     this.timeConfiguration = timeConfiguration;
+    this.defaultNamespaceConfiguration = defaultNamespaceConfiguration;
   }
 
   @Override
@@ -53,5 +58,6 @@ public class ThirdEyeCoreModule extends AbstractModule {
     bind(RcaConfiguration.class).toInstance(rcaConfiguration);
     bind(UiConfiguration.class).toInstance(uiConfiguration);
     bind(TimeConfiguration.class).toInstance(timeConfiguration);
+    bind(NamespaceConfigurationDTO.class).toInstance(defaultNamespaceConfiguration);
   }
 }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
@@ -15,7 +15,6 @@ package ai.startree.thirdeye.datalayer.bao;
 
 import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.Objects.requireNonNull;
 
 import ai.startree.thirdeye.datalayer.dao.NamespaceConfigurationDao;
 import ai.startree.thirdeye.spi.config.TimeConfiguration;

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
@@ -30,17 +30,18 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 @Singleton
 public class NamespaceConfigurationManagerImpl implements NamespaceConfigurationManager {
 
   private final NamespaceConfigurationDao dao;
-  private final TimeConfiguration timeConfiguration;
+  private final @Nullable TimeConfiguration timeConfiguration;
   private final NamespaceConfigurationDTO defaultNamespaceConfiguration;
 
   @Inject
   public NamespaceConfigurationManagerImpl(final NamespaceConfigurationDao dao,
-      final TimeConfiguration timeConfiguration,
+      final @Nullable TimeConfiguration timeConfiguration,
       final NamespaceConfigurationDTO defaultNamespaceConfiguration) {
     this.dao = dao;
     this.timeConfiguration = timeConfiguration;

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/OpenCoreBoostrapResourcesProvider.java
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/OpenCoreBoostrapResourcesProvider.java
@@ -17,16 +17,18 @@ import static ai.startree.thirdeye.spi.util.FileUtils.readJsonObjectsFromResourc
 
 import ai.startree.thirdeye.spi.api.AlertTemplateApi;
 import ai.startree.thirdeye.spi.bootstrap.BootstrapResourcesProvider;
+import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class OpenCoreBoostrapResourcesProvider implements BootstrapResourcesProvider {
 
   public static final String RESOURCES_TEMPLATES_PATH = "alert-templates";
 
   @Override
-  public List<AlertTemplateApi> getAlertTemplates() {
+  public List<AlertTemplateApi> getAlertTemplates(final @NonNull TemplateConfigurationDTO templateConfiguration) {
     final List<AlertTemplateApi> templates = readJsonObjectsFromResourcesFolder(
         RESOURCES_TEMPLATES_PATH,
         this.getClass(),

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/OpenCoreBoostrapResourcesProvider.java
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/OpenCoreBoostrapResourcesProvider.java
@@ -28,7 +28,8 @@ public class OpenCoreBoostrapResourcesProvider implements BootstrapResourcesProv
   public static final String RESOURCES_TEMPLATES_PATH = "alert-templates";
 
   @Override
-  public List<AlertTemplateApi> getAlertTemplates(final @NonNull TemplateConfigurationDTO templateConfiguration) {
+  public List<AlertTemplateApi> getAlertTemplates(
+      final @NonNull TemplateConfigurationDTO templateConfiguration) {
     final List<AlertTemplateApi> templates = readJsonObjectsFromResourcesFolder(
         RESOURCES_TEMPLATES_PATH,
         this.getClass(),
@@ -42,6 +43,20 @@ public class OpenCoreBoostrapResourcesProvider implements BootstrapResourcesProv
 
     new CommonProperties().enrichCommonProperties(templates);
 
+    applyTemplateConfiguration(templates, templateConfiguration);
+
     return templates;
+  }
+
+  private static void applyTemplateConfiguration(final List<AlertTemplateApi> templates,
+      final @NonNull TemplateConfigurationDTO templateConfiguration) {
+    // apply default SQL LIMIT statement value 
+    for (final AlertTemplateApi alertTemplateApi : templates) {
+      alertTemplateApi.getProperties()
+          .stream()
+          // WARNING: match on property name directly - ensure this naming convention is followed in new templates 
+          .filter(p -> "queryLimit".equals(p.getName()))
+          .forEach(p -> p.setDefaultValue(templateConfiguration.getSqlLimitStatement()));
+    }
   }
 }

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/OpenCoreBoostrapResourcesProvider.java
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/OpenCoreBoostrapResourcesProvider.java
@@ -47,8 +47,9 @@ public class OpenCoreBoostrapResourcesProvider implements BootstrapResourcesProv
 
     return templates;
   }
-
-  private static void applyTemplateConfiguration(final List<AlertTemplateApi> templates,
+  
+  // public to be reused by other template plugins 
+  public static void applyTemplateConfiguration(final List<AlertTemplateApi> templates,
       final @NonNull TemplateConfigurationDTO templateConfiguration) {
     // apply default SQL LIMIT statement value 
     for (final AlertTemplateApi alertTemplateApi : templates) {

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/test/java/ai/startree/thirdeye/plugins/boostrap/opencore/OpenCoreBoostrapResourcesProviderTest.java
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/test/java/ai/startree/thirdeye/plugins/boostrap/opencore/OpenCoreBoostrapResourcesProviderTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import ai.startree.thirdeye.plugins.bootstrap.opencore.OpenCoreBoostrapResourcesProvider;
 import ai.startree.thirdeye.spi.api.AlertTemplateApi;
+import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
 import java.util.List;
 import org.testng.annotations.Test;
 
@@ -27,7 +28,8 @@ public class OpenCoreBoostrapResourcesProviderTest {
   @Test
   public void testNumberOfTemplates() {
     final OpenCoreBoostrapResourcesProvider provider = new OpenCoreBoostrapResourcesProvider();
-    final List<AlertTemplateApi> templates = provider.getAlertTemplates();
+    final TemplateConfigurationDTO templateConfiguration = new TemplateConfigurationDTO();
+    final List<AlertTemplateApi> templates = provider.getAlertTemplates(templateConfiguration);
     assertThat(templates.size()).isEqualTo(8);
     assertThat(
         templates.stream().filter(t -> t.getName().contains("-percentile")).count()).isEqualTo(4);

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/test/java/ai/startree/thirdeye/plugins/boostrap/opencore/OpenCoreBoostrapResourcesProviderTest.java
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/test/java/ai/startree/thirdeye/plugins/boostrap/opencore/OpenCoreBoostrapResourcesProviderTest.java
@@ -18,7 +18,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import ai.startree.thirdeye.plugins.bootstrap.opencore.OpenCoreBoostrapResourcesProvider;
 import ai.startree.thirdeye.spi.api.AlertTemplateApi;
 import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
+import ai.startree.thirdeye.spi.template.TemplatePropertyMetadata;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.testng.annotations.Test;
 
 public class OpenCoreBoostrapResourcesProviderTest {
@@ -28,10 +31,18 @@ public class OpenCoreBoostrapResourcesProviderTest {
   @Test
   public void testNumberOfTemplates() {
     final OpenCoreBoostrapResourcesProvider provider = new OpenCoreBoostrapResourcesProvider();
-    final TemplateConfigurationDTO templateConfiguration = new TemplateConfigurationDTO();
+    int queryLimitStatement = 200_000; 
+    final TemplateConfigurationDTO templateConfiguration = new TemplateConfigurationDTO().setSqlLimitStatement(queryLimitStatement);
     final List<AlertTemplateApi> templates = provider.getAlertTemplates(templateConfiguration);
     assertThat(templates.size()).isEqualTo(8);
     assertThat(
         templates.stream().filter(t -> t.getName().contains("-percentile")).count()).isEqualTo(4);
+    for (final AlertTemplateApi t: templates) {
+      final Optional<TemplatePropertyMetadata> queryLimit = t.getProperties().stream()
+          .filter(p -> "queryLimit".equals(p.getName()))
+          .findFirst();
+      assertThat(queryLimit).isPresent();
+      assertThat(queryLimit.get().getDefaultValue()).isEqualTo(queryLimitStatement);
+    }
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServerModule.java
@@ -54,7 +54,8 @@ public class ThirdEyeServerModule extends AbstractModule {
     install(new ThirdEyeCoreModule(dataSource,
         configuration.getRcaConfiguration(),
         configuration.getUiConfiguration(),
-        configuration.getTimeConfiguration()));
+        configuration.getTimeConfiguration(),
+        configuration.getNamespaceConfiguration()));
     install(new ThirdEyeNotificationModule(configuration.getNotificationConfiguration()));
     install(new ThirdEyeDetectionPipelineModule(configuration.getDetectionPipelineConfiguration()));
     install(new ThirdEyeWorkerModule(configuration.getTaskDriverConfiguration()));

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
@@ -77,6 +77,7 @@ public class ThirdEyeServerConfiguration extends Configuration {
   @JsonProperty("time")
   private TimeConfiguration timeConfiguration = null;
 
+  // see discussion https://github.com/startreedata/thirdeye/pull/1612 on why it is ok to use a DTO - we can introduce a Configuration later
   @JsonProperty("defaultWorkspaceConfiguration")
   private NamespaceConfigurationDTO namespaceConfiguration = new NamespaceConfigurationDTO();
 

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/config/ThirdEyeServerConfiguration.java
@@ -21,10 +21,15 @@ import ai.startree.thirdeye.notification.NotificationConfiguration;
 import ai.startree.thirdeye.rootcause.configuration.RcaConfiguration;
 import ai.startree.thirdeye.scheduler.ThirdEyeSchedulerConfiguration;
 import ai.startree.thirdeye.scheduler.events.MockEventsConfiguration;
+import ai.startree.thirdeye.spi.api.NamespaceConfigurationApi;
+import ai.startree.thirdeye.spi.api.TemplateConfigurationApi;
+import ai.startree.thirdeye.spi.api.TimeConfigurationApi;
 import ai.startree.thirdeye.spi.config.TimeConfiguration;
+import ai.startree.thirdeye.spi.datalayer.dto.NamespaceConfigurationDTO;
 import ai.startree.thirdeye.worker.task.TaskDriverConfiguration;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import freemarker.core.TemplateConfiguration;
 import io.dropwizard.core.Configuration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import java.util.List;
@@ -68,8 +73,12 @@ public class ThirdEyeServerConfiguration extends Configuration {
   @JsonProperty("sentry")
   private BackendSentryConfiguration sentryConfiguration = new BackendSentryConfiguration();
 
+  @Deprecated // use defaultWorkspaceConfiguration instead
   @JsonProperty("time")
-  private TimeConfiguration timeConfiguration = new TimeConfiguration();
+  private TimeConfiguration timeConfiguration = null;
+
+  @JsonProperty("defaultWorkspaceConfiguration")
+  private NamespaceConfigurationDTO namespaceConfiguration = new NamespaceConfigurationDTO();
 
   @JsonProperty("accessControl")
   private AccessControlConfiguration accessControlConfiguration = new AccessControlConfiguration();
@@ -261,6 +270,16 @@ public class ThirdEyeServerConfiguration extends Configuration {
   public ThirdEyeServerConfiguration setSentryConfiguration(
       final BackendSentryConfiguration sentryConfiguration) {
     this.sentryConfiguration = sentryConfiguration;
+    return this;
+  }
+
+  public NamespaceConfigurationDTO getNamespaceConfiguration() {
+    return namespaceConfiguration;
+  }
+
+  public ThirdEyeServerConfiguration setNamespaceConfiguration(
+      final NamespaceConfigurationDTO namespaceConfiguration) {
+    this.namespaceConfiguration = namespaceConfiguration;
     return this;
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/core/BootstrapResourcesRegistry.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/core/BootstrapResourcesRegistry.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
 import ai.startree.thirdeye.spi.api.AlertTemplateApi;
 import ai.startree.thirdeye.spi.bootstrap.BootstrapResourcesProvider;
 import ai.startree.thirdeye.spi.bootstrap.BootstrapResourcesProviderFactory;
+import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.ArrayList;
@@ -58,11 +59,11 @@ public class BootstrapResourcesRegistry {
     return bootstrapResourcesProviderFactory.build();
   }
 
-  public List<AlertTemplateApi> getAlertTemplates() {
+  public List<AlertTemplateApi> getAlertTemplates(final @NonNull TemplateConfigurationDTO templateConfiguration) {
     final List<AlertTemplateApi> allTemplates = new ArrayList<>();
     for (String name : factoryMap.keySet()) {
       final BootstrapResourcesProvider bootstrapResourcesProvider = get(name);
-      allTemplates.addAll(bootstrapResourcesProvider.getAlertTemplates());
+      allTemplates.addAll(bootstrapResourcesProvider.getAlertTemplates(templateConfiguration));
     }
 
     return allTemplates;

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/NamespaceConfigurationApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/NamespaceConfigurationApi.java
@@ -19,6 +19,9 @@ public class NamespaceConfigurationApi implements ThirdEyeCrudApi<NamespaceConfi
   private AuthorizationConfigurationApi auth;
 
   private TimeConfigurationApi timeConfiguration;
+  
+  private TemplateConfigurationApi templateConfiguration;
+  
 
   public TimeConfigurationApi getTimeConfiguration() {
     return timeConfiguration;
@@ -45,6 +48,16 @@ public class NamespaceConfigurationApi implements ThirdEyeCrudApi<NamespaceConfi
 
   public NamespaceConfigurationApi setAuth(final AuthorizationConfigurationApi auth) {
     this.auth = auth;
+    return this;
+  }
+
+  public TemplateConfigurationApi getTemplateConfiguration() {
+    return templateConfiguration;
+  }
+
+  public NamespaceConfigurationApi setTemplateConfiguration(
+      final TemplateConfigurationApi templateConfiguration) {
+    this.templateConfiguration = templateConfiguration;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/NamespaceConfigurationApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/NamespaceConfigurationApi.java
@@ -18,9 +18,9 @@ public class NamespaceConfigurationApi implements ThirdEyeCrudApi<NamespaceConfi
   private Long id;
   private AuthorizationConfigurationApi auth;
 
-  private TimeConfigurationApi timeConfiguration = new TimeConfigurationApi();
+  private TimeConfigurationApi timeConfiguration;
   
-  private TemplateConfigurationApi templateConfiguration = new TemplateConfigurationApi();
+  private TemplateConfigurationApi templateConfiguration;
   
 
   public TimeConfigurationApi getTimeConfiguration() {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/NamespaceConfigurationApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/NamespaceConfigurationApi.java
@@ -18,9 +18,9 @@ public class NamespaceConfigurationApi implements ThirdEyeCrudApi<NamespaceConfi
   private Long id;
   private AuthorizationConfigurationApi auth;
 
-  private TimeConfigurationApi timeConfiguration;
+  private TimeConfigurationApi timeConfiguration = new TimeConfigurationApi();
   
-  private TemplateConfigurationApi templateConfiguration;
+  private TemplateConfigurationApi templateConfiguration = new TemplateConfigurationApi();
   
 
   public TimeConfigurationApi getTimeConfiguration() {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/TemplateConfigurationApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/TemplateConfigurationApi.java
@@ -11,17 +11,19 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package ai.startree.thirdeye.spi.bootstrap;
+package ai.startree.thirdeye.spi.api;
 
-import ai.startree.thirdeye.spi.api.AlertTemplateApi;
-import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
-import java.util.List;
-import org.checkerframework.checker.nullness.qual.NonNull;
+public class TemplateConfigurationApi {
+  
+  
+  private int sqlLimitStatement = 100_000_000;
 
-/**
- * BootstrapResourcesProvider provide resources to bootstrap ThirdEye installation and configuration.
- */
-public interface BootstrapResourcesProvider {
+  public int getSqlLimitStatement() {
+    return sqlLimitStatement;
+  }
 
-  List<AlertTemplateApi> getAlertTemplates(final @NonNull TemplateConfigurationDTO templateConfiguration);
+  public TemplateConfigurationApi setSqlLimitStatement(final int sqlLimitStatement) {
+    this.sqlLimitStatement = sqlLimitStatement;
+    return this;
+  }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/NamespaceConfigurationDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/NamespaceConfigurationDTO.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 public class NamespaceConfigurationDTO extends AbstractDTO {
 
   TimeConfigurationDTO timeConfiguration;
+  
+  private TemplateConfigurationDTO templateConfiguration; 
 
   public TimeConfigurationDTO getTimeConfiguration() {
     return timeConfiguration;
@@ -30,6 +32,16 @@ public class NamespaceConfigurationDTO extends AbstractDTO {
   public NamespaceConfigurationDTO setTimeConfiguration(
       final TimeConfigurationDTO timeConfiguration) {
     this.timeConfiguration = timeConfiguration;
+    return this;
+  }
+
+  public TemplateConfigurationDTO getTemplateConfiguration() {
+    return templateConfiguration;
+  }
+
+  public NamespaceConfigurationDTO setTemplateConfiguration(
+      final TemplateConfigurationDTO templateConfiguration) {
+    this.templateConfiguration = templateConfiguration;
     return this;
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TemplateConfigurationDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TemplateConfigurationDTO.java
@@ -11,17 +11,22 @@
  * See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package ai.startree.thirdeye.spi.bootstrap;
+package ai.startree.thirdeye.spi.datalayer.dto;
 
-import ai.startree.thirdeye.spi.api.AlertTemplateApi;
-import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
-import java.util.List;
-import org.checkerframework.checker.nullness.qual.NonNull;
+public class TemplateConfigurationDTO {
 
-/**
- * BootstrapResourcesProvider provide resources to bootstrap ThirdEye installation and configuration.
- */
-public interface BootstrapResourcesProvider {
+  /**
+   * Template generate queries. 
+   * Templates should generate queries with by default a statement LIMIT ${sqlLimitStatement} by default.
+   */
+  private int sqlLimitStatement = 100_000_000;
 
-  List<AlertTemplateApi> getAlertTemplates(final @NonNull TemplateConfigurationDTO templateConfiguration);
+  public int getSqlLimitStatement() {
+    return sqlLimitStatement;
+  }
+
+  public TemplateConfigurationDTO setSqlLimitStatement(final int sqlLimitStatement) {
+    this.sqlLimitStatement = sqlLimitStatement;
+    return this;
+  }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TemplateConfigurationDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TemplateConfigurationDTO.java
@@ -17,7 +17,7 @@ public class TemplateConfigurationDTO {
 
   /**
    * Template generate queries. 
-   * Templates should generate queries with by default a statement LIMIT ${sqlLimitStatement} by default.
+   * Templates should generate queries with by default a statement LIMIT ${sqlLimitStatement}.
    */
   private int sqlLimitStatement = 100_000_000;
 

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TimeConfigurationDTO.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/dto/TimeConfigurationDTO.java
@@ -13,14 +13,37 @@
  */
 package ai.startree.thirdeye.spi.datalayer.dto;
 
+import static ai.startree.thirdeye.spi.Constants.DEFAULT_CHRONOLOGY;
+
+import ai.startree.thirdeye.spi.Constants;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.joda.time.DateTimeZone;
 
 public class TimeConfigurationDTO {
 
-  private DateTimeZone timezone;
-  private String dateTimePattern;
-  private long minimumOnboardingStartTime;
+  private static final long JAN_1_2000_UTC = 946684800000L;
+
+  /**
+   * Timezone to use in notifications.
+   */
+  private DateTimeZone timezone = DEFAULT_CHRONOLOGY.getZone();
+  /**
+   * Time format to use in notifications.
+   * For instance with "MMM dd, yyyy HH:mm" the datetime will render as "Feb 03, 2020 00:00".
+   * See pattern specification here
+   * https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
+   * It is recommended to not put the timezone it this pattern.
+   * The timezone is appended in the notification text by ThirdEye, but not in all datetime strings
+   * to avoid repetition.
+   */
+  private @NonNull String dateTimePattern = Constants.NOTIFICATIONS_DEFAULT_DATE_PATTERN;
+
+  /**
+   * Onboarding start time >= onboardingStartTimeLimit.
+   * This allows administrators to prevent users from running alert onboardings too far in the past,
+   * reading too much data.
+   */
+  private long minimumOnboardingStartTime = JAN_1_2000_UTC;
 
   public DateTimeZone getTimezone() {
     return timezone;


### PR DESCRIPTION
Issue:
https://startree.atlassian.net/browse/TE-2491

Description:
This PR adds support for:
- a default workspace configuration - it is exposed in the server config file
  - `time` configuration is now deprecated. It still has precedence over the workspace configuration for the moment
- TemplateConfiguration in the NamespaceConfiguration. It allows some control on how templates are generated.   
- queryLimit control in TemplateConfiguration. The default query limit of templates can be set as a configuration. This is to be compatible with StarTree Cloud free tier.

Testing:
 - unit tests 
 - manual local test (Cyril)
 
Not part of the PR:
- kubernetes helm chart update
- enterprise query limit logic