### PR TITLE
[pinot] remove unused jdbc connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,21 +569,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pinot</groupId>
-        <artifactId>pinot-jdbc-client</artifactId>
-        <version>${pinot.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.pinot</groupId>
         <artifactId>pinot-spi</artifactId>
         <version>${pinot.version}</version>
         <exclusions>

--- a/thirdeye-plugins/thirdeye-pinot/pom.xml
+++ b/thirdeye-plugins/thirdeye-pinot/pom.xml
@@ -44,16 +44,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-jdbc-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-java-client</artifactId>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
The JDBC pinot connection was never used, then deprecated, then removed. 

This PR totally removes the dependency to make it simpler to upgrade the Pinot version. 