### PR TITLE
fix(ui): TE-2594 do not allow negative value for time period compare in anomaly view

### DIFF
--- a/thirdeye-ui/src/app/components/time-range/past-duration-picker/past-duration-picker.component.tsx
+++ b/thirdeye-ui/src/app/components/time-range/past-duration-picker/past-duration-picker.component.tsx
@@ -84,6 +84,9 @@ export const PastDurationPicker: FunctionComponent<PastDurationPickerProps> = ({
             {!!children && <Grid item>{children}</Grid>}
             <Grid item>
                 <TextField
+                    inputProps={{
+                        min: 1,
+                    }}
                     size="small"
                     type="number"
                     value={offsetValue}


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2594

#### Description

Users were able to add negative value for time period to compare in anomaly view page, which was crashing the app.
Added a check so that only positive values are allowed
