### PR TITLE
fix(ui): TE-2572 fix radio options not showing in anomaly confirmation modal

### DIFF
--- a/thirdeye-ui/src/app/components/anomaly-feedback/anomaly-feedback.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-feedback/anomaly-feedback.component.tsx
@@ -76,7 +76,9 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
             showDialog({
                 type: DialogType.ALERT,
                 contents: t("message.change-confirmation-to", {
-                    value: `"${ALL_OPTIONS_TO_DESCRIPTIONS[newSelectedFeedbackType]}"`,
+                    value: `"${
+                        ALL_OPTIONS_TO_DESCRIPTIONS(t)[newSelectedFeedbackType]
+                    }"`,
                 }),
                 okButtonText: t("label.change"),
                 cancelButtonText: t("label.cancel"),
@@ -179,10 +181,10 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
     }, [anomalyFeedback]);
 
     const shortcutCreateMenuItems = Object.keys(
-        ALL_OPTIONS_TO_DESCRIPTIONS
+        ALL_OPTIONS_TO_DESCRIPTIONS(t)
     ).map((optionKey: string) => ({
         id: optionKey,
-        text: ALL_OPTIONS_TO_DESCRIPTIONS[optionKey],
+        text: ALL_OPTIONS_TO_DESCRIPTIONS(t)[optionKey],
     }));
 
     return (
@@ -199,7 +201,7 @@ export const AnomalyFeedback: FunctionComponent<AnomalyFeedbackProps> = ({
                         }
                     >
                         <Button color="primary" variant="outlined">
-                            {ALL_OPTIONS_WITH_NO_FEEDBACK[currentlySelected]}
+                            {ALL_OPTIONS_WITH_NO_FEEDBACK(t)[currentlySelected]}
                         </Button>
                         <Button
                             color="primary"

--- a/thirdeye-ui/src/app/components/anomaly-feedback/modal/anomaly-feedback-modal.component.tsx
+++ b/thirdeye-ui/src/app/components/anomaly-feedback/modal/anomaly-feedback-modal.component.tsx
@@ -192,8 +192,8 @@ export const AnomalyFeedbackModal: FunctionComponent<AnomalyFeedbackModalProps> 
                   ),
               }
             : showNo
-            ? ALL_OPTIONS_TO_DESCRIPTIONS
-            : ANOMALY_OPTIONS_TO_DESCRIPTIONS;
+            ? ALL_OPTIONS_TO_DESCRIPTIONS(t)
+            : ANOMALY_OPTIONS_TO_DESCRIPTIONS(t);
 
         return (
             <>
@@ -224,9 +224,9 @@ export const AnomalyFeedbackModal: FunctionComponent<AnomalyFeedbackModalProps> 
                                                     control={<Radio />}
                                                     key={k}
                                                     label={
-                                                        ALL_OPTIONS_TO_DESCRIPTIONS[
-                                                            k
-                                                        ]
+                                                        ALL_OPTIONS_TO_DESCRIPTIONS(
+                                                            t
+                                                        )[k]
                                                     }
                                                     value={k}
                                                 />

--- a/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
+++ b/thirdeye-ui/src/app/utils/anomalies/anomalies.util.ts
@@ -393,31 +393,37 @@ export const getShortText = (
     return textToShow;
 };
 
-export const ANOMALY_OPTIONS_TO_DESCRIPTIONS = {
-    [AnomalyFeedbackType.ANOMALY.valueOf()]: i18n.t(
+export const ANOMALY_OPTIONS_TO_DESCRIPTIONS = (
+    translation: TFunction
+): { [key: string]: string } => ({
+    [AnomalyFeedbackType.ANOMALY.valueOf()]: translation(
         "message.yes-this-is-a-valid-anomaly"
     ),
-    [AnomalyFeedbackType.ANOMALY_EXPECTED.valueOf()]: i18n.t(
+    [AnomalyFeedbackType.ANOMALY_EXPECTED.valueOf()]: translation(
         "message.yes-this-anomaly-is-expected"
     ),
-    [AnomalyFeedbackType.ANOMALY_NEW_TREND.valueOf()]: i18n.t(
+    [AnomalyFeedbackType.ANOMALY_NEW_TREND.valueOf()]: translation(
         "message.yes-however-this-may-be-a-new-trend"
     ),
-};
+});
 
-export const ALL_OPTIONS_TO_DESCRIPTIONS = {
-    ...ANOMALY_OPTIONS_TO_DESCRIPTIONS,
-    [AnomalyFeedbackType.NOT_ANOMALY.valueOf()]: i18n.t(
+export const ALL_OPTIONS_TO_DESCRIPTIONS = (
+    translation: TFunction
+): { [key: string]: string } => ({
+    ...ANOMALY_OPTIONS_TO_DESCRIPTIONS(translation),
+    [AnomalyFeedbackType.NOT_ANOMALY.valueOf()]: translation(
         "message.no-this-is-an-anomaly"
     ),
-};
+});
 
-export const ALL_OPTIONS_WITH_NO_FEEDBACK = {
-    ...ALL_OPTIONS_TO_DESCRIPTIONS,
-    [AnomalyFeedbackType.NO_FEEDBACK.valueOf()]: i18n.t(
+export const ALL_OPTIONS_WITH_NO_FEEDBACK = (
+    translation: TFunction
+): { [key: string]: string } => ({
+    ...ALL_OPTIONS_TO_DESCRIPTIONS(translation),
+    [AnomalyFeedbackType.NO_FEEDBACK.valueOf()]: translation(
         "message.is-this-an-anomaly"
     ),
-};
+});
 
 export const handleAlertPropertyChangeGenerator = (
     setAlert: Dispatch<SetStateAction<EditableAlert>>,


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2572

#### Description

When user was clicking on either of the options, "No this is not an anomaly" or "Yes this is an anomaly", in the confirmation modal, radio options text was not visible.
