### PR TITLE
Add Jacoco Code Coverage support

### DIFF
--- a/jacoco-code-coverage/pom.xml
+++ b/jacoco-code-coverage/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2024 StarTree Inc
+
+    Licensed under the StarTree Community License (the "License"); you may not use
+    this file except in compliance with the License. You may obtain a copy of the
+    License at http://www.startree.ai/legal/startree-community-license
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+    either express or implied.
+    See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.startree.thirdeye</groupId>
+    <artifactId>thirdeye</artifactId>
+    <version>1.398.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jacoco-code-coverage</artifactId>
+
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-dataframe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-detectionpipeline</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-persistence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-scheduler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-worker</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>ai.startree.thirdeye</groupId>
+      <artifactId>thirdeye-integration-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-pinot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-detectors</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-oauth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-notification-email</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-contributors-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-bootstrap-open-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-enumerators</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.startree.thirdeye.plugins</groupId>
+      <artifactId>thirdeye-postprocessors</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <configuration>
+              <dataFileIncludes>
+                <dataFileInclude>**/jacoco.exec</dataFileInclude>
+              </dataFileIncludes>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate
+              </outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <module>pinot-test-container</module>
     <module>thirdeye-integration-tests</module>
     <module>thirdeye-benchmarks</module>
+    <module>jacoco-code-coverage</module>
   </modules>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,6 @@
     <hsqldb.version>2.7.1</hsqldb.version>
     <!-- should match dropwizard version - except for security issues -->
     <jackson.version>2.18.1</jackson.version>
-    <!-- Skip Jacoco by default -->
-    <jacoco.skip>true</jacoco.skip>
     <jodatime.version>2.12.7</jodatime.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <mockito.version>5.12.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
     <hsqldb.version>2.7.1</hsqldb.version>
     <!-- should match dropwizard version - except for security issues -->
     <jackson.version>2.18.1</jackson.version>
+    <!-- Skip Jacoco by default -->
+    <jacoco.skip>true</jacoco.skip>
     <jodatime.version>2.12.7</jodatime.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <mockito.version>5.12.0</mockito.version>
@@ -173,6 +175,23 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <!-- Sets a property to be re-used in the maven-surefire-plugin JVM argument line -->
+              <propertyName>surefireArgLine</propertyName>
+              <destFile>${project.build.directory}/jacoco.exec</destFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -264,13 +283,17 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.11</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M1</version>
           <configuration>
             <argLine>
-              -javaagent:"${settings.localRepository}"/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
-            </argLine>
+              -javaagent:"${settings.localRepository}"/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar ${surefireArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED            </argLine>
             <threadCount>1</threadCount>
             <systemPropertyVariables>
               <!-- using a single configuration file for test logging

--- a/thirdeye-integration-tests/pom.xml
+++ b/thirdeye-integration-tests/pom.xml
@@ -224,13 +224,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>skip-integration-tests</id>
-      <properties>
-        <skipTests>true</skipTests>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/thirdeye-integration-tests/pom.xml
+++ b/thirdeye-integration-tests/pom.xml
@@ -224,4 +224,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>skip-integration-tests</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### Issue(s)

[[BE] Apps Team Testing & Secure CI Update - V1 (Manual)](https://startree.atlassian.net/browse/AI-18)

### Description

This PR adds basic jacoco code coverage local setup

### How to test
1. `./mvnw clean verify`
2. Check aggregate coverage report in 
```jacoco-code-coverage/target/site/jacoco-aggregate/index.html```

![Screenshot 2024-12-16 at 8 57 03 PM](https://github.com/user-attachments/assets/6b5f5654-4c62-421d-b734-16c79d741cc7)

Also verified that maven release doesn't break by a local run
```
./mvnw clean -B -DskipTests -Darguments=-DskipTests release:clean initialize release:prepare -U
```
Output:
[thirdeye-release-logs.txt](https://github.com/user-attachments/files/18151998/thirdeye-release-logs.txt)








