### PR TITLE
[worker] add pessimistic lock task acquisition

### DIFF
--- a/config/server.yaml
+++ b/config/server.yaml
@@ -99,6 +99,8 @@ taskDriver:
   # must be a non-negative integer unique per instance/worker
   # must be omitted when `randomWorkerIdEnabled` is set `true`
   id: 0
+  # whether to use the new task acquisition logic (beta) or the old one (slow) 
+  newAcquisitionLogic: false
 
 rca:
   # default values - structure example

--- a/thirdeye-integration-tests/src/test/resources/anomalyresolution/config/server.yaml
+++ b/thirdeye-integration-tests/src/test/resources/anomalyresolution/config/server.yaml
@@ -63,6 +63,7 @@ taskDriver:
   noTaskDelay: 1
   randomDelayCap: 1
   taskFailureDelay: 1
+  newAcquisitionLogic: true
 
 scheduler:
   # Run the Quartz Scheduler.

--- a/thirdeye-integration-tests/src/test/resources/happypath/config/server.yaml
+++ b/thirdeye-integration-tests/src/test/resources/happypath/config/server.yaml
@@ -71,3 +71,4 @@ taskDriver:
   noTaskDelay: 1
   randomDelayCap: 1
   taskFailureDelay: 1
+  newAcquisitionLogic: true

--- a/thirdeye-integration-tests/src/test/resources/scheduling/config/server.yaml
+++ b/thirdeye-integration-tests/src/test/resources/scheduling/config/server.yaml
@@ -63,6 +63,7 @@ taskDriver:
   noTaskDelay: 1
   randomDelayCap: 1
   taskFailureDelay: 1
+  newAcquisitionLogic: true
 
 scheduler:
   # Run the Quartz Scheduler.

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -125,6 +125,11 @@ public class TaskManagerImpl implements TaskManager {
 
   // TODO CYRIL NOTE - RETRY IS NOT IMPLEMENTED BUT IT SHOULD BE EASY BY ACCEPTING STATUS = FAILED IN THE 2 METHODS BELOW AND PUTTING A LIMIT ON THE VALUE OF VERSION
   @Override
+  public TaskDTO acquireNextTaskToRun(final long workerId) {
+    return dao.acquireNextTaskToRun(workerId);
+  }
+
+  @Override
   public TaskDTO findNextTaskToRun() {
     final String queryClause = """
         WHERE status = 'WAITING'

--- a/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -93,22 +93,22 @@ public class TestAnomalyTaskManager {
   @Test(dependsOnMethods = {"testFindAll"})
   public void testAcquireTaskToRun() {
     CLOCK.tick(1);
-    Long workerId = 1L;
-    TaskDTO taskDTO = taskDAO.findById(anomalyTaskId1);
+    final Long workerId = 1L;
+    final TaskDTO taskDTO = taskDAO.findById(anomalyTaskId1);
     final long currentVersion = taskDTO.getVersion();
-    boolean status = taskDAO.acquireTaskToRun(taskDTO, workerId);
-    // refetch task from the persistence layer and check its values
-    TaskDTO anomalyTask = taskDAO.findById(anomalyTaskId1);
-    Assert.assertTrue(status);
-    Assert.assertEquals(anomalyTask.getStatus(), TaskStatus.RUNNING);
-    Assert.assertEquals(anomalyTask.getWorkerId(), workerId);
-    Assert.assertEquals(anomalyTask.getVersion(), currentVersion + 1);
+    final TaskDTO acquiredTask = taskDAO.acquireNextTaskToRun(workerId);
+    assertThat(acquiredTask).isNotNull();
+    assertThat(acquiredTask.getStatus()).isEqualTo(TaskStatus.RUNNING);
+    assertThat(acquiredTask.getWorkerId()).isEqualTo(workerId);
+    assertThat(acquiredTask.getVersion()).isEqualTo(currentVersion + 1);
   }
 
   @Test(dependsOnMethods = {"testAcquireTaskToRun"})
   public void testFindNextTaskToRun() {
-    TaskDTO anomalyTask = taskDAO.findNextTaskToRun();
+    final Long workerId = 1L;
+    final TaskDTO anomalyTask = taskDAO.acquireNextTaskToRun(workerId);
     assertThat(anomalyTask).isNotNull();
+    assertThat(anomalyTask.getId()).isEqualTo(anomalyTaskId2);
   }
 
   @Test(dependsOnMethods = {"testFindNextTaskToRun"})

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
@@ -33,12 +33,16 @@ public interface TaskManager extends AbstractManager<TaskDTO> {
   TaskDTO createTaskDto(final TaskInfo taskInfo, final TaskType taskType,
       final AuthorizationConfigurationDTO auth) throws Exception;
 
+  @Deprecated // use acquireNextTaskToRun instead
   TaskDTO findNextTaskToRun();
 
   // true if a task with the same name and status WAITING or RUNNING exists 
   boolean isAlreadyInQueue(final String taskName);
 
+  @Deprecated // use acquireNextTaskToRun instead
   boolean acquireTaskToRun(TaskDTO taskDTO, final long workerId);
+
+  TaskDTO acquireNextTaskToRun(final long workerId);
 
   List<TaskDTO> findByStatusAndWorkerId(Long workerId, TaskStatus status);
 

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverConfiguration.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverConfiguration.java
@@ -30,6 +30,9 @@ public class TaskDriverConfiguration {
 
   private int taskFetchSizeCap = 50;
   private int maxParallelTasks = 5;
+  
+  // still experimental -- TODO CYRIL - set to true once validated and stable - then remove
+  private boolean newAcquisitionLogic = false;
 
   public Long getId() {
     return id;
@@ -127,6 +130,16 @@ public class TaskDriverConfiguration {
 
   public TaskDriverConfiguration setActiveThresholdMultiplier(final int activeThresholdMultiplier) {
     this.activeThresholdMultiplier = activeThresholdMultiplier;
+    return this;
+  }
+
+  public boolean isNewAcquisitionLogic() {
+    return newAcquisitionLogic;
+  }
+
+  public TaskDriverConfiguration setNewAcquisitionLogic(
+      final boolean newAcquisitionLogic) {
+    this.newAcquisitionLogic = newAcquisitionLogic;
     return this;
   }
 }

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -166,6 +166,7 @@ public class TaskDriverRunnable implements Runnable {
    *
    * @return null if system is shutting down.
    */
+  @Deprecated
   private TaskDTO waitForTaskLegacy() {
     while (!isShutdown()) {
       final TaskDTO nextTask;

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -217,7 +217,7 @@ public class TaskDriverRunnable implements Runnable {
       try {
         nextTask = taskManager.acquireNextTaskToRun(workerId);
       } catch (Exception e) {
-        // FIXME CYRIL acquireNextTaskToRun is not throwing errors up to here
+        // FIXME CYRIL acquireNextTaskToRun is not throwing errors up to here - requires redesign of DatabaseClient#executeTransaction
         LOG.error("Failed to fetch a new task to run", e);
         taskRunnerWaitIdleTimer.record(() -> sleep(true));
         continue;

--- a/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
+++ b/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
@@ -67,11 +67,10 @@ public class HeartbeatTest {
   public void setUp() {
     config = new TaskDriverConfiguration()
         .setRandomWorkerIdEnabled(true)
-        .setHeartbeatInterval(HEARTBEAT_INTERVAL);
+        .setHeartbeatInterval(HEARTBEAT_INTERVAL)
+        .setNewAcquisitionLogic(true);
 
     taskManager = Mockito.mock(TaskManager.class);
-    when(taskManager.acquireTaskToRun(any(), anyLong()))
-        .thenReturn(true);
 
     doNothing().when(taskManager)
         .updateStatusAndTaskEndTime(anyLong(), any(), any(), anyLong(), any());
@@ -94,7 +93,7 @@ public class HeartbeatTest {
   public void heartbeatPulseCheck() {
     final Timestamp startTime = new Timestamp(System.currentTimeMillis());
     final TaskDTO taskDTO = newTask();
-    when(taskManager.findNextTaskToRun()).thenAnswer(i -> pollingCount++ == 0? taskDTO : null);
+    when(taskManager.acquireNextTaskToRun(anyLong())).thenAnswer(i -> pollingCount++ == 0 ? taskDTO : null);
 
     doAnswer(invocation -> {
       taskDTO.setStatus(TaskStatus.COMPLETED);


### PR DESCRIPTION
Problem: 
The current task acquisition logic uses an optimistic lock. Read  https://en.wikipedia.org/wiki/Optimistic_concurrency_control if necessary. 
Tasks are picked **in order** by every worker.
In order was not enforced before, so there was less chance of contention.
In order is now enforced, so contention is more likely to happen.
At around 5 workers (~4 threads?), workers are very likely to select the same task and spend most of their time rolling back instead of acquiring the task and making progress. 

This PR implements a pessimistic lock, and uses the SKIP LOCKED statement to avoid lock contention.
This should be roughly as fast under small load / small number of workers, and this should scale better with high number of workers (>5).
Realistic benchmarks will be necessary and are not in the scope of this PR.

The feature is disabled by default for the moment. 
It can be enabled by setting `taskDriver.newAcquisitionLogic: true` in the server config.

Tests:
- [X] simulated and checked locks manually for concurrent `SELECT ... FOR UPDATE SKIP LOCKED` queries and `UPDATE`
- [X] end to end tests pass on the new logic 
- [X] unit tests pass on the new logic

NOTE: ⚠️ 
The logic here: https://github.com/startreedata/thirdeye/blob/4951e72be61d4a1b4c0b4665a66c6c722e9fbc44/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java#L221
is slightly incorrect because nextTask could be null because the exception was caught in lower levels. 
This means the sleeping logic is incorrect and the metrics are incorrect. This bug was already present and fixing it requires a pretty big change, it will be done in another PR.

Next steps: 
- [ ] fix bug above 
- [ ] expose `taskDriver.newAcquisitionLogic` in helm chart
- [ ] simulation and benchmarks with high number of workers
  - [ ] test behavior of old and new logic under high number of workers
  - [ ] test impact of lock on other task APIs (should not have any impact)  

References: 
- FOR UPDATE SKIP LOCKED: https://dev.mysql.com/blog-archive/mysql-8-0-1-using-skip-locked-and-nowait-to-handle-hot-rows/
- locking gotchas https://forums.mysql.com/read.php?22,83098,83565#msg-83565
- SKIP LOCKED doc: https://dev.mysql.com/doc/refman/8.4/en/innodb-locking-reads.html
- implementation examples:
  - queue principle https://www.bigbinary.com/blog/solid-queue
  - https://vladmihalcea.com/database-job-queue-skip-locked/
- Investigating locks:
  - https://lefred.be/content/mysql-8-0-data-locking-visibility/
  - https://emmer.dev/blog/investigating-locks-in-mysql/