### PR TITLE
[notification] Make timers dynamic per namespace

### DIFF
--- a/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationDispatcher.java
+++ b/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationDispatcher.java
@@ -14,6 +14,8 @@
 package ai.startree.thirdeye.notification;
 
 import static ai.startree.thirdeye.spi.Constants.METRICS_TIMER_PERCENTILES;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.NAMESPACE_TAG;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.getNamespaceTagValue;
 import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 
 import ai.startree.thirdeye.spi.api.NotificationPayloadApi;
@@ -25,13 +27,10 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.Timer.Builder;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +39,6 @@ public class NotificationDispatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(NotificationDispatcher.class);
 
-  private final static String NAMESPACE_TAG = "namespace";
-  private final static String NULL_NAMESPACE_TAG_VALUE = "__null__";
   private final static String NOTIFICATION_DISPATCH_TIMER_NAME = "thirdeye_notification_dispatch";
   private final static String NOTIFICATION_DISPATCH_TIMER_DESCRIPTION = "Start: A notification payload is passed to the NotificationService#notify implementation. End: The method returns. Tag exception=true means an exception was thrown by the method call.";
 
@@ -124,16 +121,12 @@ public class NotificationDispatcher {
     }
   }
 
-  private @NonNull String getNamespaceTag(final SubscriptionGroupDTO dto) {
-    return Optional.ofNullable(dto.namespace()).orElse(NULL_NAMESPACE_TAG_VALUE);
-  }
-
   private Timer getNotificationDispatchSuccessTimer(final SubscriptionGroupDTO dto) {
     return Timer.builder(NOTIFICATION_DISPATCH_TIMER_NAME)
         .description(NOTIFICATION_DISPATCH_TIMER_DESCRIPTION)
         .publishPercentiles(METRICS_TIMER_PERCENTILES)
         .tag("exception", "false")
-        .tag(NAMESPACE_TAG, getNamespaceTag(dto))
+        .tag(NAMESPACE_TAG, getNamespaceTagValue(dto.namespace()))
         .register(Metrics.globalRegistry);
   }
 
@@ -142,7 +135,7 @@ public class NotificationDispatcher {
         .description(NOTIFICATION_DISPATCH_TIMER_DESCRIPTION)
         .publishPercentiles(METRICS_TIMER_PERCENTILES)
         .tag("exception", "true")
-        .tag(NAMESPACE_TAG, getNamespaceTag(dto))
+        .tag(NAMESPACE_TAG, getNamespaceTagValue(dto.namespace()))
         .register(Metrics.globalRegistry);
   }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/InternalResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/InternalResource.java
@@ -175,23 +175,4 @@ public class InternalResource {
       return Response.ok(-1).build();
     }
   }
-
-  @Path("run-detection-task-locally")
-  @POST
-  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-  @Timed(percentiles = {0.5, 0.75, 0.90, 0.95, 0.98, 0.99, 0.999})
-  public Response runTask(@Parameter(hidden = true) @Auth final ThirdEyeServerPrincipal principal,
-      @FormParam("alertId") final Long alertId, @FormParam("start") Long startTime,
-      @FormParam("end") Long endTime) throws Exception {
-    checkArgument(alertId != null && alertId >= 0);
-    if (endTime == null) {
-      endTime = System.currentTimeMillis();
-    }
-    if (startTime == null) {
-      startTime = endTime - TimeUnit.MINUTES.toMillis(1);
-    }
-    internalService.runDetectionTaskLocally(principal, alertId, startTime, endTime);
-
-    return Response.ok().build();
-  }
 }

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/InternalService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/InternalService.java
@@ -104,14 +104,4 @@ public class InternalService {
     }
     return emailHtml;
   }
-
-  public void runDetectionTaskLocally(final ThirdEyePrincipal principal, final long alertId, final long startTime,
-      final long endTime) throws Exception {
-    authorizationManager.hasRootAccess(principal);
-    final DetectionPipelineTaskInfo info = new DetectionPipelineTaskInfo(alertId, startTime,
-        endTime);
-    final AlertDTO alert = requireNonNull(alertManager.findById(alertId),
-        String.format("Could not find alert with id %d for local detection task run", alertId));
-    detectionPipelineTaskRunner.execute(info, new TaskContext(), alert.namespace());
-  }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
@@ -15,13 +15,18 @@ package ai.startree.thirdeye.spi.util;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import java.util.Optional;
 import java.util.concurrent.Callable;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Utilities for micrometer metrics.
  */
 public class MetricsUtils {
 
+  public final static String NAMESPACE_TAG = "namespace";
+  public final static String NULL_NAMESPACE_TAG_VALUE = "__null__";
 
   // if the callable does not throw, record time in the successTimer. 
   // Else, record time in the exceptionTimer. 
@@ -36,5 +41,9 @@ public class MetricsUtils {
       sample.stop(exceptionTimer);
       throw e;
     }
+  }
+
+  public static @NonNull String getNamespaceTagValue(@Nullable String namespace) {
+    return Optional.ofNullable(namespace).orElse(NULL_NAMESPACE_TAG_VALUE);
   }
 }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
@@ -25,7 +25,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class MetricsUtils {
 
-  public final static String NAMESPACE_TAG = "namespace";
+  public final static String NAMESPACE_TAG = "thirdeye_workspace";
   public final static String NULL_NAMESPACE_TAG_VALUE = "__null__";
 
   // if the callable does not throw, record time in the successTimer. 
@@ -43,7 +43,7 @@ public class MetricsUtils {
     }
   }
 
-  public static @NonNull String getNamespaceTagValue(@Nullable String namespace) {
+  public static @NonNull String namespaceTagValueOf(@Nullable String namespace) {
     return Optional.ofNullable(namespace).orElse(NULL_NAMESPACE_TAG_VALUE);
   }
 }

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -158,7 +158,7 @@ public class TaskDriverRunnable implements Runnable {
 
     // execute the selected task asynchronously
     return taskDriverThreadPoolManager.getTaskExecutorService()
-        .submit(() -> taskRunner.execute(taskInfo, taskContext));
+        .submit(() -> taskRunner.execute(taskInfo, taskContext, taskDTO.namespace()));
   }
 
   /**

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskRunner.java
@@ -21,5 +21,5 @@ import java.util.List;
  */
 public interface TaskRunner {
 
-  List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception;
+  List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext, String namespace) throws Exception;
 }

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskRunner.java
@@ -15,11 +15,12 @@ package ai.startree.thirdeye.worker.task;
 
 import ai.startree.thirdeye.spi.task.TaskInfo;
 import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Interface for task runner of various types of executors
  */
 public interface TaskRunner {
 
-  List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext, String namespace) throws Exception;
+  List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext, @Nullable String namespace) throws Exception;
 }

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/DetectionPipelineTaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/DetectionPipelineTaskRunner.java
@@ -75,7 +75,7 @@ public class DetectionPipelineTaskRunner implements TaskRunner {
 
   @Override
   public List<TaskResult> execute(final TaskInfo taskInfo, final TaskContext taskContext,
-      String namespace) throws Exception {
+      @Nullable String namespace) throws Exception {
     final Timer detectionTaskTimerOfSuccess = getDetectionTaskTimer(namespace, false);
     final Timer detectionTaskTimerOfException = getDetectionTaskTimer(namespace, true);
     final Timer.Sample sample = Timer.start(Metrics.globalRegistry);

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
@@ -88,7 +88,7 @@ public class NotificationTaskRunner implements TaskRunner {
 
   @Override
   public List<TaskResult> execute(final TaskInfo taskInfo, final TaskContext taskContext,
-      String namespace) throws Exception {
+      @Nullable String namespace) throws Exception {
     return execute(((DetectionAlertTaskInfo) taskInfo).getDetectionAlertConfigId(), namespace);
   }
 

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
@@ -87,17 +87,17 @@ public class NotificationTaskRunner implements TaskRunner {
   }
 
   @Override
-  public List<TaskResult> execute(final TaskInfo taskInfo, final TaskContext taskContext)
-      throws Exception {
-    return execute(((DetectionAlertTaskInfo) taskInfo).getDetectionAlertConfigId());
+  public List<TaskResult> execute(final TaskInfo taskInfo, final TaskContext taskContext,
+      String namespace) throws Exception {
+    return execute(((DetectionAlertTaskInfo) taskInfo).getDetectionAlertConfigId(), namespace);
   }
 
-  public List<TaskResult> execute(final long subscriptionGroupId) throws Exception {
-    final SubscriptionGroupDTO sg = getSubscriptionGroupDTO(subscriptionGroupId);
-    final Timer notificationTaskTimerOfSuccess = getNotificationTaskTimer(sg.namespace(), false);
-    final Timer notificationTaskTimerOfException = getNotificationTaskTimer(sg.namespace(), true);
+  public List<TaskResult> execute(final long subscriptionGroupId, String namespace) throws Exception {
+    final Timer notificationTaskTimerOfSuccess = getNotificationTaskTimer(namespace, false);
+    final Timer notificationTaskTimerOfException = getNotificationTaskTimer(namespace, true);
     return record(
         () -> {
+          final SubscriptionGroupDTO sg = getSubscriptionGroupDTO(subscriptionGroupId);
           executeInternal(sg);
           return Collections.emptyList();
         },

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/NotificationTaskRunner.java
@@ -14,6 +14,8 @@
 package ai.startree.thirdeye.worker.task.runner;
 
 import static ai.startree.thirdeye.spi.Constants.METRICS_TIMER_PERCENTILES;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.NAMESPACE_TAG;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.getNamespaceTagValue;
 import static ai.startree.thirdeye.spi.util.MetricsUtils.record;
 import static java.util.Objects.requireNonNull;
 
@@ -22,7 +24,6 @@ import ai.startree.thirdeye.notification.NotificationPayloadBuilder;
 import ai.startree.thirdeye.notification.NotificationTaskFilter;
 import ai.startree.thirdeye.notification.NotificationTaskFilterResult;
 import ai.startree.thirdeye.notification.NotificationTaskPostProcessor;
-import ai.startree.thirdeye.spi.Constants;
 import ai.startree.thirdeye.spi.api.NotificationPayloadApi;
 import ai.startree.thirdeye.spi.datalayer.bao.SubscriptionGroupManager;
 import ai.startree.thirdeye.spi.datalayer.dto.NotificationSpecDTO;
@@ -39,8 +40,6 @@ import io.micrometer.core.instrument.Timer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +52,6 @@ public class NotificationTaskRunner implements TaskRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(NotificationTaskRunner.class);
 
-  private final static String NAMESPACE_TAG = "namespace";
-  private final static String NULL_NAMESPACE_TAG_VALUE = "__null__";
   private final static String NOTIFICATION_TASK_TIMER_NAME = "thirdeye_notification_task";
   private final static String NOTIFICATION_TASK_TIMER_DESCRIPTION = "Start: a task is started from an input subscription group id. End: the task execution is finished. Tag exception=true means an exception was thrown by the method call.";
 
@@ -138,16 +135,12 @@ public class NotificationTaskRunner implements TaskRunner {
     }
   }
 
-  private @NonNull String getNamespaceTag(final SubscriptionGroupDTO dto) {
-    return Optional.ofNullable(dto.namespace()).orElse(NULL_NAMESPACE_TAG_VALUE);
-  }
-
   private Timer getNotificationTaskSuccessTimer(final SubscriptionGroupDTO dto) {
     return Timer.builder(NOTIFICATION_TASK_TIMER_NAME)
         .description(NOTIFICATION_TASK_TIMER_DESCRIPTION)
         .publishPercentiles(METRICS_TIMER_PERCENTILES)
         .tag("exception", "false")
-        .tag(NAMESPACE_TAG, getNamespaceTag(dto))
+        .tag(NAMESPACE_TAG, getNamespaceTagValue(dto.namespace()))
         .register(Metrics.globalRegistry);
   }
 
@@ -156,7 +149,7 @@ public class NotificationTaskRunner implements TaskRunner {
         .description(NOTIFICATION_TASK_TIMER_DESCRIPTION)
         .publishPercentiles(METRICS_TIMER_PERCENTILES)
         .tag("exception", "true")
-        .tag(NAMESPACE_TAG, getNamespaceTag(dto))
+        .tag(NAMESPACE_TAG, getNamespaceTagValue(dto.namespace()))
         .register(Metrics.globalRegistry);
   }
 }

--- a/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
+++ b/thirdeye-worker/src/test/java/ai/startree/thirdeye/worker/task/HeartbeatTest.java
@@ -78,7 +78,7 @@ public class HeartbeatTest {
     taskDriverThreadPoolManager = new TaskDriverThreadPoolManager(config);
 
     taskRunnerFactory = Mockito.mock(TaskRunnerFactory.class);
-    when(taskRunnerFactory.get(any())).thenReturn((taskInfo, taskContext) -> {
+    when(taskRunnerFactory.get(any())).thenReturn((taskInfo, taskContext, namespace) -> {
       Thread.sleep(TASK_DELAY.toMillis());
       return null;
     });


### PR DESCRIPTION
#### Issue(s)

[Metrics - per namespace](https://startree.atlassian.net/browse/TE-2454)

#### Description

This PR adds add a namespace tag to all metrics where relevant

#### Testing

- [X] Existing UTs
- [X] Existing Integration tests
- [X] Manual testing

1. Run local thirdeye server and UI
2. Put some load on metrics by creating few alerts and notification groups
3. check different metrics by using following command
`curl localhost:8090/admin/prometheus | grep your_metric`

[local-server-prom-logs.txt](https://github.com/user-attachments/files/17929888/local-server-prom-logs.txt)