### PR TITLE
[core] fix datasource metric gets broken in case of incorrect datasource configuration

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/cache/DataSourceCache.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/cache/DataSourceCache.java
@@ -86,10 +86,20 @@ public class DataSourceCache {
 
   // TODO CYRIL authz refacto - move this DataSourceCache should not have access to DataSourceManager - update architectureTest
   private Integer getHealthyDatasourceCount() {
-    return Math.toIntExact(dataSourceManager.findAll().stream()
-        .map(this::getDataSource)
-        .filter(this::validateWithTimeout)
-        .count());
+    int healthyDatasourceCount = 0;
+    for (final DataSourceDTO datasourceDto: dataSourceManager.findAll()) {
+      final ThirdEyeDataSource thirdEyeDataSource;
+      try {
+        thirdEyeDataSource = getDataSource(datasourceDto);
+      } catch (final Exception e) {
+        LOG.error("Failed to get data source {}", datasourceDto, e);
+        continue;
+      }
+      if (validateWithTimeout(thirdEyeDataSource)) {
+        healthyDatasourceCount++;
+      }
+    }
+    return healthyDatasourceCount;
   }
 
   private boolean validateWithTimeout(final ThirdEyeDataSource ds) {


### PR DESCRIPTION
getDataSource can throw exceptions
with the previous implementation, any exception was breaking the metric. 

change: catch the exception 