### PR TITLE
[helm] force 2 procs to JVM when cpu.requests <= 1000

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
+++ b/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
@@ -134,16 +134,20 @@ The name of the thirdeye scheduler (worker with special detector.yml) headless s
 {{- end -}}
 
 {{/*
-  Normalises the CPU requests value
-  This convert cpu values to number of millicores
+  lessOrEqualTo1Cpu returns true if cpu core count
+  is less than or equal to 1.0
 */}}
-{{- define "normalizeCpu" -}}
+{{- define "lessOrEqualTo1Cpu" -}}
 {{- $cpu := . | trim -}}
+{{- $millicores := 0.0 -}}
 {{- if hasSuffix "m" $cpu -}}
-  {{- $millicores := (trimSuffix "m" $cpu | int) -}}
-  {{- $millicores | float64 -}}
+  {{- $millicores = (trimSuffix "m" $cpu) | float64 -}}
 {{- else -}}
-  {{- $millicores := (mulf (float64 $cpu) 1000.0) -}}
-  {{- $millicores -}}
+  {{- $millicores = mulf (float64 $cpu) 1000.0 -}}
+{{- end -}}
+{{- if le $millicores 1000.0 -}}
+true
+{{- else -}}
+false
 {{- end -}}
 {{- end -}}

--- a/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
+++ b/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
@@ -133,3 +133,17 @@ The name of the thirdeye scheduler (worker with special detector.yml) headless s
 {{-    end -}}
 {{- end -}}
 
+{{/*
+  Normalises the CPU requests value
+  This convert cpu values to number of millicores
+*/}}
+{{- define "normalizeCpu" -}}
+{{- $cpu := . | trim -}}
+{{- if hasSuffix "m" $cpu -}}
+  {{- $millicores := (trimSuffix "m" $cpu | int) -}}
+  {{- $millicores | float64 -}}
+{{- else -}}
+  {{- $millicores := (mulf (float64 $cpu) 1000.0) -}}
+  {{- $millicores -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
@@ -107,10 +107,10 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
-              {{- $cpuValue := .Values.coordinator.resources.requests.cpu -}}
-              {{- $normalizedCpu := include "normalizeCpu" $cpuValue | float64 -}}
-              {{ if le $normalizedCpu 1000.0 }}
+              {{- if and .Values.coordinator .Values.coordinator.resources .Values.coordinator.resources.requests .Values.coordinator.resources.requests.cpu }}
+              {{- if eq (include "lessOrEqualTo1Cpu" .Values.coordinator.resources.requests.cpu) "true" }}
               -XX:ActiveProcessorCount=2
+              {{- end }}
               {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
               -Djavax.net.ssl.trustStorePassword=changeit {{.Values.coordinator.javaOpts}}

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/deployment.yaml
@@ -107,6 +107,11 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
+              {{- $cpuValue := .Values.coordinator.resources.requests.cpu -}}
+              {{- $normalizedCpu := include "normalizeCpu" $cpuValue | float64 -}}
+              {{ if le $normalizedCpu 1000.0 }}
+              -XX:ActiveProcessorCount=2
+              {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
               -Djavax.net.ssl.trustStorePassword=changeit {{.Values.coordinator.javaOpts}}
         ports:

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
@@ -117,6 +117,11 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
+              {{- $cpuValue := .Values.scheduler.resources.requests.cpu -}}
+              {{- $normalizedCpu := include "normalizeCpu" $cpuValue | float64 -}}
+              {{ if le $normalizedCpu 1000.0 }}
+              -XX:ActiveProcessorCount=2
+              {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
               -Djavax.net.ssl.trustStorePassword=changeit {{.Values.scheduler.javaOpts}}
         ports:

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/deployment.yaml
@@ -117,10 +117,10 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
-              {{- $cpuValue := .Values.scheduler.resources.requests.cpu -}}
-              {{- $normalizedCpu := include "normalizeCpu" $cpuValue | float64 -}}
-              {{ if le $normalizedCpu 1000.0 }}
+              {{- if and .Values.scheduler .Values.scheduler.resources .Values.scheduler.resources.requests .Values.scheduler.resources.requests.cpu }}
+              {{- if eq (include "lessOrEqualTo1Cpu" .Values.scheduler.resources.requests.cpu) "true" }}
               -XX:ActiveProcessorCount=2
+              {{- end }}
               {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
               -Djavax.net.ssl.trustStorePassword=changeit {{.Values.scheduler.javaOpts}}

--- a/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
@@ -121,6 +121,11 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
+              {{- $cpuValue := .Values.worker.resources.requests.cpu -}}
+              {{- $normalizedCpu := include "normalizeCpu" $cpuValue | float64 -}}
+              {{ if le $normalizedCpu 1000.0 }}
+              -XX:ActiveProcessorCount=2
+              {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
               -Djavax.net.ssl.trustStorePassword=changeit {{.Values.worker.javaOpts}}
         ports:

--- a/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/deployment.yaml
@@ -121,10 +121,10 @@ spec:
               -Djavax.net.ssl.keyStore=/opt/thirdeye/server/keystore/keystore
               -Djavax.net.ssl.keyStorePassword=changeit
               {{- end }}
-              {{- $cpuValue := .Values.worker.resources.requests.cpu -}}
-              {{- $normalizedCpu := include "normalizeCpu" $cpuValue | float64 -}}
-              {{ if le $normalizedCpu 1000.0 }}
+              {{- if and .Values.worker .Values.worker.resources .Values.worker.resources.requests .Values.worker.resources.requests.cpu }}
+              {{- if eq (include "lessOrEqualTo1Cpu" .Values.worker.resources.requests.cpu) "true" }}
               -XX:ActiveProcessorCount=2
+              {{- end }}
               {{- end }}
               -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
               -Djavax.net.ssl.trustStorePassword=changeit {{.Values.worker.javaOpts}}


### PR DESCRIPTION
#### Issue(s)

[k8s - force 2 procs to JVM when cpu.requests <= 1000](https://startree.atlassian.net/browse/TE-2558)

#### Description

For small or lightly used environments, we'd like to have cpu.requests<=1000m. 
Problem when we do this is java thinks there is only one proc and this hurts the parallel computation capabilities, especially in the simple create flow

Java behaviour based on cpu.requests
- Up to 1000m: 1 proc
-  1001-2000m: 2 procs
-  2001-3000m: 3 procs

When cpu.requests is smaller than or equal to 1000m, we should pass the argument 
`-XX:ActiveProcessorCount=2`

This PR adds the logic to dynamically pass this argument in JAVA_OPTS of coordinator / scheduler / worker deployments based on the cpu request count

#### Testing
Tested via helm install dry run with different values for cpu requests of coordinator, scheduler and workers
`helm install startree-thirdeye --dry-run --debug --generate-name --set coordinator.resources.requests.cpu=<coordinator-cpu> --set scheduler.resources.requests.cpu=<scheduler-cpu> --set worker.resources.requests.cpu=<worker-cpu>`

| Coordinator cpu req  | Scheduler cpu req | Worker cpu req | output |
| ------------- | ------------- | ------------- | ------------- |
| 0.99 | 1.00 | 1.01 | [decimal-val-output-1.txt](https://github.com/user-attachments/files/17945828/decimal-val-output-1.txt) |
| 1.00 |  1.01 | 0.99 | [decimal-val-output-2.txt](https://github.com/user-attachments/files/17945831/decimal-val-output-2.txt) |
| 1.01 | 0.99 | 1.00 | [decimal-val-output-3.txt](https://github.com/user-attachments/files/17945832/decimal-val-output-3.txt) |
| 999m | 1000m | 1001m | [millicore-val-output-1.txt](https://github.com/user-attachments/files/17945836/millicore-val-output-1.txt) |
| 1000m |  1001m | 999m | [millicore-val-output-2.txt](https://github.com/user-attachments/files/17945840/millicore-val-output-2.txt) |
| 1001m | 999m | 1000m | [millicore-val-output-3.txt](https://github.com/user-attachments/files/17945841/millicore-val-output-3.txt) |

**Snippets from helm output:**

Cases when cpu requests <= 1.0 / 1000m
```
          - name: JAVA_OPTS
            value: >
              -XX:ActiveProcessorCount=2
              -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
              -Djavax.net.ssl.trustStorePassword=changeit -Xmx1G -XX:+UseG1GC
```

Cases when cpu requests > 1.0 / 1000m
```
          - name: JAVA_OPTS
            value: >
              -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
              -Djavax.net.ssl.trustStorePassword=changeit -Xmx1G -XX:+UseG1GC
```