### PR TITLE
[mvn] bump dropwizard version to 3.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <guice.version>5.1.0</guice.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <!-- should match dropwizard version - except for security issues -->
-    <jackson.version>2.17.2</jackson.version>
+    <jackson.version>2.18.1</jackson.version>
     <jodatime.version>2.12.7</jodatime.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <mockito.version>5.12.0</mockito.version>
@@ -640,7 +640,7 @@
       <dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-bom</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.10</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
#### Issue(s)

[upgrade dropwizard to 3.0.10](https://startree.atlassian.net/browse/TE-2525)

#### Description

Upgrading dropwizard version to [latest 3.0.X version](https://mvnrepository.com/artifact/io.dropwizard/dropwizard-core) 

#### Testing

- [X] check ThirdEyeServer manually
- [X] check ThirdEyeDebugServer manually
- [X] check swagger manually
- [X] check integration with FrontEnd manually
- [ ] Follow up in enterprise TE

```diff
diff dependency-tree-before dependency-tree-after 
1d0
< ./mvnw dependency:tree
87,89c86,88
< [INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
95c94
< [INFO] \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
119,122c118,121
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
127,132c126,131
< [INFO] +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
134,135c133,134
< [INFO] |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
140,141c139,140
< [INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
143,144c142,143
< [INFO] |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
164c163
< [INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:runtime
---
> [INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:runtime
237,239c236,238
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
242,247c241,246
< [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
249,250c248,249
< [INFO] |  |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
255,256c254,255
< [INFO] |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
258,259c257,258
< [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
270c269
< [INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
---
> [INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
285c284
< [INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:runtime
---
> [INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:runtime
339,342c338,341
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
360c359
< [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:runtime
---
> [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:runtime
382,387c381,386
< [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
389,390c388,389
< [INFO] |  |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
395,396c394,395
< [INFO] |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
398,399c397,398
< [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
443,445c442,444
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
447c446
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
451,456c450,455
< [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
458,459c457,458
< [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
464,465c463,464
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
467,468c466,467
< [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
492c491
< [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:runtime
---
> [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:runtime
533,538c532,537
< [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
540,541c539,540
< [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
546,547c545,546
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
549,550c548,549
< [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
561c560
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
576c575
< [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:runtime
---
> [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:runtime
615,616c614,615
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
618c617
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
653,655c652,654
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
657c656
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
661,666c660,665
< [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
668,669c667,668
< [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
674,675c673,674
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
677,678c676,677
< [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
702c701
< [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:runtime
---
> [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:runtime
759c758
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
774c773
< [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:compile
---
> [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:compile
810,812c809,811
< [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
842,843c841,842
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
845,848c844,847
< [INFO] +- io.dropwizard:dropwizard-auth:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-jersey:jar:3.0.8:compile
< [INFO] |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:2.44:runtime
< [INFO] |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.44:runtime
---
> [INFO] +- io.dropwizard:dropwizard-auth:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-jersey:jar:3.0.10:compile
> [INFO] |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:2.45:runtime
> [INFO] |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.45:runtime
850c849
< [INFO] |  |  +- io.dropwizard.metrics:metrics-jersey2:jar:4.2.27:compile
---
> [INFO] |  |  +- io.dropwizard.metrics:metrics-jersey2:jar:4.2.28:compile
858,859c857,858
< [INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.44:runtime
< [INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.44:compile
---
> [INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.45:runtime
> [INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.45:compile
862,864c861,863
< [INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.27:compile
---
> [INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.28:compile
869c868
< [INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:2.44:compile
---
> [INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:2.45:compile
871,875c870,874
< [INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:2.44:compile
< [INFO] |  |  \- org.glassfish.jersey.core:jersey-client:jar:2.44:compile
< [INFO] |  +- org.eclipse.jetty:jetty-security:jar:10.0.23:compile
< [INFO] |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
---
> [INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:2.45:compile
> [INFO] |  |  \- org.glassfish.jersey.core:jersey-client:jar:2.45:compile
> [INFO] |  +- org.eclipse.jetty:jetty-security:jar:10.0.24:compile
> [INFO] |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
877,879c876,878
< [INFO] +- io.dropwizard:dropwizard-core:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-jackson:jar:3.0.8:compile
---
> [INFO] +- io.dropwizard:dropwizard-core:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-jackson:jar:3.0.10:compile
885c884
< [INFO] |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
887,889c886,888
< [INFO] |  +- io.dropwizard:dropwizard-configuration:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-logging:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.27:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-configuration:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-logging:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.28:compile
895,906c894,905
< [INFO] |  +- io.dropwizard:dropwizard-metrics:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-servlets:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-jetty:jar:3.0.8:compile
< [INFO] |  |  \- org.eclipse.jetty:jetty-servlets:jar:10.0.23:compile
< [INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-health:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-jetty10:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-servlets:jar:4.2.27:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.27:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-metrics:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-servlets:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-jetty:jar:3.0.10:compile
> [INFO] |  |  \- org.eclipse.jetty:jetty-servlets:jar:10.0.24:compile
> [INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-health:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-jetty10:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-servlets:jar:4.2.28:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.28:compile
908,909c907,908
< [INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard:dropwizard-request-logging:jar:3.0.8:compile
---
> [INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard:dropwizard-request-logging:jar:3.0.10:compile
914,915c913,914
< [INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:10.0.23:compile
< [INFO] |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:10.0.24:compile
> [INFO] |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
917c916
< [INFO] |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.44:compile
---
> [INFO] |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.45:compile
919,921c918,920
< [INFO] |  +- io.dropwizard:dropwizard-assets:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-views:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-views-freemarker:jar:3.0.8:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-assets:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-views:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-views-freemarker:jar:3.0.10:compile
950c949
< [INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
999,1001c998,1000
< [INFO]    +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
< [INFO]    +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
< [INFO]    +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
---
> [INFO]    +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:provided
> [INFO]    +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:provided
> [INFO]    +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:provided
1003c1002
< [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
---
> [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:provided
1012,1014c1011,1013
< [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
---
> [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
1053c1052
< [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
---
> [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:provided
1082,1085c1081,1084
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
1122,1124c1121,1123
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
1126c1125
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
1162,1164c1161,1163
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:provided
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:provided
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:provided
1166c1165
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:provided
1213,1216c1212,1215
< [INFO]    +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
< [INFO]    +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
< [INFO]    +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
< [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
---
> [INFO]    +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:provided
> [INFO]    +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:provided
> [INFO]    +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:provided
> [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:provided
1241c1240
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
1275c1274
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
1299,1300c1298,1299
< [INFO]    +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
---
> [INFO]    +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:provided
1328,1330c1327,1329
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
1332c1331
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
1382,1384c1381,1383
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
1386c1385
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
1420,1421c1419,1420
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
1423c1422
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:provided
1425c1424
< [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
1461,1464c1460,1463
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
1492c1491
< [INFO]    |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:test
---
> [INFO]    |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:test
1514,1519c1513,1518
< [INFO]    |  +- io.dropwizard:dropwizard-db:jar:3.0.8:test
< [INFO]    |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:test
< [INFO]    |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:test
< [INFO]    |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:test
< [INFO]    |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:test
< [INFO]    |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:test
---
> [INFO]    |  +- io.dropwizard:dropwizard-db:jar:3.0.10:test
> [INFO]    |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:test
> [INFO]    |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:test
> [INFO]    |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:test
> [INFO]    |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:test
> [INFO]    |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:test
1521,1522c1520,1521
< [INFO]    |  |  +- io.dropwizard:dropwizard-util:jar:3.0.8:test
< [INFO]    |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:test
---
> [INFO]    |  |  +- io.dropwizard:dropwizard-util:jar:3.0.10:test
> [INFO]    |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:test
1527,1528c1526,1527
< [INFO]    |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:test
< [INFO]    |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:test
---
> [INFO]    |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:test
> [INFO]    |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:test
1530,1531c1529,1530
< [INFO]    |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:test
< [INFO]    |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:test
---
> [INFO]    |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:test
> [INFO]    |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:test
1552c1551
< [INFO]    |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
---
> [INFO]    |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
1567c1566
< [INFO]    |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:compile
---
> [INFO]    |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:compile
1603,1605c1602,1604
< [INFO]    |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO]    |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO]    |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO]    |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO]    |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO]    |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
1635,1636c1634,1635
< [INFO]    |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO]    |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO]    |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO]    |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
1638,1641c1637,1640
< [INFO]    +- io.dropwizard:dropwizard-auth:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-jersey:jar:3.0.8:compile
< [INFO]    |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:2.44:runtime
< [INFO]    |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.44:runtime
---
> [INFO]    +- io.dropwizard:dropwizard-auth:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-jersey:jar:3.0.10:compile
> [INFO]    |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:2.45:runtime
> [INFO]    |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.45:runtime
1643c1642
< [INFO]    |  |  +- io.dropwizard.metrics:metrics-jersey2:jar:4.2.27:compile
---
> [INFO]    |  |  +- io.dropwizard.metrics:metrics-jersey2:jar:4.2.28:compile
1651,1652c1650,1651
< [INFO]    |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.44:runtime
< [INFO]    |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.44:compile
---
> [INFO]    |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.45:runtime
> [INFO]    |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.45:compile
1655,1657c1654,1656
< [INFO]    |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO]    |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO]    |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.27:compile
---
> [INFO]    |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO]    |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO]    |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.28:compile
1662c1661
< [INFO]    |  +- org.glassfish.jersey.core:jersey-common:jar:2.44:compile
---
> [INFO]    |  +- org.glassfish.jersey.core:jersey-common:jar:2.45:compile
1664,1668c1663,1667
< [INFO]    |  +- org.glassfish.jersey.core:jersey-server:jar:2.44:compile
< [INFO]    |  |  \- org.glassfish.jersey.core:jersey-client:jar:2.44:compile
< [INFO]    |  +- org.eclipse.jetty:jetty-security:jar:10.0.23:compile
< [INFO]    |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO]    |  |  \- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
---
> [INFO]    |  +- org.glassfish.jersey.core:jersey-server:jar:2.45:compile
> [INFO]    |  |  \- org.glassfish.jersey.core:jersey-client:jar:2.45:compile
> [INFO]    |  +- org.eclipse.jetty:jetty-security:jar:10.0.24:compile
> [INFO]    |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO]    |  |  \- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
1670,1672c1669,1671
< [INFO]    +- io.dropwizard:dropwizard-core:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-jackson:jar:3.0.8:compile
---
> [INFO]    +- io.dropwizard:dropwizard-core:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-jackson:jar:3.0.10:compile
1678c1677
< [INFO]    |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO]    |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
1680,1682c1679,1681
< [INFO]    |  +- io.dropwizard:dropwizard-configuration:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-logging:jar:3.0.8:compile
< [INFO]    |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.27:compile
---
> [INFO]    |  +- io.dropwizard:dropwizard-configuration:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-logging:jar:3.0.10:compile
> [INFO]    |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.28:compile
1688,1699c1687,1698
< [INFO]    |  +- io.dropwizard:dropwizard-metrics:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-servlets:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-jetty:jar:3.0.8:compile
< [INFO]    |  |  \- org.eclipse.jetty:jetty-servlets:jar:10.0.23:compile
< [INFO]    |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-health:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard.metrics:metrics-jetty10:jar:4.2.27:compile
< [INFO]    |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.27:compile
< [INFO]    |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.27:compile
< [INFO]    |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.27:compile
< [INFO]    |  +- io.dropwizard.metrics:metrics-servlets:jar:4.2.27:compile
< [INFO]    |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.27:compile
---
> [INFO]    |  +- io.dropwizard:dropwizard-metrics:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-servlets:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-jetty:jar:3.0.10:compile
> [INFO]    |  |  \- org.eclipse.jetty:jetty-servlets:jar:10.0.24:compile
> [INFO]    |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-health:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard.metrics:metrics-jetty10:jar:4.2.28:compile
> [INFO]    |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.28:compile
> [INFO]    |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.28:compile
> [INFO]    |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.28:compile
> [INFO]    |  +- io.dropwizard.metrics:metrics-servlets:jar:4.2.28:compile
> [INFO]    |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.28:compile
1701,1702c1700,1701
< [INFO]    |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
< [INFO]    |  +- io.dropwizard:dropwizard-request-logging:jar:3.0.8:compile
---
> [INFO]    |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
> [INFO]    |  +- io.dropwizard:dropwizard-request-logging:jar:3.0.10:compile
1707,1708c1706,1707
< [INFO]    |  +- org.eclipse.jetty:jetty-servlet:jar:10.0.23:compile
< [INFO]    |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO]    |  +- org.eclipse.jetty:jetty-servlet:jar:10.0.24:compile
> [INFO]    |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
1710c1709
< [INFO]    |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.44:compile
---
> [INFO]    |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.45:compile
1712,1714c1711,1713
< [INFO]    |  +- io.dropwizard:dropwizard-assets:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-views:jar:3.0.8:compile
< [INFO]    |  +- io.dropwizard:dropwizard-views-freemarker:jar:3.0.8:compile
---
> [INFO]    |  +- io.dropwizard:dropwizard-assets:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-views:jar:3.0.10:compile
> [INFO]    |  +- io.dropwizard:dropwizard-views-freemarker:jar:3.0.10:compile
1743c1742
< [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO]    \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
1759c1758
< [INFO]    |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
---
> [INFO]    |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
1783c1782
< [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:compile
---
> [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:compile
1802,1804c1801,1803
< [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
1821,1822c1820,1821
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
1824,1825c1823,1824
< [INFO] |  +- io.dropwizard:dropwizard-auth:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.27:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-auth:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.28:compile
1829,1845c1828,1844
< [INFO] |  |  \- org.eclipse.jetty:jetty-security:jar:10.0.23:compile
< [INFO] |  +- io.dropwizard:dropwizard-core:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-metrics:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-servlets:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-health:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-jetty10:jar:4.2.27:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.27:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.27:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.27:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-servlets:jar:4.2.27:compile
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.27:compile
< [INFO] |  |  |  \- com.helger:profiler:jar:1.1.1:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-request-logging:jar:3.0.8:compile
< [INFO] |  |  |  \- ch.qos.logback:logback-access:jar:1.3.14:compile
< [INFO] |  |  +- org.eclipse.jetty:jetty-servlet:jar:10.0.23:compile
< [INFO] |  |  +- org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:jar:1.0.4:compile
< [INFO] |  |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.44:compile
---
> [INFO] |  |  \- org.eclipse.jetty:jetty-security:jar:10.0.24:compile
> [INFO] |  +- io.dropwizard:dropwizard-core:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-metrics:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-servlets:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-health:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-jetty10:jar:4.2.28:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.28:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.28:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.28:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-servlets:jar:4.2.28:compile
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.28:compile
> [INFO] |  |  |  \- com.helger:profiler:jar:1.1.1:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-request-logging:jar:3.0.10:compile
> [INFO] |  |  |  \- ch.qos.logback:logback-access:jar:1.3.14:compile
> [INFO] |  |  +- org.eclipse.jetty:jetty-servlet:jar:10.0.24:compile
> [INFO] |  |  +- org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:jar:1.0.4:compile
> [INFO] |  |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.45:compile
1847,1849c1846,1848
< [INFO] |  |  +- io.dropwizard:dropwizard-assets:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-views:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard:dropwizard-views-freemarker:jar:3.0.8:compile
---
> [INFO] |  |  +- io.dropwizard:dropwizard-assets:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-views:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard:dropwizard-views-freemarker:jar:3.0.10:compile
1937,1939c1936,1938
< [INFO] +- io.dropwizard:dropwizard-testing:jar:3.0.8:test
< [INFO] |  +- io.dropwizard:dropwizard-configuration:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-jackson:jar:3.0.8:compile
---
> [INFO] +- io.dropwizard:dropwizard-testing:jar:3.0.10:test
> [INFO] |  +- io.dropwizard:dropwizard-configuration:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-jackson:jar:3.0.10:compile
1945,1947c1944,1946
< [INFO] |  +- io.dropwizard:dropwizard-jersey:jar:3.0.8:compile
< [INFO] |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:2.44:runtime
< [INFO] |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.44:runtime
---
> [INFO] |  +- io.dropwizard:dropwizard-jersey:jar:3.0.10:compile
> [INFO] |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:2.45:runtime
> [INFO] |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.45:runtime
1949c1948
< [INFO] |  |  +- io.dropwizard.metrics:metrics-jersey2:jar:4.2.27:compile
---
> [INFO] |  |  +- io.dropwizard.metrics:metrics-jersey2:jar:4.2.28:compile
1954c1953
< [INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.44:runtime
---
> [INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.45:runtime
1957,1963c1956,1962
< [INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  +- io.dropwizard:dropwizard-jetty:jar:3.0.8:compile
< [INFO] |  |  +- org.eclipse.jetty:jetty-servlets:jar:10.0.23:compile
< [INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard:dropwizard-logging:jar:3.0.8:compile
< [INFO] |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.27:compile
---
> [INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  +- io.dropwizard:dropwizard-jetty:jar:3.0.10:compile
> [INFO] |  |  +- org.eclipse.jetty:jetty-servlets:jar:10.0.24:compile
> [INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard:dropwizard-logging:jar:3.0.10:compile
> [INFO] |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.28:compile
1969,1971c1968,1970
< [INFO] |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
1980,1981c1979,1980
< [INFO] |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:2.44:compile
---
> [INFO] |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:2.45:compile
1983,1990c1982,1989
< [INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.44:compile
< [INFO] |  +- org.glassfish.jersey.connectors:jersey-apache5-connector:jar:2.44:test
< [INFO] |  +- org.apache.httpcomponents.client5:httpclient5:jar:5.3.1:runtime
< [INFO] |  |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.2.4:runtime
< [INFO] |  +- org.glassfish.jersey.core:jersey-client:jar:2.44:compile
< [INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:2.44:compile
< [INFO] |  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:2.44:test
< [INFO] |  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:2.44:test
---
> [INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.45:compile
> [INFO] |  +- org.glassfish.jersey.connectors:jersey-apache5-connector:jar:2.45:test
> [INFO] |  +- org.apache.httpcomponents.client5:httpclient5:jar:5.4:runtime
> [INFO] |  |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.3:runtime
> [INFO] |  +- org.glassfish.jersey.core:jersey-client:jar:2.45:compile
> [INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:2.45:compile
> [INFO] |  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:2.45:test
> [INFO] |  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:2.45:test
1999c1998
< [INFO] |  +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:2.44:test
---
> [INFO] |  +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:2.45:test
2002,2003c2001,2002
< [INFO] +- io.dropwizard:dropwizard-client:jar:3.0.8:test
< [INFO] |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] +- io.dropwizard:dropwizard-client:jar:3.0.10:test
> [INFO] |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
2005,2007c2004,2006
< [INFO] |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
< [INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.2.5:runtime
< [INFO] |  \- io.dropwizard.metrics:metrics-httpclient5:jar:4.2.27:test
---
> [INFO] |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
> [INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.3:runtime
> [INFO] |  \- io.dropwizard.metrics:metrics-httpclient5:jar:4.2.28:test
2009,2010c2008,2009
< [INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
2079,2081c2078,2080
< [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
< [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
---
> [INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.1:compile
> [INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.1:compile
2083c2082
< [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
---
> [INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.18.1:compile
2087,2092c2086,2091
< [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.8:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.23:compile
< [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.23:compile
< [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.23:compile
< [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.23:compile
---
> [INFO] |  |  +- io.dropwizard:dropwizard-db:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-lifecycle:jar:3.0.10:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-server:jar:10.0.24:compile
> [INFO] |  |  |  |  |  +- org.eclipse.jetty:jetty-http:jar:10.0.24:compile
> [INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-io:jar:10.0.24:compile
> [INFO] |  |  |  |  +- org.eclipse.jetty:jetty-util:jar:10.0.24:compile
2094,2095c2093,2094
< [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.8:compile
< [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.8:compile
---
> [INFO] |  |  |  +- io.dropwizard:dropwizard-util:jar:3.0.10:compile
> [INFO] |  |  |  +- io.dropwizard:dropwizard-validation:jar:3.0.10:compile
2100,2101c2099,2100
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.27:compile
< [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.27:compile
---
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-core:jar:4.2.28:compile
> [INFO] |  |  |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.28:compile
2103,2104c2102,2103
< [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.26:compile
< [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.26:compile
---
> [INFO] |  |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.31:compile
> [INFO] |  |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.31:compile
2128c2127
< [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:runtime
---
> [INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.1:runtime
2157,2160c2156,2159
```
