### PR TITLE
[persistence] remove namespace migration logic that could cause oom in edge cases

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
@@ -384,6 +384,14 @@ public class AnomalyManagerImpl extends AbstractManagerImpl<AnomalyDTO>
     return count(finalPredicate);
   }
 
+  @Override
+  public long countWithNamespace(final @NonNull AnomalyFilter filter,
+      final @Nullable String namespace) {
+    // todo authz extremely inefficient because will load anomalies in memory to count them
+    // it is not possible to perform a count directly in the DB until all anomalies are migrated in the index table to ensure they have their namespace value set
+    return filterWithNamespace(filter, namespace).size();
+  }
+
   private Predicate toPredicate(final AnomalyFilter af) {
     final List<Predicate> predicates = new ArrayList<>();
     optional(af.getCreateTimeWindow())

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/AnomalyManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/AnomalyManager.java
@@ -40,11 +40,7 @@ public interface AnomalyManager extends AbstractManager<AnomalyDTO> {
   // internal only - prefer countWithNamespace  
   long count(final @NonNull AnomalyFilter filter);
 
-  default long countWithNamespace(final @NonNull AnomalyFilter filter, final @Nullable String namespace) {
-    // todo authz extremely inefficient because will load anomalies in memory to count them
-    // it is not possible to perform a count directly in the DB until all anomalies are migrated in the index table to ensure they have their namespace value set
-    return filterWithNamespace(filter, namespace).size(); 
-  }
+  long countWithNamespace(final @NonNull AnomalyFilter filter, final @Nullable String namespace);
 
   List<AnomalyDTO> filter(@NonNull AnomalyFilter anomalyFilter);
   


### PR DESCRIPTION
update temporary code paths that could result in OOM when the number of anomalies for many alerts is high and multiple stats call are performed concurrentl (this can happen in the landing page)