### PR TITLE
[helm] Improve helper logic to avoid using mulf

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
+++ b/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
@@ -139,15 +139,18 @@ The name of the thirdeye scheduler (worker with special detector.yml) headless s
 */}}
 {{- define "lessOrEqualTo1Cpu" -}}
 {{- $cpu := . | trim -}}
-{{- $millicores := 0.0 -}}
 {{- if hasSuffix "m" $cpu -}}
-  {{- $millicores = (trimSuffix "m" $cpu) | float64 -}}
+  {{- $millicores := (trimSuffix "m" $cpu) | float64 -}}
+  {{- if le $millicores 1000.0 -}}
+  true
+  {{- else -}}
+  false
+  {{- end -}}
 {{- else -}}
-  {{- $millicores = mulf (float64 $cpu) 1000.0 -}}
-{{- end -}}
-{{- if le $millicores 1000.0 -}}
-true
-{{- else -}}
-false
+  {{- if le (float64 $cpu) 1.0 -}}
+  true
+  {{- else -}}
+  false
+  {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### Issue(s)

[k8s - force 2 procs to JVM when cpu.requests <= 1000](https://startree.atlassian.net/browse/TE-2558)

#### Description

In #1693, we added logic to dynamically pass this argument in JAVA_OPTS of coordinator / scheduler / worker deployments based on the cpu request count

Current helm installation in startree-platform doesn't support [mulf](https://helm.sh/docs/chart_template_guide/function_list/#mulf) function

This PR modifying the helper method to avoid using mulf

#### Testing
Tested via helm install dry run with different values for cpu requests of coordinator, scheduler and workers
`helm install startree-thirdeye --dry-run --debug --generate-name --set coordinator.resources.requests.cpu=<coordinator-cpu> --set scheduler.resources.requests.cpu=<scheduler-cpu> --set worker.resources.requests.cpu=<worker-cpu>`

| Coordinator cpu req  | Scheduler cpu req | Worker cpu req | output |
| ------------- | ------------- | ------------- | ------------- |
| 0.99 | 1.00 | 1.01 | [decimal-val-output-1.txt](https://github.com/user-attachments/files/17945828/decimal-val-output-1.txt) |
| 1.00 |  1.01 | 0.99 | [decimal-val-output-2.txt](https://github.com/user-attachments/files/17945831/decimal-val-output-2.txt) |
| 1.01 | 0.99 | 1.00 | [decimal-val-output-3.txt](https://github.com/user-attachments/files/17945832/decimal-val-output-3.txt) |
| 999m | 1000m | 1001m | [millicore-val-output-1.txt](https://github.com/user-attachments/files/17945836/millicore-val-output-1.txt) |
| 1000m |  1001m | 999m | [millicore-val-output-2.txt](https://github.com/user-attachments/files/17945840/millicore-val-output-2.txt) |
| 1001m | 999m | 1000m | [millicore-val-output-3.txt](https://github.com/user-attachments/files/17945841/millicore-val-output-3.txt) |

**Snippets from helm output:**

Cases when cpu requests <= 1.0 / 1000m
```
          - name: JAVA_OPTS
            value: >
              -XX:ActiveProcessorCount=2
              -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
              -Djavax.net.ssl.trustStorePassword=changeit -Xmx1G -XX:+UseG1GC
```

Cases when cpu requests > 1.0 / 1000m
```
          - name: JAVA_OPTS
            value: >
              -Djavax.net.ssl.trustStore=/opt/thirdeye/server/truststore/truststore
              -Djavax.net.ssl.trustStorePassword=changeit -Xmx1G -XX:+UseG1GC
```