### PR TITLE
[worker] add thread name to sleep metrics

### DIFF
--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -80,6 +80,7 @@ public class TaskDriverRunnable implements Runnable {
         .register(Metrics.globalRegistry);
     this.taskRunnerWaitIdleTimer = io.micrometer.core.instrument.Timer.builder(
             "thirdeye_task_runner_idle")
+        .tag("thread_name", Thread.currentThread().getName())
         .description(
             "Start: start thread sleep because no tasks were found. End: end of sleep. Mostly used for the sum and the count.")
         .publishPercentiles(METRICS_TIMER_PERCENTILES)


### PR DESCRIPTION
ThirdEye workers have multiple threads.
for the benchmarks, we need to measure idle times per thread.

Add thread as a tag to the idle and sleep metrics. 
The threads are properly named, see https://github.com/startreedata/thirdeye/blob/f9d99e3939afd9bf5e195afc719388b55c0b71bb/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverThreadPoolManager.java#L47
