### PR TITLE
[persistence] optimize first heartbeat

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/TaskManagerImpl.java
@@ -129,6 +129,7 @@ public class TaskManagerImpl implements TaskManager {
     return dao.acquireNextTaskToRun(workerId);
   }
 
+  @Deprecated
   @Override
   public TaskDTO findNextTaskToRun() {
     final String queryClause = """
@@ -147,6 +148,7 @@ public class TaskManagerImpl implements TaskManager {
    * This method has side effects on the task DTO, even if the acquisition attempt fails.
    * Re-fetch the taskDto if you need to ensure consistency with the persistence layer.
    */
+  @Deprecated
   @Override
   public boolean acquireTaskToRun(final TaskDTO task, final long workerId) {
     task.setStatus(TaskStatus.RUNNING);
@@ -154,6 +156,7 @@ public class TaskManagerImpl implements TaskManager {
     task.setStartTime(System.currentTimeMillis());
     final int currentVersion = task.getVersion();
     task.setVersion(currentVersion + 1);
+    task.setLastActive(new Timestamp(System.currentTimeMillis()));
     final Predicate predicate = Predicate.AND(
         Predicate.EQ("version", currentVersion),
         Predicate.EQ("status", TaskStatus.WAITING.toString())

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
@@ -309,6 +309,7 @@ public class TaskDao {
               toUpdate.setWorkerId(workerId);
               toUpdate.setStartTime(System.currentTimeMillis());
               toUpdate.setVersion(toUpdate.getVersion() + 1);
+              toUpdate.setLastActive(new Timestamp(System.currentTimeMillis()));
               final int success = databaseOrm.update(toEntity(toUpdate), null, connection);
               if (success == 1) {
                 return toUpdate;

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -114,7 +114,8 @@ public class TaskDriverRunnable implements Runnable {
           .scheduleAtFixedRate(() -> taskExecutionHeartbeat(taskDTO),
               // a heartbeat is recorded at the same time the task is acquired 
               // assuming runTask is run just after the task is acquired 
-              // we can run the next heartbeat at the next heartbeat interval. Taking 1 millisecond of margin just in case  
+              // we can run the first next heartbeat with a delay of heartbeat interval. 
+              // Taking 1 millisecond of margin just in case to account for the delay between the task acquisition and the start of this schedule  
               config.getHeartbeatInterval().toMillis() - 1,
               config.getHeartbeatInterval().toMillis(),
               TimeUnit.MILLISECONDS);

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/TaskDriverRunnable.java
@@ -112,7 +112,10 @@ public class TaskDriverRunnable implements Runnable {
     if (config.isRandomWorkerIdEnabled()) {
       heartbeat = taskDriverThreadPoolManager.getHeartbeatExecutorService()
           .scheduleAtFixedRate(() -> taskExecutionHeartbeat(taskDTO),
-              0,
+              // a heartbeat is recorded at the same time the task is acquired 
+              // assuming runTask is run just after the task is acquired 
+              // we can run the next heartbeat at the next heartbeat interval. Taking 1 millisecond of margin just in case  
+              config.getHeartbeatInterval().toMillis() - 1,
               config.getHeartbeatInterval().toMillis(),
               TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
See https://startree.atlassian.net/browse/TE-2586

We can skip the first heartbeat by setting the `lastActive` value at acquisition directly. 
this saves 2 queries for all task that run faster than the heartbeat frequency. 

For most detection, this means the number of queries per task is reduced by 2.
At high scale this matters. The heartbeat queries take locks.


Note:
the heartbeat logic is still bad because it has a concurrency issue but this will be taken in another PR. See https://startree.atlassian.net/browse/TE-2578