### PR TITLE
fix(ui): TE-2617 fix evaluate API error in create alert flow on date range change

### DIFF
--- a/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-easy-page/alerts-create-easy-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-create-page/alerts-create-easy-page/alerts-create-easy-page.component.tsx
@@ -100,6 +100,7 @@ import { getAlertsAllPath } from "../../../utils/routes/routes.util";
 import { AlertCreatedGuidedPageOutletContext } from "../../alerts-create-guided-page/alerts-create-guided-page.interfaces";
 import { SETUP_DETAILS_TEST_IDS } from "../../alerts-create-guided-page/setup-details/setup-details-page.interface";
 import { easyAlertStyles } from "./alerts-create-easy-page.styles";
+import { generateInputFieldConfigsForAlertTemplate } from "../../../components/alert-wizard-v3/threshold-setup/threshold-setup.utils";
 
 const PROPERTIES_TO_COPY = [
     "dataSource",
@@ -644,7 +645,29 @@ export const AlertsCreateEasyPage: FunctionComponent = () => {
     ): void => {
         const copiedAlert = { ...alertConfigForPreview, ...(alert ?? {}) };
         delete copiedAlert.id;
-        getEvaluation(createAlertEvaluation(copiedAlert, start, end));
+        if (selectedAlertTemplate && algorithmOption) {
+            const requiredProperties =
+                generateInputFieldConfigsForAlertTemplate(
+                    selectedAlertTemplate
+                );
+            const requiredPropertiesName = requiredProperties.map(
+                (requiredProperty) => requiredProperty.templatePropertyName
+            );
+            const alertProperties = alert?.templateProperties;
+            if (alertProperties) {
+                if (
+                    requiredPropertiesName.every(
+                        (requiredProperty) => alertProperties[requiredProperty]
+                    )
+                ) {
+                    getEvaluation(
+                        createAlertEvaluation(copiedAlert, start, end)
+                    );
+                }
+            }
+        } else {
+            getEvaluation(createAlertEvaluation(copiedAlert, start, end));
+        }
     };
     // Update the preview config if selections change
     useEffect(() => {
@@ -1891,7 +1914,8 @@ export const AlertsCreateEasyPage: FunctionComponent = () => {
                                                                                             ) => {
                                                                                                 fetchAlertEvaluation(
                                                                                                     newStart,
-                                                                                                    newEnd
+                                                                                                    newEnd,
+                                                                                                    alert
                                                                                                 );
                                                                                             }}
                                                                                         />


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2617

#### Description

In alert create flow, on updating date range, evaluate call was not taking template properties in account. Fixed in this PR
