### PR TITLE
chore(ui): TE - Update pinot version to 1.2.0

### DIFF
--- a/pinot-test-container/src/main/java/org/apache/pinot/testcontainer/PinotContainer.java
+++ b/pinot-test-container/src/main/java/org/apache/pinot/testcontainer/PinotContainer.java
@@ -61,7 +61,7 @@ public class PinotContainer extends GenericContainer<PinotContainer> {
     
     // if the test does not run for every supported Pinot version, use this version
     public static PinotVersion recommendedVersion() {
-      return v1_1_0;
+      return v1_2_0;
     }
   }
   

--- a/scripts/load-datasets.sh
+++ b/scripts/load-datasets.sh
@@ -16,7 +16,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TE_REPO="${SCRIPT_DIR}/.."
 if [ -z "${PINOT_VERSION}" ]; then
-  PINOT_VERSION=1.1.0
+  PINOT_VERSION=1.2.0
 fi
 if [ -z "${CONTROLLER_PROTOCOL}" ]; then
   CONTROLLER_PROTOCOL=http

--- a/scripts/start-pinot.sh
+++ b/scripts/start-pinot.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_DIR="${SCRIPT_DIR}/.."
 
 if [ -z "${PINOT_VERSION}" ]; then
-  PINOT_VERSION=1.1.0
+  PINOT_VERSION=1.2.0
 fi
 
 export PINOT_INSTALL_TMP_DIR="${REPO_DIR}/tmp/pinot-bin"

--- a/thirdeye-ui/src/test/e2e/helper-scripts/docker-compose.yaml
+++ b/thirdeye-ui/src/test/e2e/helper-scripts/docker-compose.yaml
@@ -16,7 +16,7 @@ version: "3"
 
 services:
     pinot:
-        image: apachepinot/pinot:1.1.0
+        image: apachepinot/pinot:1.2.0
         command: QuickStart -type batch
         ports:
             - "2123:2123"

--- a/thirdeye-ui/src/test/e2e/helper-scripts/launch_fresh_be_with_current_fe.py
+++ b/thirdeye-ui/src/test/e2e/helper-scripts/launch_fresh_be_with_current_fe.py
@@ -27,8 +27,8 @@ from retry.api import retry_call
 from setup_local.launch_backend import setup_and_launch_thirdeye_backend
 from setup_local.launch_frontend import launch_thirdeye_frontend
 
-PINOT = 'apachepinot/pinot:1.1.0'
-PINOT_ARM64 = 'apachepinot/pinot:1.1.0'
+PINOT = 'apachepinot/pinot:1.2.0'
+PINOT_ARM64 = 'apachepinot/pinot:1.2.0'
 TE_UI_DIR = 'thirdeye-ui'
 
 args_parser = argparse.ArgumentParser()


### PR DESCRIPTION
#### Issue(s)

[Update Pinot Version to 1.2.0](https://startree.atlassian.net/browse/TE-2614)

#### Description

Pinot 1.1.0 is not available anymore on: 
https://downloads.apache.org/pinot/

#### Testing

- [X] UTs
- [X] Integration Tests
- [X] Local Running Server + UI
