### PR TITLE
[server] make only the scheduler register expensive database metrics

### DIFF
--- a/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/persistence/DelegateDatasetConfigManager.java
+++ b/thirdeye-detectionpipeline/src/main/java/ai/startree/thirdeye/detectionpipeline/persistence/DelegateDatasetConfigManager.java
@@ -132,4 +132,9 @@ public class DelegateDatasetConfigManager implements DatasetConfigManager {
   public List<DatasetConfigDTO> findActive() {
     return delegate.findActive();
   }
+
+  @Override
+  public void registerDatabaseMetrics() {
+    delegate.registerDatabaseMetrics();
+  }
 }

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/arch/ArchitectureTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/arch/ArchitectureTest.java
@@ -26,6 +26,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import ai.startree.thirdeye.PluginLoader;
+import ai.startree.thirdeye.ThirdEyeServer;
 import ai.startree.thirdeye.ThirdEyeServerModule;
 import ai.startree.thirdeye.alert.AlertTemplateRenderer;
 import ai.startree.thirdeye.alert.EvaluationContextProcessor;
@@ -194,6 +195,7 @@ public class ArchitectureTest {
         EvaluationContextProcessor.class,
         AlertTemplateRenderer.class,
         AuthorizationManager.class, // OK - REVIEW ON MAY 6 2024
+        ThirdEyeServer.class // used to register database-reading metrics
     };
     final ArchRule rule = noClasses().that(
             doNot(

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AbstractManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AbstractManagerImpl.java
@@ -159,4 +159,9 @@ public abstract class AbstractManagerImpl<E extends AbstractDTO> implements Abst
   public long count(final Predicate predicate) {
     return genericPojoDao.count(predicate, dtoClass);
   }
+
+  @Override
+  public void registerDatabaseMetrics() {
+    // do nothing by default
+  }
 }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AlertManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AlertManagerImpl.java
@@ -30,10 +30,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class AlertManagerImpl extends AbstractManagerImpl<AlertDTO> implements
     AlertManager {
+  
+  private static final Logger LOG = LoggerFactory.getLogger(AlertManagerImpl.class);
 
   @Inject
   public AlertManagerImpl(final GenericPojoDao genericPojoDao) {
@@ -73,6 +77,7 @@ public class AlertManagerImpl extends AbstractManagerImpl<AlertDTO> implements
     Gauge.builder("thirdeye_active_timeseries",
             memoizeWithExpiration(activeTimeseriesCountFun, 15, TimeUnit.MINUTES))
         .register(Metrics.globalRegistry);
+    LOG.info("Registered alert database metrics.");
   }
 
   @Override

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AlertManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AlertManagerImpl.java
@@ -38,6 +38,24 @@ public class AlertManagerImpl extends AbstractManagerImpl<AlertDTO> implements
   @Inject
   public AlertManagerImpl(final GenericPojoDao genericPojoDao) {
     super(AlertDTO.class, genericPojoDao);
+  }
+
+  @Override
+  public int update(final AlertDTO alertDTO) {
+    if (alertDTO.getId() == null) {
+      final Long id = save(alertDTO);
+      if (id > 0) {
+        return 1;
+      } else {
+        return 0;
+      }
+    } else {
+      return genericPojoDao.update(alertDTO);
+    }
+  }
+
+  @Override
+  public void registerDatabaseMetrics() {
     Gauge.builder("thirdeye_active_alerts",
             memoizeWithExpiration(this::countActive, METRICS_CACHE_TIMEOUT.toMinutes(),
                 TimeUnit.MINUTES))
@@ -55,20 +73,6 @@ public class AlertManagerImpl extends AbstractManagerImpl<AlertDTO> implements
     Gauge.builder("thirdeye_active_timeseries",
             memoizeWithExpiration(activeTimeseriesCountFun, 15, TimeUnit.MINUTES))
         .register(Metrics.globalRegistry);
-  }
-
-  @Override
-  public int update(final AlertDTO alertDTO) {
-    if (alertDTO.getId() == null) {
-      final Long id = save(alertDTO);
-      if (id > 0) {
-        return 1;
-      } else {
-        return 0;
-      }
-    } else {
-      return genericPojoDao.update(alertDTO);
-    }
   }
 
   @Override

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/EventManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/EventManagerImpl.java
@@ -43,6 +43,7 @@ public class EventManagerImpl extends AbstractManagerImpl<EventDTO> implements E
   public EventManagerImpl(GenericPojoDao genericPojoDao) {
     super(EventDTO.class, genericPojoDao);
 
+    // FIXME CYRIL remove this early 2025
     shareEventsInUnsetNamespace = System.getenv("TE_SHARE_EVENTS_IN_UNSET_NAMESPACE") != null;
     if (shareEventsInUnsetNamespace) {
       LOG.warn("Events with a namespace not set are made available to all namespaces. " 

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/RcaInvestigationManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/RcaInvestigationManagerImpl.java
@@ -26,17 +26,18 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class RcaInvestigationManagerImpl extends AbstractManagerImpl<RcaInvestigationDTO> implements
     RcaInvestigationManager {
-  
+
+  private static final Logger LOG = LoggerFactory.getLogger(RcaInvestigationManagerImpl.class);
+
   @Inject
   public RcaInvestigationManagerImpl(final GenericPojoDao genericPojoDao) {
     super(RcaInvestigationDTO.class, genericPojoDao);
-    Gauge.builder("thirdeye_rca_investigations", 
-        memoizeWithExpiration(this::count, METRICS_CACHE_TIMEOUT.toMinutes(), TimeUnit.MINUTES))
-        .register(Metrics.globalRegistry);
   }
 
   @Override
@@ -70,5 +71,13 @@ public class RcaInvestigationManagerImpl extends AbstractManagerImpl<RcaInvestig
   @Override
   public List<RcaInvestigationDTO> findByAnomalyId(long id) {
     return findByPredicate(Predicate.EQ("anomalyId", id));
+  }
+
+  @Override
+  public void registerDatabaseMetrics() {
+    Gauge.builder("thirdeye_rca_investigations",
+            memoizeWithExpiration(this::count, METRICS_CACHE_TIMEOUT.toMinutes(), TimeUnit.MINUTES))
+        .register(Metrics.globalRegistry);
+    LOG.info("Registered RCA investigation database metrics.");
   }
 }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/SubscriptionGroupManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/SubscriptionGroupManagerImpl.java
@@ -26,14 +26,22 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class SubscriptionGroupManagerImpl extends
     AbstractManagerImpl<SubscriptionGroupDTO> implements SubscriptionGroupManager {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SubscriptionGroupManagerImpl.class);
+
   @Inject
   public SubscriptionGroupManagerImpl(final GenericPojoDao genericPojoDao) {
     super(SubscriptionGroupDTO.class, genericPojoDao);
+  }
+
+  @Override
+  public void registerDatabaseMetrics() {
     final Supplier<Number> notificationFlowsFun = () -> findAll().stream()
         .filter(sg -> CollectionUtils.isNotEmpty(sg.getAlertAssociations()))
         .filter(sg -> CollectionUtils.isNotEmpty(sg.getSpecs()))
@@ -44,5 +52,7 @@ public class SubscriptionGroupManagerImpl extends
             memoizeWithExpiration(notificationFlowsFun, METRICS_CACHE_TIMEOUT.toMinutes(),
                 TimeUnit.MINUTES))
         .register(Metrics.globalRegistry);
+
+    LOG.info("Registered subscription group database metrics.");
   }
 }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -59,12 +59,12 @@ public class TaskManagerImpl implements TaskManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskManagerImpl.class);
 
-  private final AtomicInteger orphanTasksCountMetric;
+  private final AtomicInteger orphanTasksGauge;
 
   @Inject
   public TaskManagerImpl(final TaskDao dao) {
     this.dao = dao;
-    orphanTasksCountMetric = Metrics.globalRegistry.gauge("thirdeye_task_orphans",
+    orphanTasksGauge = Metrics.globalRegistry.gauge("thirdeye_task_orphans",
         new AtomicInteger(0));
     registerMetrics();
   }
@@ -230,7 +230,7 @@ public class TaskManagerImpl implements TaskManager {
             Predicate.LT("lastActive", activeThreshold)
         )
     );
-    orphanTasksCountMetric.set(orphanTasks.size());
+    orphanTasksGauge.set(orphanTasks.size());
     orphanTasks.forEach(task -> updateStatusAndTaskEndTime(
             task.getId(),
             TaskStatus.RUNNING,

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -274,6 +274,7 @@ public class TaskManagerImpl implements TaskManager {
             .register(Metrics.globalRegistry);
       }
     }
+    LOG.info("Registered task database metrics.");
   }
 
   // FIXME CYRIL - this should have as less cache as possible and as precise as possible

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -66,7 +66,6 @@ public class TaskManagerImpl implements TaskManager {
     this.dao = dao;
     orphanTasksGauge = Metrics.globalRegistry.gauge("thirdeye_task_orphans",
         new AtomicInteger(0));
-    registerMetrics();
   }
 
   @Override
@@ -251,7 +250,8 @@ public class TaskManagerImpl implements TaskManager {
         Predicate.EQ("type", type)));
   }
 
-  private void registerMetrics() {
+  @Override
+  public void registerDatabaseMetrics() {
     for (final TaskType type : TaskType.values()) {
       Gauge.builder("thirdeye_task_latency",
               memoizeWithExpiration(() -> getTaskLatency(type, TaskStatus.WAITING, TaskStatus.RUNNING), 30, TimeUnit.SECONDS))

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SchedulerService.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SchedulerService.java
@@ -16,6 +16,7 @@ package ai.startree.thirdeye.scheduler;
 import ai.startree.thirdeye.scheduler.events.HolidayEventsLoaderConfiguration;
 import ai.startree.thirdeye.scheduler.events.HolidayEventsLoaderScheduler;
 import ai.startree.thirdeye.scheduler.taskcleanup.TaskCleanUpConfiguration;
+import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
 import ai.startree.thirdeye.spi.datalayer.bao.TaskManager;
 import ai.startree.thirdeye.worker.task.TaskDriverConfiguration;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -53,7 +54,8 @@ public class SchedulerService implements Managed {
       final HolidayEventsLoaderScheduler holidayEventsLoader,
       final DetectionCronScheduler detectionScheduler,
       final SubscriptionCronScheduler subscriptionScheduler,
-      final TaskManager taskManager) {
+      final TaskManager taskManager,
+      final AlertManager alertManager) {
     this.config = config;
     this.holidayEventsLoaderConfiguration = holidayEventsLoaderConfiguration;
     this.taskDriverConfiguration = taskDriverConfiguration;

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SchedulerService.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SchedulerService.java
@@ -16,7 +16,6 @@ package ai.startree.thirdeye.scheduler;
 import ai.startree.thirdeye.scheduler.events.HolidayEventsLoaderConfiguration;
 import ai.startree.thirdeye.scheduler.events.HolidayEventsLoaderScheduler;
 import ai.startree.thirdeye.scheduler.taskcleanup.TaskCleanUpConfiguration;
-import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
 import ai.startree.thirdeye.spi.datalayer.bao.TaskManager;
 import ai.startree.thirdeye.worker.task.TaskDriverConfiguration;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -54,8 +53,7 @@ public class SchedulerService implements Managed {
       final HolidayEventsLoaderScheduler holidayEventsLoader,
       final DetectionCronScheduler detectionScheduler,
       final SubscriptionCronScheduler subscriptionScheduler,
-      final TaskManager taskManager,
-      final AlertManager alertManager) {
+      final TaskManager taskManager) {
     this.config = config;
     this.holidayEventsLoaderConfiguration = holidayEventsLoaderConfiguration;
     this.taskDriverConfiguration = taskDriverConfiguration;

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServer.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServer.java
@@ -40,7 +40,7 @@ import com.google.inject.Binding;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
-import com.google.inject.spi.DefaultBindingScopingVisitor;
+import com.google.inject.spi.DefaultElementVisitor;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.AuthValueFactoryProvider;
@@ -70,7 +70,10 @@ import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.logback.SentryAppender;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import javax.ws.rs.WebApplicationException;
@@ -248,14 +251,22 @@ public class ThirdEyeServer extends Application<ThirdEyeServerConfiguration> {
   }
 
   private void registerDatabaseMetricsOfAllDaos(final Injector injector) {
-    for(final Map.Entry<Key<?>, Binding<?>> entry : injector.getAllBindings().entrySet()) {
+    final Set<Entry<Key<?>, Binding<?>>> keyToBinding = injector.getAllBindings().entrySet();
+    // both implementation and interface may be listed in keyToBinding - so we deduplicate manually 
+    final Set<Class> loadedClasses = new HashSet<>();
+    for(final Map.Entry<Key<?>, Binding<?>> entry : keyToBinding) {
       final Binding<?> binding = entry.getValue();
-      if (AbstractManager.class.isAssignableFrom(
-          entry.getKey().getTypeLiteral().getRawType())) {
-        binding.acceptScopingVisitor(new DefaultBindingScopingVisitor<Void>() {
-          @Override public Void visitEagerSingleton() {
-            final AbstractManager instance = (AbstractManager) (binding.getProvider().get());
-            instance.registerDatabaseMetrics();
+      if (AbstractManager.class.isAssignableFrom(entry.getKey().getTypeLiteral().getRawType())) {
+        binding.acceptVisitor(new DefaultElementVisitor<AbstractManager<?>>() {
+          @Override
+          public <T> AbstractManager<?> visit(final Binding<T> binding) {
+            final AbstractManager<?> instance = (AbstractManager<?>) binding.getProvider().get();
+            if (!loadedClasses.contains(instance.getClass())) {
+              instance.registerDatabaseMetrics();
+              loadedClasses.add(instance.getClass());
+            } else {
+              System.out.println("look who's here");
+            }
             return null;
           }
         });

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServer.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/ThirdEyeServer.java
@@ -264,8 +264,6 @@ public class ThirdEyeServer extends Application<ThirdEyeServerConfiguration> {
             if (!loadedClasses.contains(instance.getClass())) {
               instance.registerDatabaseMetrics();
               loadedClasses.add(instance.getClass());
-            } else {
-              System.out.println("look who's here");
             }
             return null;
           }

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/AbstractManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/AbstractManager.java
@@ -71,4 +71,12 @@ public interface AbstractManager<E extends AbstractDTO> {
   default long count(final Predicate predicate) {
     throw new UnsupportedOperationException();
   }
+
+  /**
+   * Register metrics that perform regular calls to the persistence database.
+   * These metrics should not be registered by all components of ThirdEye. 
+   * This would result in a linear scaling of database queries when components are scaled linearly. 
+   * It is recommended to only have the scheduler component register such metrics.
+   */
+  void registerDatabaseMetrics();
 }


### PR DESCRIPTION
Some metrics are based on queries run on the MySql instance. 
As of today they are registered when DAO singletons are instantiated. 
This means they are registered for all components of ThirdEye. (coordinator, scheduler, worker).
This causes two issues: 
- it is confusing
  - because there is a cache, the value of the metric may not match between components. The difference can be huge.
  - when writing prometheus queries, one must be wary of not aggregating the same thing twice
- when scaling workers or coordinators, the number of metrics queries scale linearly. It should not.

This PR implements logic to only have the scheduler collect the expensive database-based metrics.

A log is added to make it simple to check if the metrics are registered correctly:
```
INFO  [2024-11-28 16:15:29,616] ai.startree.thirdeye.datalayer.bao.AnomalyManagerImpl: Registered anomaly database metrics.
INFO  [2024-11-28 16:15:29,616] ai.startree.thirdeye.datalayer.bao.TaskManagerImpl: Registered task database metrics.
INFO  [2024-11-28 16:15:29,617] ai.startree.thirdeye.datalayer.bao.RcaInvestigationManagerImpl: Registered RCA investigation database metrics.
INFO  [2024-11-28 16:15:29,617] ai.startree.thirdeye.datalayer.bao.AlertManagerImpl: Registered alert database metrics.
INFO  [2024-11-28 16:15:29,617] ai.startree.thirdeye.datalayer.bao.SubscriptionGroupManagerImpl: Registered subscription group database metrics.
```

these logs should only happen once in the lifecycle of a scheduler, at the start.


Main changes are in `ThirdEyeServer` and `AbstractManager`.
ThirdEyeServer finds instances of AbstractManager and calls registerDatabaseMetrics.