### PR TITLE
[java] upgrade to java 21

### DIFF
--- a/.github/workflows/check-license-header.yml
+++ b/.github/workflows/check-license-header.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       # don't use setup-java cache - hash file pattern has issues
       - name: Cache local Maven repository

--- a/.github/workflows/helm-tests.yaml
+++ b/.github/workflows/helm-tests.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/publish-backend.yaml
+++ b/.github/workflows/publish-backend.yaml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Pull repository
         uses: actions/checkout@v4
-      - name: Install JDK 17
+      - name: Install JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Cache - restore local Maven repository
         id: cache-restore

--- a/.github/workflows/publish-frontend.yaml
+++ b/.github/workflows/publish-frontend.yaml
@@ -29,10 +29,10 @@ jobs:
           cache: "npm"
           cache-dependency-path: './thirdeye-ui/package-lock.json'
       # java is required to get the backend project version with maven
-      - name: Install JDK 17
+      - name: Install JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Generate frontend distribution
         id: generate-frontend-dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,10 +66,10 @@ jobs:
     steps:
       - name: Pull repository
         uses: actions/checkout@v4
-      - name: Install JDK 17
+      - name: Install JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Set git ci user info
         run: |

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -22,11 +22,11 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install java and setup artifactory
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         server-id: startree-releases
         server-username: ARTIFACTORY_USERNAME_REF

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # the License.
 #
 
-FROM eclipse-temurin:17-jdk-alpine as builder
+FROM eclipse-temurin:21-jdk-alpine as builder
 # build jcmd tools to make them available at runtime
 RUN ${JAVA_HOME}/bin/jlink --module-path jmods --add-modules jdk.jcmd --output /jcmd
 WORKDIR /build
@@ -21,7 +21,7 @@ COPY ./ ./
 # if the disitrbution is provided, do nothing - else build it
 RUN if [[ ! -d thirdeye-distribution/target/thirdeye-distribution-*-dist/thirdeye-distribution-* ]]; then ./mvnw package -U -DskipTests; fi
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -g 1000 thirdeye && \
   adduser -u 1000 thirdeye -G thirdeye -D
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # the License.
 #
 
-FROM eclipse-temurin:21-jdk-alpine as builder
+FROM eclipse-temurin:21-jdk-alpine AS builder
 # build jcmd tools to make them available at runtime
 RUN ${JAVA_HOME}/bin/jlink --module-path jmods --add-modules jdk.jcmd --output /jcmd
 WORKDIR /build

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For a complete description of ThirdEye's features, see [**ThirdEye documentation
 
 ### Requirements
 - tested on Linux and Mac OS
-- Java 17
+- Java 21
 - MySQL 8.0
 - the UI requires internal npm packages. Make sure you can access them. See [thirdeye-ui prerequisites](./thirdeye-ui/README.md#configure-node-package-manager-npm-for-use-with-artifactory)
 

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
           <!-- download weaver jar - required for surefire goals-->
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.8.1</version>
           <executions>
             <execution>
               <id>resolve</id>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </modules>
 
   <properties>
-    <jdk.version>17</jdk.version>
+    <jdk.version>21</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!--  Dependency Versions -->

--- a/thirdeye-benchmarks/pom.xml
+++ b/thirdeye-benchmarks/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmh.version>1.37</jmh.version>
-    <javac.target>17</javac.target>
+    <javac.target>21</javac.target>
     <uberjar.name>benchmarks</uberjar.name>
   </properties>
   

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/query/QueryProjection.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/query/QueryProjection.java
@@ -114,7 +114,7 @@ public class QueryProjection {
           SqlParserPos.ZERO,
           quantifier != null ? symbolLiteralOf(quantifier) : null));
     } else if (operands.size() == 1 && quantifier == null) {
-      return applySpecialOperators(operandNodes(sqlParserConfig).get(0));
+      return applySpecialOperators(operandNodes(sqlParserConfig).getFirst());
     } else {
       throw new UnsupportedOperationException(String.format(
           "Unsupported combination for QueryProjection: %s",

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/detectionpipeline/sql/filter/FilterEngine.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/detectionpipeline/sql/filter/FilterEngine.java
@@ -105,7 +105,7 @@ public class FilterEngine {
       } else if (call.getClass() == SqlOrderBy.class) {
         final SqlOrderBy orderByNode = (SqlOrderBy) call;
         // element of index 0 is the select node
-        selectNode = (SqlSelect) orderByNode.getOperandList().get(0);
+        selectNode = (SqlSelect) orderByNode.getOperandList().getFirst();
       } else if (call.getClass() == SqlWith.class) {
         final SqlWith withNode = (SqlWith) call;
         // element of index 1 is the select node - in simple with + select queries

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/util/CalciteUtils.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/util/CalciteUtils.java
@@ -235,9 +235,9 @@ public class CalciteUtils {
     if (predicates.isEmpty()) {
       return null;
     } else if (predicates.size() == 1) {
-      return predicates.get(0);
+      return predicates.getFirst();
     }
-    return addPredicates(predicates.get(0), predicates.subList(1, predicates.size()));
+    return addPredicates(predicates.getFirst(), predicates.subList(1, predicates.size()));
   }
 
   /**

--- a/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperatorTest.java
+++ b/thirdeye-detectionpipeline/src/test/java/ai/startree/thirdeye/detectionpipeline/operator/PostProcessorOperatorTest.java
@@ -154,7 +154,7 @@ public class PostProcessorOperatorTest {
   private void assertLabelsAreCorrect(final OperatorResult r) {
     for (final AnomalyDTO anomaly : r.getAnomalies()) {
       assertThat(anomaly.getAnomalyLabels().size()).isEqualTo(1);
-      final AnomalyLabelDTO label = anomaly.getAnomalyLabels().get(0);
+      final AnomalyLabelDTO label = anomaly.getAnomalyLabels().getFirst();
       assertThat(label.getName()).isEqualTo(TEST_POST_PROCESSOR_LABEL_NAME);
       assertThat(label.getSourceNodeName()).isEqualTo(NODE_BEAN_NAME);
       assertThat(label.getSourcePostProcessor()).isEqualTo(TEST_POST_PROCESSOR_NAME);

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/AnomalyPaginationTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/AnomalyPaginationTest.java
@@ -83,7 +83,7 @@ public class AnomalyPaginationTest {
             .setLastTimestamp(new Date())
             .setTemplate(new AlertTemplateApi().setNodes(List.of(new PlanNodeApi()))))))
         .readEntity(new GenericType<List<AlertApi>>() {})
-        .get(0)
+        .getFirst()
         .getId();
 
     final List<AnomalyApi> anomalies = new ArrayList<>();
@@ -144,7 +144,7 @@ public class AnomalyPaginationTest {
     final StatusListApi results = response.readEntity(ERROR_LIST_TYPE);
     assertThat(response.getStatus()).isEqualTo(400);
     assertThat(results.getList()).isNotEmpty();
-    assertThat(results.getList().get(0).getCode()).isEqualTo(ERR_NEGATIVE_LIMIT_VALUE);
+    assertThat(results.getList().getFirst().getCode()).isEqualTo(ERR_NEGATIVE_LIMIT_VALUE);
   }
 
   @Test
@@ -153,7 +153,7 @@ public class AnomalyPaginationTest {
     final StatusListApi results = response.readEntity(ERROR_LIST_TYPE);
     assertThat(response.getStatus()).isEqualTo(400);
     assertThat(results.getList()).isNotEmpty();
-    assertThat(results.getList().get(0).getCode()).isEqualTo(ERR_NEGATIVE_OFFSET_VALUE);
+    assertThat(results.getList().getFirst().getCode()).isEqualTo(ERR_NEGATIVE_OFFSET_VALUE);
   }
 
   @Test
@@ -162,7 +162,7 @@ public class AnomalyPaginationTest {
     final StatusListApi results = response.readEntity(ERROR_LIST_TYPE);
     assertThat(response.getStatus()).isEqualTo(400);
     assertThat(results.getList()).isNotEmpty();
-    assertThat(results.getList().get(0).getCode()).isEqualTo(ERR_OFFSET_WITHOUT_LIMIT);
+    assertThat(results.getList().getFirst().getCode()).isEqualTo(ERR_OFFSET_WITHOUT_LIMIT);
   }
 
   @Test

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/AnomalyResolutionTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/AnomalyResolutionTest.java
@@ -137,7 +137,7 @@ public class AnomalyResolutionTest {
     response = client.request("api/data-sources")
         .post(Entity.json(List.of(pinotDataSourceApi)));
     assert200(response);
-    final DataSourceApi dataSourceInResponse = response.readEntity(DATASOURCE_LIST_TYPE).get(0);
+    final DataSourceApi dataSourceInResponse = response.readEntity(DATASOURCE_LIST_TYPE).getFirst();
     pinotDataSourceApi.setId(dataSourceInResponse.getId());
 
     // create dataset
@@ -158,7 +158,7 @@ public class AnomalyResolutionTest {
         .post(Entity.json(List.of(ALERT_API)));
     assertThat(createResponse.getStatus()).isEqualTo(200);
     final List<AlertApi> alerts = createResponse.readEntity(ALERT_LIST_TYPE);
-    alertId = alerts.get(0).getId();
+    alertId = alerts.getFirst().getId();
 
     final AlertDTO alert = alertManager.findById(alertId);
     final AlertTemplateDTO renderedTemplate = alertTemplateRenderer.renderAlert(alert);
@@ -182,7 +182,7 @@ public class AnomalyResolutionTest {
     try (final Response r = client.request("api/subscription-groups")
         .post(Entity.json(List.of(SUBSCRIPTION_GROUP_API)))) {
       assertThat(r.getStatus()).isEqualTo(200);
-      subscriptionGroupId = r.readEntity(SUBSCRIPTION_GROUP_LIST_TYPE).get(0).getId();
+      subscriptionGroupId = r.readEntity(SUBSCRIPTION_GROUP_LIST_TYPE).getFirst().getId();
     }
   }
 
@@ -231,7 +231,7 @@ public class AnomalyResolutionTest {
     final NotificationPayloadApi notificationPayload = nsf.getNotificationPayload();
     assertThat(notificationPayload.getAnomalyReports()).hasSize(1);
 
-    final AnomalyApi anomalyApi = notificationPayload.getAnomalyReports().get(0).getAnomaly();
+    final AnomalyApi anomalyApi = notificationPayload.getAnomalyReports().getFirst().getAnomaly();
     assertThat(anomalyApi.getStartTime()).isEqualTo(new Date(epoch("2020-02-17 00:00")));
     assertThat(anomalyApi.getEndTime()).isEqualTo(new Date(epoch("2020-02-21 00:00")));
   }
@@ -296,7 +296,7 @@ public class AnomalyResolutionTest {
     final NotificationPayloadApi notificationPayload = nsf.getNotificationPayload();
     assertThat(notificationPayload.getAnomalyReports()).hasSize(1);
 
-    final AnomalyApi anomalyApi = notificationPayload.getAnomalyReports().get(0).getAnomaly();
+    final AnomalyApi anomalyApi = notificationPayload.getAnomalyReports().getFirst().getAnomaly();
     assertThat(anomalyApi.getStartTime()).isEqualTo(new Date(epoch("2020-03-02 00:00")));
     assertThat(anomalyApi.getEndTime()).isEqualTo(new Date(epoch("2020-03-03 00:00")));
   }

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
@@ -170,7 +170,7 @@ public class HappyPathTest {
     final Response response = request("api/data-sources").post(Entity.json(List.of(
         pinotDataSourceApi)));
     assert200(response);
-    final DataSourceApi dataSourceInResponse = response.readEntity(DATASOURCE_LIST_TYPE).get(0);
+    final DataSourceApi dataSourceInResponse = response.readEntity(DATASOURCE_LIST_TYPE).getFirst();
     pinotDataSourceApi.setId(dataSourceInResponse.getId());
     
   }
@@ -268,7 +268,7 @@ public class HappyPathTest {
 
     assert200(response);
     final List<AlertApi> alerts = response.readEntity(ALERT_LIST_TYPE);
-    alertId = alerts.get(0).getId();
+    alertId = alerts.getFirst().getId();
     UPDATE_ALERT_API.setId(alertId);
   }
 
@@ -370,8 +370,8 @@ public class HappyPathTest {
     final Response response = request("api/alerts").put(Entity.json(List.of(UPDATE_ALERT_API)));
     assert200(response);
     final List<AlertApi> alerts = response.readEntity(ALERT_LIST_TYPE);
-    assertThat(alerts.get(0).getId()).isEqualTo(alertId);
-    alertLastUpdateTime = alerts.get(0).getUpdated().getTime();
+    assertThat(alerts.getFirst().getId()).isEqualTo(alertId);
+    alertLastUpdateTime = alerts.getFirst().getUpdated().getTime();
   }
 
   @Test(dependsOnMethods = "testUpdateAlert", timeOut = 50000L)
@@ -748,7 +748,7 @@ public class HappyPathTest {
     final var response = request("api/alerts")
         .post(Entity.json(List.of(alertApi)));
     assertThat(response.getStatus()).isEqualTo(200);
-    final var gotApi = response.readEntity(new GenericType<List<AlertApi>>() {}).get(0);
+    final var gotApi = response.readEntity(new GenericType<List<AlertApi>>() {}).getFirst();
     assertThat(gotApi).isNotNull();
     assertThat(gotApi.getId()).isNotNull();
     return gotApi.getId();
@@ -758,7 +758,7 @@ public class HappyPathTest {
     final var response = request("api/rca/investigations")
         .post(Entity.json(List.of(investigationApi)));
     assertThat(response.getStatus()).isEqualTo(200);
-    final var gotApi = response.readEntity(new GenericType<List<RcaInvestigationApi>>() {}).get(0);
+    final var gotApi = response.readEntity(new GenericType<List<RcaInvestigationApi>>() {}).getFirst();
     assertThat(gotApi).isNotNull();
     assertThat(gotApi.getId()).isNotNull();
     return gotApi.getId();

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
@@ -112,7 +112,7 @@ public class SchedulingTest {
     response = client.request("api/data-sources")
         .post(Entity.json(List.of(pinotDataSourceApi)));
     assert200(response);
-    final DataSourceApi dataSourceInResponse = response.readEntity(DATASOURCE_LIST_TYPE).get(0);
+    final DataSourceApi dataSourceInResponse = response.readEntity(DATASOURCE_LIST_TYPE).getFirst();
     pinotDataSourceApi.setId(dataSourceInResponse.getId());
 
     // create dataset
@@ -133,7 +133,7 @@ public class SchedulingTest {
         .post(Entity.json(List.of(ALERT_API)));
     assertThat(createResponse.getStatus()).isEqualTo(200);
     final List<AlertApi> alerts = createResponse.readEntity(ALERT_LIST_TYPE);
-    alertId = alerts.get(0).getId();
+    alertId = alerts.getFirst().getId();
 
     // time advancing should not impact lastTimestamp
     CLOCK.tick(5);

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/auth/AuthIntegrationTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/auth/AuthIntegrationTest.java
@@ -105,7 +105,7 @@ public class AuthIntegrationTest {
         .issuer(ISSUER)
         .expirationTime(new Date(System.currentTimeMillis() + 36000000))
         .build();
-    oAuthToken = String.format("Bearer %s", getToken(jwks.getKeys().get(0), claimsSet));
+    oAuthToken = String.format("Bearer %s", getToken(jwks.getKeys().getFirst(), claimsSet));
 
     dir = new File(DIR);
     dir.mkdir();

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/MetricConfigManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/MetricConfigManagerImpl.java
@@ -43,7 +43,7 @@ public class MetricConfigManagerImpl extends AbstractManagerImpl<MetricConfigDTO
         .stream().filter(d -> Objects.equals(d.namespace(), namespace)).toList();
     if (CollectionUtils.isNotEmpty(list)) {
       // TODO CYRIL behavior is different in AbstractManager#findUniqueByNameAndNamespace --> clarify
-      return list.get(0);
+      return list.getFirst();
     }
     return null;
   }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -135,7 +135,7 @@ public class TaskManagerImpl implements TaskManager {
     if (dtos.isEmpty()) {
       return null;
     }
-    return dtos.get(0);
+    return dtos.getFirst();
   }
 
   /**

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/core/EnumerationItemMaintainer.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/core/EnumerationItemMaintainer.java
@@ -156,7 +156,7 @@ public class EnumerationItemMaintainer {
       return source;
     } else if (matching.size() == 1) {
       // already exists
-      return matching.get(0);
+      return matching.getFirst();
     } else {
       final List<Long> ids = matching.stream()
           .map(EnumerationItemDTO::getId)
@@ -166,7 +166,7 @@ public class EnumerationItemMaintainer {
           ids);
       // returning the first item of the list 
       // fixme cyril kept the existing behavior but we should throw an error - the system is in an inconsistent state
-      return matching.get(0);
+      return matching.getFirst();
     }
   }
 

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -265,7 +265,7 @@ public class GenericPojoDao {
       if (genericJsonEntity != null) {
         return toDto(genericJsonEntity,
             SubEntities.BEAN_TYPE_MAP.asMultimap().inverse().get(
-                SubEntityType.valueOf(genericJsonEntity.getType())).asList().get(0));
+                SubEntityType.valueOf(genericJsonEntity.getType())).asList().getFirst());
       }
     } catch (final JsonProcessingException | SQLException e) {
       LOG.error(e.getMessage(), e);

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/mapper/DtoIndexMapper.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/mapper/DtoIndexMapper.java
@@ -54,19 +54,16 @@ public class DtoIndexMapper {
   private static <E extends AbstractDTO> AbstractIndexEntity buildAbstractIndexEntity(final E pojo,
       final Class<? extends AbstractIndexEntity> indexClass)
       throws InstantiationException, IllegalAccessException {
-    if (pojo instanceof AnomalyDTO) {
-      return IndexMapper.INSTANCE.toIndexEntity((AnomalyDTO) pojo);
-    } else if (pojo instanceof EnumerationItemDTO) {
-      return IndexMapper.INSTANCE.toIndexEntity((EnumerationItemDTO) pojo);
-    } else if (pojo instanceof RcaInvestigationDTO) {
-      return IndexMapper.INSTANCE.toIndexEntity((RcaInvestigationDTO) pojo);
-    }
-
-    return buildWithLegacyModelMapper(pojo, indexClass);
+    return switch (pojo) {
+      case AnomalyDTO obj -> IndexMapper.INSTANCE.toIndexEntity(obj);
+      case EnumerationItemDTO obj -> IndexMapper.INSTANCE.toIndexEntity(obj);
+      case RcaInvestigationDTO obj -> IndexMapper.INSTANCE.toIndexEntity(obj);
+      case null, default -> buildWithLegacyModelMapper(pojo, indexClass);
+    };
   }
 
   /**
-   * TODO spyne remove modelmapper code and dependencies
+   * TODO cyril remove modelmapper code and dependencies
    */
   private static <E extends AbstractDTO> AbstractIndexEntity buildWithLegacyModelMapper(
       final E pojo,

--- a/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/CommonProperties.java
+++ b/thirdeye-plugins/thirdeye-bootstrap-open-core/src/main/java/ai/startree/thirdeye/plugins/bootstrap/opencore/CommonProperties.java
@@ -38,7 +38,7 @@ public class CommonProperties {
       final TemplatePropertyMetadata[] commonProperties = readJsonObjectsFromResourcesFolder(
           COMMON_PROPERTIES_PATH,
           this.getClass(),
-          TemplatePropertyMetadata[].class).get(0);
+          TemplatePropertyMetadata[].class).getFirst();
       NAME_TO_PROPERTY = Arrays.stream(commonProperties)
           .collect(Collectors.toMap(TemplatePropertyMetadata::getName, e -> e));
     }

--- a/thirdeye-plugins/thirdeye-pinot/src/main/java/ai/startree/thirdeye/plugins/datasource/pinot/PinotSqlExpressionBuilder.java
+++ b/thirdeye-plugins/thirdeye-pinot/src/main/java/ai/startree/thirdeye/plugins/datasource/pinot/PinotSqlExpressionBuilder.java
@@ -176,7 +176,7 @@ public class PinotSqlExpressionBuilder implements SqlExpressionBuilder {
         checkArgument(operands.size() == 1,
             "Incorrect number of operands for percentile sql generation. Expected: 1. Got: %s",
             operands.size());
-        return PERCENTILE_TDIGEST_PREFIX + "(" + operands.get(0) + "," + percentile + ")";
+        return PERCENTILE_TDIGEST_PREFIX + "(" + operands.getFirst() + "," + percentile + ")";
       default:
         throw new UnsupportedOperationException();
     }

--- a/thirdeye-plugins/thirdeye-postprocessors/src/main/java/ai/startree/thirdeye/plugins/postprocessor/AnomalyMergerPostProcessor.java
+++ b/thirdeye-plugins/thirdeye-postprocessors/src/main/java/ai/startree/thirdeye/plugins/postprocessor/AnomalyMergerPostProcessor.java
@@ -428,9 +428,8 @@ public class AnomalyMergerPostProcessor implements AnomalyPostProcessor {
             .filter(a -> !hasOutdatedLabel(a))
             .sorted(COMPARATOR)
             .toList();
-        final AnomalyDTO firstChildren = sortedNotOutdatedChildren.get(0);
-        final AnomalyDTO lastChildren = sortedNotOutdatedChildren.get(
-            sortedNotOutdatedChildren.size() - 1);
+        final AnomalyDTO firstChildren = sortedNotOutdatedChildren.getFirst();
+        final AnomalyDTO lastChildren = sortedNotOutdatedChildren.getLast();
         existingAnomaly.setStartTime(firstChildren.getStartTime());
         updateAnomalyWithNewValues(existingAnomaly, firstChildren);
         final List<List<AnomalyLabelDTO>> notOutdatedLabels = sortedNotOutdatedChildren.stream()

--- a/thirdeye-plugins/thirdeye-postprocessors/src/test/java/ai/startree/thirdeye/plugins/postprocessor/ColdStartPostProcessorTest.java
+++ b/thirdeye-plugins/thirdeye-postprocessors/src/test/java/ai/startree/thirdeye/plugins/postprocessor/ColdStartPostProcessorTest.java
@@ -111,10 +111,10 @@ public class ColdStartPostProcessorTest {
     assertThat(resultMap).hasSize(2);
     final List<AnomalyDTO> res1Anomalies = resultMap.get(RES_1_KEY).getAnomalies();
     assertThat(res1Anomalies).hasSize(2);
-    final AnomalyDTO firstAnomaly = res1Anomalies.get(0);
+    final AnomalyDTO firstAnomaly = res1Anomalies.getFirst();
     // first anomaly is in cold start zone
     assertThat(firstAnomaly.getAnomalyLabels()).hasSize(1);
-    final AnomalyLabelDTO label = firstAnomaly.getAnomalyLabels().get(0);
+    final AnomalyLabelDTO label = firstAnomaly.getAnomalyLabels().getFirst();
     assertThat(label.getName()).isEqualTo(labelName(Period.days(28)));
     assertThat(label.isIgnore()).isTrue();
     // second anomaly is out of cold start zone
@@ -123,10 +123,10 @@ public class ColdStartPostProcessorTest {
 
     final List<AnomalyDTO> res2Anomalies = resultMap.get(RES_2_KEY).getAnomalies();
     assertThat(res2Anomalies).hasSize(1);
-    final AnomalyDTO res2SingleAnomaly = res2Anomalies.get(0);
+    final AnomalyDTO res2SingleAnomaly = res2Anomalies.getFirst();
     // first anomaly is in cold start zone
     assertThat(res2SingleAnomaly.getAnomalyLabels()).hasSize(1);
-    final AnomalyLabelDTO res2Label = res2SingleAnomaly.getAnomalyLabels().get(0);
+    final AnomalyLabelDTO res2Label = res2SingleAnomaly.getAnomalyLabels().getFirst();
     assertThat(res2Label.getName()).isEqualTo(labelName(Period.days(28)));
     assertThat(res2Label.isIgnore()).isTrue();
   }
@@ -143,8 +143,8 @@ public class ColdStartPostProcessorTest {
     postProcessor.postProcess(UTC_DETECTION_INTERVAL, resultMap);
 
     final List<AnomalyDTO> res1Anomalies = resultMap.get(RES_1_KEY).getAnomalies();
-    final AnomalyDTO firstAnomaly = res1Anomalies.get(0);
-    final AnomalyLabelDTO label = firstAnomaly.getAnomalyLabels().get(0);
+    final AnomalyDTO firstAnomaly = res1Anomalies.getFirst();
+    final AnomalyLabelDTO label = firstAnomaly.getAnomalyLabels().getFirst();
     assertThat(label.isIgnore()).isFalse();
   }
 
@@ -167,7 +167,7 @@ public class ColdStartPostProcessorTest {
     postProcessor.postProcess(UTC_DETECTION_INTERVAL, resultMap);
 
     final List<AnomalyDTO> res1Anomalies = resultMap.get(RES_1_KEY).getAnomalies();
-    final AnomalyDTO firstAnomaly = res1Anomalies.get(0);
+    final AnomalyDTO firstAnomaly = res1Anomalies.getFirst();
     final List<AnomalyLabelDTO> labels = firstAnomaly.getAnomalyLabels();
     assertThat(labels).hasSize(2);
     final AnomalyLabelDTO label1 = labels.get(0);

--- a/thirdeye-plugins/thirdeye-postprocessors/src/test/java/ai/startree/thirdeye/plugins/postprocessor/EventPostProcessorTest.java
+++ b/thirdeye-plugins/thirdeye-postprocessors/src/test/java/ai/startree/thirdeye/plugins/postprocessor/EventPostProcessorTest.java
@@ -183,7 +183,7 @@ public class EventPostProcessorTest {
       final List<AnomalyLabelDTO> labels = res1Anomalies.get(i).getAnomalyLabels();
       if (expectedIsLabeled) {
         assertThat(labels).hasSize(1);
-        final AnomalyLabelDTO label = labels.get(0);
+        final AnomalyLabelDTO label = labels.getFirst();
         assertThat(label.isIgnore()).isEqualTo(isIgnore);
         assertThat(label.getName()).isEqualTo("Anomaly happens during " + eventName + " event");
       } else {

--- a/thirdeye-plugins/thirdeye-postprocessors/src/test/java/ai/startree/thirdeye/plugins/postprocessor/ThresholdPostProcessorTest.java
+++ b/thirdeye-plugins/thirdeye-postprocessors/src/test/java/ai/startree/thirdeye/plugins/postprocessor/ThresholdPostProcessorTest.java
@@ -121,7 +121,7 @@ public class ThresholdPostProcessorTest {
       if (isLabeled) {
         final List<AnomalyLabelDTO> anomalyLabels = anomaly.getAnomalyLabels();
         assertThat(anomalyLabels).hasSize(1);
-        final AnomalyLabelDTO label = anomalyLabels.get(0);
+        final AnomalyLabelDTO label = anomalyLabels.getFirst();
         assertThat(label.isIgnore()).isEqualTo(ignoreMode);
         assertThat(label.getName()).isEqualTo(labelName(min, max, metric1));
       } else {
@@ -211,7 +211,7 @@ public class ThresholdPostProcessorTest {
       if (isLabeled) {
         final List<AnomalyLabelDTO> anomalyLabels = anomaly.getAnomalyLabels();
         assertThat(anomalyLabels).hasSize(1);
-        final AnomalyLabelDTO label = anomalyLabels.get(0);
+        final AnomalyLabelDTO label = anomalyLabels.getFirst();
         assertThat(label.isIgnore()).isEqualTo(true);
         assertThat(label.getName()).isEqualTo(labelName(min, max, metric1));
       } else {

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
@@ -191,7 +191,7 @@ public class DetectionCronScheduler implements Runnable {
   @SuppressWarnings("unchecked")
   private boolean isJobUpdated(final AlertDTO config, final JobKey key) throws SchedulerException {
     final List<Trigger> triggers = (List<Trigger>) scheduler.getTriggersOfJob(key);
-    final CronTrigger cronTrigger = (CronTrigger) triggers.get(0);
+    final CronTrigger cronTrigger = (CronTrigger) triggers.getFirst();
     final String cronInSchedule = cronTrigger.getCronExpression();
 
     if (!config.getCron().equals(cronInSchedule)) {

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SubscriptionCronScheduler.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SubscriptionCronScheduler.java
@@ -195,7 +195,7 @@ public class SubscriptionCronScheduler implements Runnable {
       throws SchedulerException {
     final List<? extends Trigger> triggers = scheduler.getTriggersOfJob(jobKey);
     if (!triggers.isEmpty()) {
-      final CronTrigger cronTrigger = (CronTrigger) triggers.get(0);
+      final CronTrigger cronTrigger = (CronTrigger) triggers.getFirst();
       final String currentCron = cronTrigger.getCronExpression();
       if (!currentCron.equals(cron)) {
         stopJob(jobKey);

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/CrudService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/CrudService.java
@@ -112,7 +112,7 @@ public abstract class CrudService<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exten
         .map(this::toApi)
         .collect(Collectors.toList());
     if (!result.isEmpty()) {
-      authorizationManager.invalidateCache(result.get(0).namespace(), result.get(0).getClass());
+      authorizationManager.invalidateCache(result.getFirst().namespace(), result.getFirst().getClass());
     }
     return result;
   }
@@ -127,7 +127,7 @@ public abstract class CrudService<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exten
         .map(this::toApi)
         .collect(Collectors.toList());
     if (!result.isEmpty()) {
-      authorizationManager.invalidateCache(result.get(0).namespace(), result.get(0).getClass());
+      authorizationManager.invalidateCache(result.getFirst().namespace(), result.getFirst().getClass());
     }
     return result;
   }
@@ -218,7 +218,7 @@ public abstract class CrudService<ApiT extends ThirdEyeCrudApi<ApiT>, DtoT exten
       LOG.warn("Deleted id: {} by principal: {}", dto.getId(), principal.getName());
     }
     if (!entities.isEmpty()) {
-      authorizationManager.invalidateCache(namespace, entities.get(0).getClass());
+      authorizationManager.invalidateCache(namespace, entities.getFirst().getClass());
     }
   }
 

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/EventService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/EventService.java
@@ -91,6 +91,6 @@ public class EventService extends CrudService<EventApi, EventDTO> {
       LOG.error("Failed to create event from an anomaly. List of created entities is not of size 1. Returned list: {}", created);
       throw new RuntimeException("Failed to create event from anomaly. Number of anomalies created: " + created.size());
     }
-    return created.get(0);
+    return created.getFirst();
   }
 }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/alert/EvaluationContextProcessorTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/alert/EvaluationContextProcessorTest.java
@@ -62,6 +62,6 @@ public class EvaluationContextProcessorTest {
 
     assertThat(res.getPredicates()).isNotNull();
     assertThat(res.getPredicates().size()).isEqualTo(1);
-    assertThat(res.getPredicates().get(0)).isEqualTo(new Predicate("browser", OPER.EQ, "chrome"));
+    assertThat(res.getPredicates().getFirst()).isEqualTo(new Predicate("browser", OPER.EQ, "chrome"));
   }
 }

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/CrudResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/CrudResourceTest.java
@@ -71,7 +71,7 @@ public class CrudResourceTest {
         new ThirdEyeAuthorizerProvider.AlwaysAllowAuthorizer(Map.of()));
 
     final List<String> emails = List.of("tester1@testing.com", "tester2@testing.com");
-    final ThirdEyeServerPrincipal owner = getPrincipal(emails.get(0));
+    final ThirdEyeServerPrincipal owner = getPrincipal(emails.getFirst());
     final DummyApi api = new DummyApi().setData("testData");
 
     final Timestamp before = new Timestamp(1671476530000L);
@@ -80,9 +80,9 @@ public class CrudResourceTest {
 
     assertThat(response).isNotNull();
     assertThat(response.isEmpty()).isFalse();
-    final DummyApi responseApi = response.get(0);
-    assertThat(responseApi.getCreatedBy()).isEqualTo(emails.get(0));
-    assertThat(responseApi.getUpdatedBy()).isEqualTo(emails.get(0));
+    final DummyApi responseApi = response.getFirst();
+    assertThat(responseApi.getCreatedBy()).isEqualTo(emails.getFirst());
+    assertThat(responseApi.getUpdatedBy()).isEqualTo(emails.getFirst());
     assertThat(responseApi.getCreateTime().after(before)).isTrue();
     assertThat(responseApi.getCreateTime()).isEqualTo(responseApi.getUpdateTime());
   }
@@ -119,7 +119,7 @@ public class CrudResourceTest {
 
     assertThat(response).isNotNull();
     assertThat(response.isEmpty()).isFalse();
-    final DummyApi responseApi = response.get(0);
+    final DummyApi responseApi = response.getFirst();
     assertThat(responseApi.getData()).isEqualTo("updateTestData");
     assertThat(responseApi.getCreatedBy()).isEqualTo(owner.getName());
     assertThat(responseApi.getUpdatedBy()).isEqualTo(updater.getName());
@@ -166,7 +166,7 @@ public class CrudResourceTest {
       final List<DummyApi> entities = ((Stream<DummyApi>) resp.getEntity()).collect(
           Collectors.toList());
       assertThat(1).isEqualTo(entities.size());
-      assertThat(2L).isEqualTo(entities.get(0).getId());
+      assertThat(2L).isEqualTo(entities.getFirst().getId());
     }
   }
 

--- a/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
+++ b/thirdeye-server/src/test/java/ai/startree/thirdeye/resources/DataSourceResourceTest.java
@@ -105,7 +105,7 @@ public class DataSourceResourceTest {
     assertThat(entity.getList()).isNotNull();
     assertThat(entity.getList().isEmpty()).isFalse();
 
-    final StatusApi statusApi = entity.getList().get(0);
+    final StatusApi statusApi = entity.getList().getFirst();
     assertThat(statusApi.getCode()).isEqualTo(ThirdEyeStatus.ERR_DATASOURCE_VALIDATION_FAILED);
   }
 

--- a/thirdeye-spi/pom.xml
+++ b/thirdeye-spi/pom.xml
@@ -27,6 +27,7 @@
   <name>thirdeye-spi</name>
   <url>http://maven.apache.org</url>
 
+  <!--NOTE: the spi should stay compatible with jdk 11. Some users are building custom plugins in jdk 11 TODO CYRIL enforce with maven-compiler-plugin-->
   <properties>
 
   </properties>

--- a/thirdeye-spi/pom.xml
+++ b/thirdeye-spi/pom.xml
@@ -27,7 +27,7 @@
   <name>thirdeye-spi</name>
   <url>http://maven.apache.org</url>
 
-  <!--NOTE: the spi should stay compatible with jdk 11. Some users are building custom plugins in jdk 11 TODO CYRIL enforce with maven-compiler-plugin-->
+  <!--NOTE: the spi should stay compatible with jdk 11. This means thirdeye-dataframe should also stay compatible with jdk 11. Some users are building custom plugins in jdk 11.  TODO CYRIL enforce with maven-compiler-plugin-->
   <properties>
 
   </properties>


### PR DESCRIPTION
- **[java] upgrade github actions to java 21**
- **[java] upgrade DockerFile to java 21**
- **[java] update readme to java 21**
- **[java] upgrade benchmark compilation target to java 21**


Checks: 
- [x] `./mvnw clean install` 
- [x] able to build the Docker image
- [x] able to launch the thirdeye-distribution

How to review: 
look commit per commit

Ref: 
https://nipafx.dev/road-to-21-upgrade/
dropwizard is tested on java 21: https://github.com/dropwizard/dropwizard/discussions/8173
https://www.baeldung.com/java-lts-21-new-features

Note 1: 
virtual threads may have an impact on the performance/behavior of the system.
this PR does not directly introduce virtual threads usage. 
by default, dropwizard does not use virtual threads either: https://www.dropwizard.io/en/stable/manual/configuration.html
the dropwizard virtual threads toggle will be exposed in another PR

Note 2:
java 21 adds support for generational ZGC. 
https://openjdk.org/jeps/439
It's likely it will improve the performance of the evaluate endpoint. 
This is not in the scope of this PR.