### PR TITLE
[server] Make AuthorizationManager class a Singleton

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/auth/AuthorizationManager.java
@@ -53,6 +53,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
@@ -75,6 +76,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
 public class AuthorizationManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuthorizationManager.class);


### PR DESCRIPTION
#### Issue(s)

[Make AuthorizationManager a Singleton to improve memory footprint](https://startree.atlassian.net/browse/TE-2607)

#### Description

Ideally AuthorizationManager should be a singleton but currently that is not enforced
which results into higher memory footprint and instance duplication

#### Testing
1. Run local thirdeye debug server
2. Find PID of running server -> `ps aux | grep java`
3. Run `jmap -histo <PID> | grep ai.startree.thirdeye.auth.AuthorizationManager`

| Before  | After |
| ------------- | ------------- |
| [before-jmap.txt](https://github.com/user-attachments/files/18196286/before-jmap.txt)  | [after-jmap.txt](https://github.com/user-attachments/files/18196287/after-jmap.txt) |

**How to interpret output:**

Column 1: Rank (Index) -> The rank of the class in terms of the number of instances
Column 2: Number of Instances currently in the heap
Column 3: Total Bytes -> The total amount of memory (in bytes) consumed by all instances of this class
Column 4: Class Name

- AuthorizationManager$2, AuthorizationManager$3, etc., refer to anonymous or non-static inner classes of AuthorizationManager

- AuthorizationManager$$FastClassByGuice$$2538f97 and AuthorizationManager$$Lambda/... are generated by Guice or the JVM for proxying or lambda-related functionality. 

**Main points to observe:**
1. AuthorizationManager -> Number of instances have reduced from 23 to just 1, indicating that it's behaving as a singleton
2. Total memory footprint has reduced significantly of all rows combined