### PR TITLE
[k8s] fix lessOrEqualTo1Cpu when cpu input is of type int

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
+++ b/kubernetes/helm/startree-thirdeye/templates/_helpers.tpl
@@ -138,7 +138,7 @@ The name of the thirdeye scheduler (worker with special detector.yml) headless s
   is less than or equal to 1.0
 */}}
 {{- define "lessOrEqualTo1Cpu" -}}
-{{- $cpu := . | trim -}}
+{{- $cpu := . | toString | trim -}}
 {{- if hasSuffix "m" $cpu -}}
   {{- $millicores := (trimSuffix "m" $cpu) | float64 -}}
   {{- if le $millicores 1000.0 -}}


### PR DESCRIPTION
fix helm failure when requests.cpu is an int. eg `requests.cpu:2`

## testing
```
helm template startree-thirdeye  --set coordinator.resources.requests.cpu=1 --set scheduler.resources.requests.cpu=0.5 --set worker.resources.requests.cpu=2 
```
```
helm template startree-thirdeye  --set coordinator.resources.requests.cpu=100m --set scheduler.resources.requests.cpu=1000m --set worker.resources.requests.cpu=2000m
```