### PR TITLE
[persistence] optimize db metrics caching by scheduling and spreading refresh load

### DIFF
--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/cache/DataSourceCache.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/cache/DataSourceCache.java
@@ -20,9 +20,9 @@ package ai.startree.thirdeye.datasource.cache;
 
 import static ai.startree.thirdeye.spi.Constants.METRICS_CACHE_TIMEOUT;
 import static ai.startree.thirdeye.spi.util.ExecutorUtils.threadsNamed;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.scheduledRefreshSupplier;
 import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static java.util.Collections.emptyList;
 
 import ai.startree.thirdeye.datasource.DataSourcesLoader;
@@ -78,7 +78,7 @@ public class DataSourceCache {
     this.dataSourcesLoader = dataSourcesLoader;
 
     Gauge.builder("thirdeye_healthy_datasources",
-            memoizeWithExpiration(this::getHealthyDatasourceCount, METRICS_CACHE_TIMEOUT))
+            scheduledRefreshSupplier(this::getHealthyDatasourceCount, METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
     Metrics.gaugeMapSize("thirdeye_cached_datasources", emptyList(), cache);
   }

--- a/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/cache/DataSourceCache.java
+++ b/thirdeye-core/src/main/java/ai/startree/thirdeye/datasource/cache/DataSourceCache.java
@@ -78,8 +78,7 @@ public class DataSourceCache {
     this.dataSourcesLoader = dataSourcesLoader;
 
     Gauge.builder("thirdeye_healthy_datasources",
-            memoizeWithExpiration(this::getHealthyDatasourceCount, METRICS_CACHE_TIMEOUT.toMinutes(),
-                TimeUnit.MINUTES))
+            memoizeWithExpiration(this::getHealthyDatasourceCount, METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
     Metrics.gaugeMapSize("thirdeye_cached_datasources", emptyList(), cache);
   }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AlertManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AlertManagerImpl.java
@@ -13,7 +13,7 @@
  */
 package ai.startree.thirdeye.datalayer.bao;
 
-import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.scheduledRefreshSupplier;
 
 import ai.startree.thirdeye.datalayer.DatabaseClient;
 import ai.startree.thirdeye.datalayer.dao.GenericPojoDao;
@@ -26,9 +26,9 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,10 +77,10 @@ public class AlertManagerImpl extends AbstractManagerImpl<AlertDTO> implements
   @Override
   public void registerDatabaseMetrics() {
     Gauge.builder("thirdeye_active_alerts",
-            memoizeWithExpiration(this::countActive, 1, TimeUnit.MINUTES))
+            scheduledRefreshSupplier(this::countActive, Duration.ofMinutes(1)))
         .register(Metrics.globalRegistry);
     Gauge.builder("thirdeye_active_timeseries",
-            memoizeWithExpiration(this::countActiveTimeseries, 1, TimeUnit.MINUTES))
+            scheduledRefreshSupplier(this::countActiveTimeseries, Duration.ofMinutes(1)))
         .register(Metrics.globalRegistry);
     LOG.info("Registered alert database metrics.");
   }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
@@ -202,18 +202,14 @@ public class AnomalyManagerImpl extends AbstractManagerImpl<AnomalyDTO>
   @Override
   public void registerDatabaseMetrics() {
     Gauge.builder("thirdeye_anomalies",
-            memoizeWithExpiration(() -> count(NOT_CHILD_NOT_IGNORED_FILTER),
-                METRICS_CACHE_TIMEOUT.toMinutes(),
-                TimeUnit.MINUTES))
+            memoizeWithExpiration(() -> count(NOT_CHILD_NOT_IGNORED_FILTER), METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
     Gauge.builder("thirdeye_anomaly_feedbacks",
-            memoizeWithExpiration(() -> count(HAS_FEEDBACK_FILTER), METRICS_CACHE_TIMEOUT.toMinutes(),
-                TimeUnit.MINUTES))
+            memoizeWithExpiration(() -> count(HAS_FEEDBACK_FILTER), METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
 
     final Supplier<ConfusionMatrix> cachedConfusionMatrix = memoizeWithExpiration(
-        this::computeConfusionMatrixForAnomalies, METRICS_CACHE_TIMEOUT.toMinutes(),
-        TimeUnit.MINUTES);
+        this::computeConfusionMatrixForAnomalies, METRICS_CACHE_TIMEOUT);
     Gauge.builder("thirdeye_anomaly_precision",
             () -> cachedConfusionMatrix.get().getPrecision())
         .register(Metrics.globalRegistry);

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/AnomalyManagerImpl.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.datalayer.bao;
 
 import static ai.startree.thirdeye.spi.Constants.METRICS_CACHE_TIMEOUT;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.scheduledRefreshSupplier;
 import static ai.startree.thirdeye.spi.util.SpiUtils.optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
@@ -202,13 +203,13 @@ public class AnomalyManagerImpl extends AbstractManagerImpl<AnomalyDTO>
   @Override
   public void registerDatabaseMetrics() {
     Gauge.builder("thirdeye_anomalies",
-            memoizeWithExpiration(() -> count(NOT_CHILD_NOT_IGNORED_FILTER), METRICS_CACHE_TIMEOUT))
+            scheduledRefreshSupplier(() -> count(NOT_CHILD_NOT_IGNORED_FILTER), METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
     Gauge.builder("thirdeye_anomaly_feedbacks",
-            memoizeWithExpiration(() -> count(HAS_FEEDBACK_FILTER), METRICS_CACHE_TIMEOUT))
+            scheduledRefreshSupplier(() -> count(HAS_FEEDBACK_FILTER), METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
 
-    final Supplier<ConfusionMatrix> cachedConfusionMatrix = memoizeWithExpiration(
+    final Supplier<ConfusionMatrix> cachedConfusionMatrix = scheduledRefreshSupplier(
         this::computeConfusionMatrixForAnomalies, METRICS_CACHE_TIMEOUT);
     Gauge.builder("thirdeye_anomaly_precision",
             () -> cachedConfusionMatrix.get().getPrecision())

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/RcaInvestigationManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/RcaInvestigationManagerImpl.java
@@ -14,7 +14,7 @@
 package ai.startree.thirdeye.datalayer.bao;
 
 import static ai.startree.thirdeye.spi.Constants.METRICS_CACHE_TIMEOUT;
-import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.scheduledRefreshSupplier;
 
 import ai.startree.thirdeye.datalayer.dao.GenericPojoDao;
 import ai.startree.thirdeye.spi.datalayer.Predicate;
@@ -75,7 +75,7 @@ public class RcaInvestigationManagerImpl extends AbstractManagerImpl<RcaInvestig
   @Override
   public void registerDatabaseMetrics() {
     Gauge.builder("thirdeye_rca_investigations",
-            memoizeWithExpiration(this::count, METRICS_CACHE_TIMEOUT))
+            scheduledRefreshSupplier(this::count, METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
     LOG.info("Registered RCA investigation database metrics.");
   }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/RcaInvestigationManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/RcaInvestigationManagerImpl.java
@@ -25,7 +25,6 @@ import com.google.inject.Singleton;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +75,7 @@ public class RcaInvestigationManagerImpl extends AbstractManagerImpl<RcaInvestig
   @Override
   public void registerDatabaseMetrics() {
     Gauge.builder("thirdeye_rca_investigations",
-            memoizeWithExpiration(this::count, METRICS_CACHE_TIMEOUT.toMinutes(), TimeUnit.MINUTES))
+            memoizeWithExpiration(this::count, METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
     LOG.info("Registered RCA investigation database metrics.");
   }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/SubscriptionGroupManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/SubscriptionGroupManagerImpl.java
@@ -14,6 +14,7 @@
 package ai.startree.thirdeye.datalayer.bao;
 
 import static ai.startree.thirdeye.spi.Constants.METRICS_CACHE_TIMEOUT;
+import static ai.startree.thirdeye.spi.util.MetricsUtils.scheduledRefreshSupplier;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 
 import ai.startree.thirdeye.datalayer.dao.GenericPojoDao;
@@ -49,7 +50,7 @@ public class SubscriptionGroupManagerImpl extends
         .reduce(0, Integer::sum);
 
     Gauge.builder("thirdeye_notification_flows",
-            memoizeWithExpiration(notificationFlowsFun, METRICS_CACHE_TIMEOUT))
+            scheduledRefreshSupplier(notificationFlowsFun, METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
 
     LOG.info("Registered subscription group database metrics.");

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/SubscriptionGroupManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/SubscriptionGroupManagerImpl.java
@@ -24,7 +24,6 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +49,7 @@ public class SubscriptionGroupManagerImpl extends
         .reduce(0, Integer::sum);
 
     Gauge.builder("thirdeye_notification_flows",
-            memoizeWithExpiration(notificationFlowsFun, METRICS_CACHE_TIMEOUT.toMinutes(),
-                TimeUnit.MINUTES))
+            memoizeWithExpiration(notificationFlowsFun, METRICS_CACHE_TIMEOUT))
         .register(Metrics.globalRegistry);
 
     LOG.info("Registered subscription group database metrics.");

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/Constants.java
@@ -129,15 +129,6 @@ public interface Constants {
     DATASETS
   }
 
-  enum CompareMode {
-    WoW, Wo2W, Wo3W, Wo4W
-  }
-
-  enum MonitorType {
-    UPDATE,
-    EXPIRE
-  }
-
   Duration METRICS_CACHE_TIMEOUT = Duration.ofMinutes(10);
   double[] METRICS_TIMER_PERCENTILES = {0.5, 0.75, 0.90, 0.95, 0.98, 0.99, 0.999};
   

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
@@ -17,6 +17,7 @@ import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -42,6 +43,10 @@ public class MetricsUtils {
       .newScheduledThreadPool(3, new ThreadFactoryBuilder()
           .setNameFormat("scheduled-refresh-metrics-%d")
           .build());
+
+  static {
+    ExecutorServiceMetrics.monitor(Metrics.globalRegistry, SCHEDULED_SUPPLIERS_EXECUTOR_SERVICE, "scheduled-refresh-metrics");
+  }
   
   public final static String NAMESPACE_TAG = "thirdeye_workspace";
   public final static String NULL_NAMESPACE_TAG_VALUE = "__null__";

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/util/MetricsUtils.java
@@ -13,18 +13,36 @@
  */
 package ai.startree.thirdeye.spi.util;
 
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for micrometer metrics.
  */
 public class MetricsUtils {
 
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsUtils.class);
+  
+  // the number 3 is not optimized - we just know 1 is not optimal - some queries performed by scheduled suppliers can take time   
+  private static final ScheduledExecutorService SCHEDULED_SUPPLIERS_EXECUTOR_SERVICE = Executors
+      .newScheduledThreadPool(3, new ThreadFactoryBuilder()
+          .setNameFormat("scheduled-refresh-metrics-%d")
+          .build());
+  
   public final static String NAMESPACE_TAG = "thirdeye_workspace";
   public final static String NULL_NAMESPACE_TAG_VALUE = "__null__";
 
@@ -59,5 +77,34 @@ public class MetricsUtils {
 
   public static @NonNull String namespaceTagValueOf(@Nullable String namespace) {
     return Optional.ofNullable(namespace).orElse(NULL_NAMESPACE_TAG_VALUE);
+  }
+  
+  public static <T extends @Nullable Object> Supplier<T> scheduledRefreshSupplier(
+      final @NonNull Supplier<T> delegate, final @NonNull Duration period) {
+    final AtomicReference<T> value = new AtomicReference<>();
+    final Runnable toSchedule = () -> {
+      // catch all exceptions to prevent unscheduling 
+      try {
+        final T currentValue = value.get();
+        final T newValue = delegate.get();
+        value.compareAndSet(currentValue, newValue);
+      } catch (Exception e) {
+        LOG.error("Failed to execute scheduled supplier.", e);
+      }
+    };
+    // add random delay to spread the load of the scheduled suppliers
+    final long periodInMillis = period.toMillis();
+    final long randomDelay = ThreadLocalRandom.current().nextLong(0, periodInMillis);
+    SCHEDULED_SUPPLIERS_EXECUTOR_SERVICE.scheduleAtFixedRate(toSchedule,
+        randomDelay,
+        periodInMillis, 
+        TimeUnit.MILLISECONDS);
+    
+    return () -> {
+      if (value.get() == null) {
+          toSchedule.run();
+      }
+      return value.get();
+    };
   }
 }


### PR DESCRIPTION
some metrics are expensive to compute
with `memoizeWithExpiration`, the computation is performed when the prometheus endpoint is hit.
if there are many metrics supplier that expired at the same time (which is very likely), the computation is triggered for all these metrics at the same time. This is stressing the db and also result in prometheus parse timeout.  

This PR introduce a helper to schedule the refresh of a metric instead of waiting for the prometheus hit. Some random delay is added to spread the request load (the spread may not be optimal but it's ok to begin with)  

Let me know what you think. 
