### PR TITLE
[server] Handle PinotClientException in exception handler

### DIFF
--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/ThirdEyeStatus.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/ThirdEyeStatus.java
@@ -53,6 +53,7 @@ public enum ThirdEyeStatus {
   ERR_TIMEOUT("Operation timed out!"),
   ERR_UNEXPECTED_QUERY_PARAM("Unexpected Query Param. Allowed values: %s"),
   ERR_UNKNOWN("%s"),
+  ERR_EXECUTION_RCA_ALGORITHM("RCA Algorithm Execution Failed. Error: %s"),
   ERR_UNKNOWN_RCA_ALGORITHM("Unknown error running the rca algorithm: %s"),
   ERR_CALCITE_FILTERING("Failed running Calcite filtering query with filter: %s"),
   ERR_INVALID_PARAMS_COMPONENTS("Invalid param components: %s for Class %s"),
@@ -61,6 +62,8 @@ public enum ThirdEyeStatus {
   ERR_NEGATIVE_LIMIT_VALUE("Negative 'limit' value provided."),
   ERR_NEGATIVE_OFFSET_VALUE("Negative 'offset' value provided."),
   ERR_OFFSET_WITHOUT_LIMIT("'offset' value provided without 'limit' value."),
+  ERR_PINOT_QUERY_QUOTA_EXCEEDED("Pinot Query Quota Exceeded. Error: %s. SQL: %s"),
+  ERR_PINOT_QUERY_EXECUTION("Pinot Query Execution Failed. Error: %s. SQL: %s"),
 
   OK("OK"),
   ;


### PR DESCRIPTION
#### Issue(s)

[Surface the pinot quota error properly](https://startree.atlassian.net/browse/TE-2580)

#### Description

Currently, there are several problems in how pinot exceptions are caught and surfaced.
1. Errors thrown by PinotQueryExecutor's [load()](https://github.com/startreedata/thirdeye/blob/302335a30554a628eb1ce5f20d63991d8e71ae07/thirdeye-plugins/thirdeye-pinot/src/main/java/ai/startree/thirdeye/plugins/datasource/pinot/PinotQueryExecutor.java#L216) method are not caught properly in the [caller code](https://github.com/startreedata/thirdeye/blob/302335a30554a628eb1ce5f20d63991d8e71ae07/thirdeye-plugins/thirdeye-pinot/src/main/java/ai/startree/thirdeye/plugins/datasource/pinot/PinotThirdEyeDataSource.java#L161) because any exception thrown in load method of a guava cache is wrapped around by UncheckedExecutionException, which is not being caught here
2. These exceptions are further down the line wrapped around by ExecutionException but they're not being handled properly in [ExceptionHandler for RCA case](https://github.com/startreedata/thirdeye/blob/302335a30554a628eb1ce5f20d63991d8e71ae07/thirdeye-server/src/main/java/ai/startree/thirdeye/core/ExceptionHandler.java#L79)
3. Exceptions thrown by PinotQueryExecutor emit only the sql command in their error message, not the root exception reason.

This results into final exception to be thrown of the form:
```
{
    "code": "ERR_UNKNOWN_RCA_ALGORITHM",
    "msg": "Unknown error running the rca algorithm: java.util.concurrent.ExecutionException: org.apache.pinot.client.PinotClientException: Error when running SQL: ...",
}
```

This PR:
1. Fixes ExceptionHandler for RCA case to catch ExecutionExceptions and further checks if underlying exception is a ThirdEyeException (which is thrown in pinot client). If yes, then it throws that exception with same cause and message, else use a custom cause.
2. Handles UncheckedExecutionException exceptions when PinotQueryExecutor cache get() (underlying load()) is called.
4. Currently, there's no proper way to know error code in resultSetGroup returned by the Pinot client, hence for short term workaround, we have added a substring check for QuotaExceededError error.

Post these fixes, pinot client exceptions are caught and surfaced correctly in following form:
```
{
    "code": "ERR_PINOT_QUERY_EXECUTION",
    "msg": "Pinot Query Execution Failed. Error: org.apache.pinot.client.PinotClientException: Query had processing exceptions: \n[{\"message\":\"null:\\n1 segments unavailable: [pageviews_with_nulls_OFFLINE_20200202_20200730_0]\",\"errorCode\":305}]. SQL: ...",
}
```

#### Testing

- [X] Existing UTs
- [X] Existing Integration tests
- [X] Manual test of `/api/rca/metrics/heatmap` API via swagger

| Heatmap Response Before  | Heatmap Response After |
| ------------- | ------------- |
| [rca-heatmap-before.json](https://github.com/user-attachments/files/18094664/rca-heatmap-before.json)  | [rca-heatmap-after.json](https://github.com/user-attachments/files/18094666/rca-heatmap-after.json) |
