### PR TITLE
[core] Add guardrails to prevent same dataset from onboarding twice

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/DataSourceOnboarder.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/DataSourceOnboarder.java
@@ -129,6 +129,11 @@ public class DataSourceOnboarder {
     final List<MetricConfigDTO> metrics = datasetConfigDTO.getMetrics();
     datasetConfigDTO.setAuth(auth);
     datasetConfigDTO.setMetrics(null);
+    final DatasetConfigDTO existingDatasetConfig = datasetConfigManager.findUniqueByNameAndNamespace(
+        datasetConfigDTO.getDataset(), datasetConfigDTO.namespace());
+    checkState(existingDatasetConfig == null,
+        "Dataset with name %s already exists in namespace %s",
+        datasetConfigDTO.getDataset(), datasetConfigDTO.namespace());
     final Long datasetId = datasetConfigManager.save(datasetConfigDTO);
     checkState(datasetId != null, "Failed creating dataset %s", datasetConfigDTO.getDataset());
 


### PR DESCRIPTION
#### Issue(s)

[Add guardrails to prevent same dataset(s) from onboarding twice](https://startree.atlassian.net/browse/TE-2437)

#### Description

If for some reason, same datasets are onboarded twice within split second, both are onboarded and it results in an illegal state of DB, and entire functionality breaks -> user is not able to create alerts

This happens in welcome flow, where at dataset onboarding stage, if user accidentally clicks "onboard dataset" button twice before the first operation is completed, datasets are onboarded twice. 

This issue happens only in case of null namespace because in case of non-null namespace, uniqueness constraint in _dataset_config_index_ rejects double persistence of same dataset within a particular namespace ([error log](https://github.com/user-attachments/files/17702226/index_uniqueness_constraint.txt))

This PR adds backend guardrail to check for any existing dataset with given name in same namespace before persisting it to avoid such situations

#### Testing
- [X] Existing UTs
- [X] Existing Integration Tests
- [X] Manual testing
