### PR TITLE
[persistence] optimize task acquisition query

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/dao/TaskDao.java
@@ -57,7 +57,8 @@ public class TaskDao {
   // it is important to enforce in-order execution for tasks referencing the same entity - this condition may be relaxed later on
   // for the moment this means we need AND ref_id not in (select ref_id from task_entity where status = 'RUNNING') + ORDER BY id ASC
   private static final String SELECT_AND_LOCK_NEXT_TASK_QUERY = """
-      select * from task_entity
+      SELECT *
+      FROM task_entity FORCE INDEX (task_status_idx)
       WHERE status = 'WAITING'
       AND ref_id not in (select ref_id from task_entity where status = 'RUNNING')
       ORDER BY id ASC


### PR DESCRIPTION
Add `FORCE INDEX (task_status_idx)`
to force the usage of the index primary key in the `SORT BY id LIMIT 1` operation.
Without this hint, the engine decides to sort in memory instead of using the index structure, which is ok when the number of WAITING tasks is small but gets more expensive when the number of WAITING tasks is big.
Overhead when the waiting tasks is small is fine.

Measurements on a stressed instance with 7k tasks with `status = 'WAITING'`: 
```
mysql> select *  from task_entity WHERE status = 'WAITING'  AND ref_id not in (select ref_id from task_entity where status = 'RUNNING') ORDER BY id ASC LIMIT 1 FOR UPDATE SKIP LOCKED;
+---------+----------------+---------+-----------+------------+----------+--------+-----------+---------------------+---------------------+---------+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-----------+
| id      | name           | status  | type      | start_time | end_time | job_id | worker_id | create_time         | update_time         | version | last_active | json_val                                                                                                                                                                                                                           | ref_id | namespace |
+---------+----------------+---------+-----------+------------+----------+--------+-----------+---------------------+---------------------+---------+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-----------+
| 2473958 | DETECTION_5476 | WAITING | DETECTION |          0 |        0 |      0 |         0 | 2024-12-20 09:07:09 | 2024-12-20 09:07:09 |       1 | NULL        | {"version":0,"auth":{"namespace":null},"taskType":"DETECTION","jobName":"DETECTION_5476","status":"WAITING","startTime":0,"endTime":0,"taskInfo":"{\"configId\":5476,\"start\":1734676380000,\"end\":1734685620000}","refId":5476} |   5476 | NULL      |
+---------+----------------+---------+-----------+------------+----------+--------+-----------+---------------------+---------------------+---------+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-----------+
1 row in set (32.50 sec)

mysql> select *  from task_entity FORCE INDEX (task_status_idx) WHERE status = 'WAITING'  AND ref_id not in (select ref_id from task_entity where status = 'RUNNING') ORDER BY id ASC LIMIT 1 FOR UPDATE SKIP LOCKED;
+---------+----------------+---------+-----------+------------+----------+--------+-----------+---------------------+---------------------+---------+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-----------+
| id      | name           | status  | type      | start_time | end_time | job_id | worker_id | create_time         | update_time         | version | last_active | json_val                                                                                                                                                                                                                           | ref_id | namespace |
+---------+----------------+---------+-----------+------------+----------+--------+-----------+---------------------+---------------------+---------+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-----------+
| 2473958 | DETECTION_5476 | WAITING | DETECTION |          0 |        0 |      0 |         0 | 2024-12-20 09:07:09 | 2024-12-20 09:07:09 |       1 | NULL        | {"version":0,"auth":{"namespace":null},"taskType":"DETECTION","jobName":"DETECTION_5476","status":"WAITING","startTime":0,"endTime":0,"taskInfo":"{\"configId\":5476,\"start\":1734676380000,\"end\":1734685620000}","refId":5476} |   5476 | NULL      |
+---------+----------------+---------+-----------+------------+----------+--------+-----------+---------------------+---------------------+---------+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-----------+
1 row in set (0.00 sec)
```

--> 30 seconds to 0.

Will add more info in the internal doc
Refs:
- https://stackoverflow.com/questions/49815703/what-is-the-default-order-by-for-a-mysql-innodb-query-that-omits-the-order-by
- https://stackoverflow.com/questions/48154625/should-i-add-id-primary-key-to-composite-index-of-a-table
- https://dev.mysql.com/doc/refman/8.4/en/index-hints.html