### PR TITLE
[persistence] remove exception catch in DatabaseClient

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/DatabaseClient.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/DatabaseClient.java
@@ -52,8 +52,8 @@ public class DatabaseClient {
         .register(Metrics.globalRegistry);
   }
 
-  public <T> T executeTransaction(final DBOperation<T> operation, final T defaultReturn)
-      throws SQLException {
+  public <T> T executeTransaction(final DBOperation<T> operation)
+      throws Exception {
     try (Connection connection = dataSource.getConnection()) {
       try {
         connection.setAutoCommit(false);
@@ -72,7 +72,7 @@ public class DatabaseClient {
             LOG.error("Failed to rollback SQL execution", e);
           }
         }
-        return defaultReturn;
+        throw e;
       }
     }
   }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -124,7 +124,7 @@ public class TaskManagerImpl implements TaskManager {
 
   // TODO CYRIL NOTE - RETRY IS NOT IMPLEMENTED BUT IT SHOULD BE EASY BY ACCEPTING STATUS = FAILED IN THE 2 METHODS BELOW AND PUTTING A LIMIT ON THE VALUE OF VERSION
   @Override
-  public TaskDTO acquireNextTaskToRun(final long workerId) {
+  public TaskDTO acquireNextTaskToRun(final long workerId) throws Exception {
     return dao.acquireNextTaskToRun(workerId);
   }
 

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/NamespaceConfigurationDao.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/NamespaceConfigurationDao.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -103,10 +102,10 @@ public class NamespaceConfigurationDao {
     try {
       final NamespaceConfigurationEntity entity = toEntity(pojo);
       return databaseClient.executeTransaction(
-          (connection) -> databaseOrm.save(entity, connection),
-          null);
-    } catch (JsonProcessingException | SQLException e) {
+          (connection) -> databaseOrm.save(entity, connection));
+    } catch (Exception e) {
       LOG.error(e.getMessage(), e);
+      // TODO cyril design - surface exception to remove error logic in consumers ? 
       return null;
     }
   }
@@ -151,10 +150,10 @@ public class NamespaceConfigurationDao {
     try {
       final NamespaceConfigurationEntity entity = toEntity(pojo);
       return databaseClient.executeTransaction(
-          (connection) -> databaseOrm.update(entity, predicate, connection),
-          0);
-    } catch (JsonProcessingException | SQLException e) {
+          (connection) -> databaseOrm.update(entity, predicate, connection));
+    } catch (Exception e) {
       LOG.error(e.getMessage(), e);
+      // TODO cyril design - surface exception to remove error logic in consumers ?
       return 0;
     }
   }
@@ -163,11 +162,11 @@ public class NamespaceConfigurationDao {
     try {
       final List<NamespaceConfigurationEntity> entities = databaseClient.executeTransaction(
           (connection) -> databaseOrm.findAll(null,
-              null, null, NamespaceConfigurationEntity.class, connection),
-          Collections.emptyList());
+              null, null, NamespaceConfigurationEntity.class, connection));
       return toDto(entities);
-    } catch (final JsonProcessingException | SQLException e) {
+    } catch (final Exception e) {
       LOG.error(e.getMessage(), e);
+      // TODO cyril design - surface exception to remove error logic in consumers ?
       return Collections.emptyList();
     }
   }
@@ -176,11 +175,11 @@ public class NamespaceConfigurationDao {
     try {
       final List<NamespaceConfigurationEntity> entities = databaseClient.executeTransaction(
           (connection) -> databaseOrm.findAll(null,
-              limit, offset, NamespaceConfigurationEntity.class, connection),
-          Collections.emptyList());
+              limit, offset, NamespaceConfigurationEntity.class, connection));
       return toDto(entities);
-    } catch (final JsonProcessingException | SQLException e) {
+    } catch (final Exception e) {
       LOG.error(e.getMessage(), e);
+      // TODO cyril design - surface exception to remove error logic in consumers ?
       return Collections.emptyList();
     }
   }
@@ -188,13 +187,12 @@ public class NamespaceConfigurationDao {
   public NamespaceConfigurationDTO get(final Long id) {
     try {
       final NamespaceConfigurationEntity entity = databaseClient.executeTransaction(
-          (connection) -> databaseOrm.find(id, NamespaceConfigurationEntity.class, connection),
-          null);
+          (connection) -> databaseOrm.find(id, NamespaceConfigurationEntity.class, connection));
       if (entity == null) {
         return null;
       }
       return toDto(entity);
-    } catch (final JsonProcessingException | SQLException e) {
+    } catch (final Exception e) {
       LOG.error(e.getMessage(), e);
       return null;
     }
@@ -221,10 +219,9 @@ public class NamespaceConfigurationDao {
     try {
       final List<NamespaceConfigurationEntity> entities = databaseClient.executeTransaction(
           (connection) -> databaseOrm.findAll(
-              predicate, limit, null, NamespaceConfigurationEntity.class, connection),
-          Collections.emptyList());
+              predicate, limit, null, NamespaceConfigurationEntity.class, connection));
       return toDto(entities);
-    } catch (final JsonProcessingException | SQLException e) {
+    } catch (final Exception e) {
       LOG.error(e.getMessage(), e);
       return Collections.emptyList();
     }
@@ -234,10 +231,10 @@ public class NamespaceConfigurationDao {
     try {
       return databaseClient.executeTransaction(
           (connection) -> databaseOrm.count(null, NamespaceConfigurationEntity.class,
-              connection),
-          0L);
-    } catch (SQLException e) {
+              connection));
+    } catch (Exception e) {
       LOG.error(e.getMessage(), e);
+      // TODO cyril design - surface exception to remove error logic in consumers ?
       return 0;
     }
   }
@@ -246,10 +243,10 @@ public class NamespaceConfigurationDao {
     try {
       return databaseClient.executeTransaction(
           (connection) -> databaseOrm.count(predicate, NamespaceConfigurationEntity.class,
-              connection),
-          0L);
-    } catch (SQLException e) {
+              connection));
+    } catch (Exception e) {
       LOG.error(e.getMessage(), e);
+      // TODO cyril design - surface exception to remove error logic in consumers ?
       return 0;
     }
   }
@@ -266,10 +263,10 @@ public class NamespaceConfigurationDao {
     try {
       return databaseClient.executeTransaction(
           (connection) -> databaseOrm.delete(predicate, NamespaceConfigurationEntity.class,
-              connection),
-          0);
-    } catch (SQLException e) {
+              connection));
+    } catch (Exception e) {
       LOG.error(e.getMessage(), e);
+      // TODO cyril design - surface exception to remove error logic in consumers ?
       return 0;
     }
   }

--- a/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye-persistence/src/test/java/ai/startree/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -91,7 +91,7 @@ public class TestAnomalyTaskManager {
   }
 
   @Test(dependsOnMethods = {"testFindAll"})
-  public void testAcquireTaskToRun() {
+  public void testAcquireTaskToRun() throws Exception {
     CLOCK.tick(1);
     final Long workerId = 1L;
     final TaskDTO taskDTO = taskDAO.findById(anomalyTaskId1);
@@ -104,7 +104,7 @@ public class TestAnomalyTaskManager {
   }
 
   @Test(dependsOnMethods = {"testAcquireTaskToRun"})
-  public void testFindNextTaskToRun() {
+  public void testFindNextTaskToRun() throws Exception {
     final Long workerId = 1L;
     final TaskDTO anomalyTask = taskDAO.acquireNextTaskToRun(workerId);
     assertThat(anomalyTask).isNotNull();

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DatabaseAdminResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/DatabaseAdminResource.java
@@ -29,7 +29,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -57,14 +56,6 @@ public class DatabaseAdminResource {
   public Response getTables(@Parameter(hidden = true) @Auth ThirdEyeServerPrincipal principal)
       throws Exception {
     return Response.ok(databaseAdminService.getTables(principal)).build();
-  }
-
-  @Deprecated // fixme cyril remove this
-  @GET
-  @Path("execute-query")
-  public Response executeQuery(@Parameter(hidden = true) @Auth ThirdEyeServerPrincipal principal,
-      @QueryParam("sql") String sql) throws Exception {
-    return Response.ok(databaseAdminService.executeQuery(principal, sql)).build();
   }
 
   @POST

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DatabaseAdminService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/DatabaseAdminService.java
@@ -13,8 +13,6 @@
  */
 package ai.startree.thirdeye.service;
 
-import static ai.startree.thirdeye.ResourceUtils.resultSetToMap;
-
 import ai.startree.thirdeye.auth.AuthorizationManager;
 import ai.startree.thirdeye.datalayer.DatabaseClient;
 import ai.startree.thirdeye.resources.DatabaseAdminResource;
@@ -24,8 +22,6 @@ import com.google.inject.Singleton;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Map;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,14 +45,6 @@ public class DatabaseAdminService {
   public List<String> getTables(final ThirdEyePrincipal principal) throws SQLException {
     authorizationManager.hasRootAccess(principal);
     return databaseClient.adminGetTables();
-  }
-
-  @NonNull
-  public List<Map<String, Object>> executeQuery(final ThirdEyePrincipal principal, final String sql)
-      throws SQLException {
-    authorizationManager.hasRootAccess(principal);
-    return resultSetToMap(databaseClient.executeTransaction(
-        c -> c.createStatement().executeQuery(sql), null));
   }
 
   public void createAllTables(final ThirdEyePrincipal principal) throws SQLException, IOException {

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/datalayer/bao/TaskManager.java
@@ -42,7 +42,7 @@ public interface TaskManager extends AbstractManager<TaskDTO> {
   @Deprecated // use acquireNextTaskToRun instead
   boolean acquireTaskToRun(TaskDTO taskDTO, final long workerId);
 
-  TaskDTO acquireNextTaskToRun(final long workerId);
+  TaskDTO acquireNextTaskToRun(final long workerId) throws Exception;
 
   List<TaskDTO> findByStatusAndWorkerId(Long workerId, TaskStatus status);
 

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -213,7 +213,6 @@ public class TaskDriverRunnable implements Runnable {
       try {
         nextTask = taskManager.acquireNextTaskToRun(workerId);
       } catch (Exception e) {
-        // FIXME CYRIL acquireNextTaskToRun is not throwing errors up to here - requires redesign of DatabaseClient#executeTransaction
         LOG.error("Failed to fetch a new task to run", e);
         idleTimer().record(() -> sleep(true));
         continue;


### PR DESCRIPTION
See https://startree.atlassian.net/browse/TE-2579

Fix DatabaseClient exception throwing design. DatabaseClient does not catch exception anymore, it's the consumer that is responsible for catching the error. 
From what I saw having the DAOs catching error is still not a good design because they log the errorn, replace with an error values (0, null), and then the consumer still has to perform an argument/state check on the error value. If an error value is encountered, the an exception is thrown but it does not contain the stack of the original error anymore.
This can be taken in another PR. 

Has the effect of fixing the issue of `TaskManager(Impl).acquireNextTaskToRun` not surfacing errors because they were caught by the DatabaseClient, ie it fixes a task scheduler bug.
https://github.com/startreedata/thirdeye/pull/1713/files#diff-d93736e73d043688707a5ad2c487338a9ec51dcf0bed01f6a3d55e7783d17330L216
This bug needs to be fixed for proper benchmarking. 