### PR TITLE
fix(ui): TE-2493 use new alert flow from onboarding page

### DIFF
--- a/thirdeye-ui/src/app/pages/welcome-page/landing/landing-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/welcome-page/landing/landing-page.component.tsx
@@ -32,7 +32,8 @@ import {
     getConfigurationPath,
     getDataConfigurationCreatePath,
     getHomePath,
-    getWelcomeCreateAlert,
+    // getWelcomeCreateAlert,
+    getAlertsEasyCreatePath,
 } from "../../../utils/routes/routes.util";
 import { useGetAlertsCount } from "../../../rest/alerts/alerts.actions";
 import { useNavigate } from "react-router-dom";
@@ -161,7 +162,8 @@ export const WelcomeLandingPage: FunctionComponent = () => {
                                         entity: t("label.alert"),
                                     })}
                                     disabled={!hasDatasets}
-                                    link={getWelcomeCreateAlert()}
+                                    // link={getWelcomeCreateAlert()}
+                                    link={getAlertsEasyCreatePath()}
                                     subtitle={t(
                                         "message.explore-startree-thirdeye-in-one-click"
                                     )}


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2493

#### Description

Onboarding flow should use new alert flow ux as default



https://github.com/user-attachments/assets/fd71c79d-b320-45fc-9b04-a348bd3f6c71

