### PR TITLE
[persistence] Fix flaky NamespaceConfigurationDao tests

### DIFF
--- a/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/dao/TestNamespaceConfigurationDao.java
+++ b/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/dao/TestNamespaceConfigurationDao.java
@@ -33,6 +33,15 @@ public class TestNamespaceConfigurationDao {
 
   private static final String namespace1 = "my-namespace";
   private static final String namespace2 = "my-namespace-2";
+  private static final String namespace3 = "my-namespace-3";
+  private static final String namespace4 = "my-namespace-4";
+  private static final String namespace5 = "my-namespace-5";
+  private static final String namespace6 = "my-namespace-6";
+
+  private Long namespaceConfigurationId1;
+  private Long namespaceConfigurationId2;
+  private Long namespaceConfigurationId3;
+  private Long namespaceConfigurationId4;
 
   private NamespaceConfigurationDao dao;
 
@@ -51,22 +60,34 @@ public class TestNamespaceConfigurationDao {
   public void saveTest() {
     final NamespaceConfigurationDTO dto1 = buildNamespaceConfiguration(namespace1);
     final NamespaceConfigurationDTO dto2 = buildNamespaceConfiguration(namespace2);
+    final NamespaceConfigurationDTO dto3 = buildNamespaceConfiguration(namespace3);
+    final NamespaceConfigurationDTO dto4 = buildNamespaceConfiguration(namespace4);
 
-    final Long namespaceConfigurationId1 = dao.put(dto1);
+    namespaceConfigurationId1 = dao.put(dto1);
     assertThat(namespaceConfigurationId1).isGreaterThan(0L);
     dto1.setId(namespaceConfigurationId1);
 
-    final Long namespaceConfigurationId2 = dao.put(dto2);
+    namespaceConfigurationId2 = dao.put(dto2);
     assertThat(namespaceConfigurationId2).isGreaterThan(0L);
     dto2.setId(namespaceConfigurationId2);
 
+    namespaceConfigurationId3 = dao.put(dto3);
+    assertThat(namespaceConfigurationId3).isGreaterThan(0L);
+    dto3.setId(namespaceConfigurationId3);
+
+    namespaceConfigurationId4 = dao.put(dto4);
+    assertThat(namespaceConfigurationId4).isGreaterThan(0L);
+    dto4.setId(namespaceConfigurationId4);
+
     assertThat(dao.get(namespaceConfigurationId1)).isEqualTo(dto1);
     assertThat(dao.get(namespaceConfigurationId2)).isEqualTo(dto2);
+    assertThat(dao.get(namespaceConfigurationId3)).isEqualTo(dto3);
+    assertThat(dao.get(namespaceConfigurationId4)).isEqualTo(dto4);
   }
 
   @Test(dependsOnMethods = {"saveTest"})
   public void updateTest() {
-    final NamespaceConfigurationDTO dto = dao.getAll().get(0);
+    final NamespaceConfigurationDTO dto = dao.get(namespaceConfigurationId1);
     dto.setVersion(dto.getVersion()+1);
 
     assertThat(dao.update(dto)).isEqualTo(1);
@@ -81,11 +102,11 @@ public class TestNamespaceConfigurationDao {
 
   @Test(dependsOnMethods = {"saveTest"})
   public void updateMultipleTest() {
-    final NamespaceConfigurationDTO dto1 = dao.getAll().get(0);
+    final NamespaceConfigurationDTO dto1 = dao.get(namespaceConfigurationId2);
     dto1.setTimeConfiguration(dto1.getTimeConfiguration()
         .setMinimumOnboardingStartTime(996684800000L));
 
-    final NamespaceConfigurationDTO dto2 = dao.getAll().get(1);
+    final NamespaceConfigurationDTO dto2 = dao.get(namespaceConfigurationId3);
     dto2.setVersion(dto2.getVersion()+1);
 
     assertThat(dao.update(Collections.emptyList())).isEqualTo(0);
@@ -97,18 +118,18 @@ public class TestNamespaceConfigurationDao {
 
   @Test(dependsOnMethods = {"saveTest"})
   public void updatePredicateTest() {
-    final NamespaceConfigurationDTO dto = dao.getAll().get(0);
+    final NamespaceConfigurationDTO dto = dao.get(namespaceConfigurationId4);
     dto.setVersion(dto.getVersion()+1);
 
     assertThat(dao.update(dto, Predicate.EQ("namespace", "some-other-namespace")))
         .isEqualTo(0);
-    assertThat(dao.update(dto, Predicate.EQ("namespace", namespace1)))
+    assertThat(dao.update(dto, Predicate.EQ("namespace", namespace4)))
         .isEqualTo(1);
   }
 
   @Test(dependsOnMethods = {"saveTest"})
   public void countTest() {
-    assertThat(dao.count()).isEqualTo(2);
+    assertThat(dao.count()).isEqualTo(4);
   }
 
   @Test(dependsOnMethods = {"saveTest"})
@@ -119,26 +140,44 @@ public class TestNamespaceConfigurationDao {
         .isEqualTo(1);
     assertThat(dao.count(Predicate.EQ("namespace", namespace2)))
         .isEqualTo(1);
+    assertThat(dao.count(Predicate.EQ("namespace", namespace3)))
+        .isEqualTo(1);
+    assertThat(dao.count(Predicate.EQ("namespace", namespace4)))
+        .isEqualTo(1);
   }
 
-  @Test(dependsOnMethods = {"updateTest"})
+  @Test
   public void deleteTest() {
-    final List<NamespaceConfigurationDTO> tasks = dao.getAll();
-    assertThat(tasks.size()).isGreaterThan(0);
+    final NamespaceConfigurationDTO dto = buildNamespaceConfiguration(null);
+    Long id = dao.put(dto);
+    assertThat(id).isGreaterThan(0L);
+    dto.setId(id);
 
-    final NamespaceConfigurationDTO namespaceConfigToDelete = tasks.get(0);
-    dao.delete(namespaceConfigToDelete.getId());
+    dao.delete(dto.getId());
 
-    assertThat(dao.get(namespaceConfigToDelete.getId())).isNull();
-    assertThat(dao.count()).isEqualTo(tasks.size()-1);
+    assertThat(dao.get(dto.getId())).isNull();
   }
 
   @Test
   public void deleteByPredicateTest() {
-    final NamespaceConfigurationDTO dto = buildNamespaceConfiguration(namespace1);
-    dao.put(dto);
+    final NamespaceConfigurationDTO dto = buildNamespaceConfiguration(namespace5);
+    Long id = dao.put(dto);
+    assertThat(id).isGreaterThan(0L);
+    dto.setId(id);
+
+    final NamespaceConfigurationDTO dto1 = buildNamespaceConfiguration(namespace6);
+    Long id1 = dao.put(dto1);
+    assertThat(id1).isGreaterThan(0L);
+    dto1.setId(id1);
+
+    assertThat(dao.deleteByPredicate(Predicate.EQ("namespace", dto1.namespace())))
+        .isEqualTo(1);
+    assertThat(dao.get(dto1.getId())).isNull();
+    assertThat(dao.get(dto.getId())).isNotNull();
+
     assertThat(dao.deleteByPredicate(Predicate.EQ("namespace", dto.namespace())))
         .isEqualTo(1);
+    assertThat(dao.get(dto1.getId())).isNull();
     assertThat(dao.get(dto.getId())).isNull();
   }
 }


### PR DESCRIPTION
#### Issue(s)

[Time configuration - introduce namespace configuration entity](https://startree.atlassian.net/browse/TE-2447)

#### Description

Test order constraints is not correct in TestNamespaceConfigurationDao and makes test flaky based on the order in which independent tests are run

This PR fixes the tests logic by making sure their affected entities don't coincide such that each independent test can run in any order

#### Testing
- [X] UTs
- [X] Integration Tests

 
