### PR TITLE
[thirdeye-pinot] Enrich pinot controller schema fetch error log

### DIFF
--- a/thirdeye-plugins/thirdeye-pinot/src/main/java/ai/startree/thirdeye/plugins/datasource/pinot/restclient/PinotControllerRestClient.java
+++ b/thirdeye-plugins/thirdeye-pinot/src/main/java/ai/startree/thirdeye/plugins/datasource/pinot/restclient/PinotControllerRestClient.java
@@ -138,7 +138,7 @@ public class PinotControllerRestClient {
         schema = VANILLA_OBJECT_MAPPER.readValue(schemaContent, Schema.class);
       }
     } catch (final Exception e) {
-      LOG.error("Exception in retrieving schema collections, skipping {}", dataset);
+      LOG.error("Exception in retrieving schema collections, skipping {}", dataset, e);
     } finally {
       if (schemaRes != null) {
         if (schemaRes.getEntity() != null) {


### PR DESCRIPTION
Error log when fetching schema from pinot controller currently doesn't log exception object
This PR adds exception obj to the log