### PR TITLE
[server] add suspiciousDatasetStartTime to insights api when start time is negative

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/alert/AlertInsightsProvider.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/alert/AlertInsightsProvider.java
@@ -195,7 +195,15 @@ public class AlertInsightsProvider {
               datasetConfigDTO.getDataset())));
       return;
     }
-    insights.setDatasetStartTime(datasetStartTime);
+    if (datasetStartTime > 0) {
+      insights.setDatasetStartTime(datasetStartTime);
+    } else {
+      LOG.warn(
+          "Dataset minTime is negative: {}. Most likely a data issue in the dataset. Replacing minTime by 0.",
+          datasetStartTime);
+      insights.setDatasetStartTime(0L);
+      insights.setSuspiciousDatasetStartTime(datasetStartTime);
+    }
 
     // process endTime
     final @Nullable Long datasetMaxTime = maxTimeFuture.get(FETCH_TIMEOUT_MILLIS, MILLISECONDS);

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/alert/AlertInsightsProvider.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/alert/AlertInsightsProvider.java
@@ -185,6 +185,8 @@ public class AlertInsightsProvider {
     final Interval safeInterval = new Interval(0L, maximumPossibleEndTime);
     final Future<@Nullable Long> safeMaxTimeFuture = minMaxTimeLoader.fetchMaxTimeAsync(
         dataSourceDTO, datasetConfigDTO, safeInterval);
+    final Future<@Nullable Long> safeMinTimeFuture = minMaxTimeLoader.fetchMinTimeAsync(
+        dataSourceDTO, datasetConfigDTO, safeInterval);
 
     // process futures
     // process startTime
@@ -199,10 +201,17 @@ public class AlertInsightsProvider {
       insights.setDatasetStartTime(datasetStartTime);
     } else {
       LOG.warn(
-          "Dataset minTime is negative: {}. Most likely a data issue in the dataset. Replacing minTime by 0.",
+          "Dataset minTime is negative: {}. Most likely a data issue in the dataset. Rerunning query with a filter time >= 0 to get a safe minTime.",
           datasetStartTime);
-      insights.setDatasetStartTime(0L);
       insights.setSuspiciousDatasetStartTime(datasetStartTime);
+      final @Nullable Long safeMinTime = safeMinTimeFuture.get(FETCH_TIMEOUT_MILLIS, MILLISECONDS);
+      if (safeMinTime == null) {
+        insights.setAnalysisRunInfo(AnalysisRunInfo.failure(String.format(
+            "Failed to fetch dataset safe start time. The time configuration of the table %s may be incorrect.",
+            datasetConfigDTO.getDataset())));
+      } else {
+        insights.setDatasetStartTime(safeMinTime);
+      }
     }
 
     // process endTime

--- a/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertInsightsApi.java
+++ b/thirdeye-spi/src/main/java/ai/startree/thirdeye/spi/api/AlertInsightsApi.java
@@ -36,6 +36,12 @@ public class AlertInsightsApi {
    * safe value is put in the datasetEndTime field.
    */
   private Long suspiciousDatasetEndTime;
+
+  /**
+   * If the datasetStartTime fetched from the database looks incorrect, it is stored in this field. A
+   * safer value is put in the datasetStartTime field.
+   */
+  private Long suspiciousDatasetStartTime;
   /**
    * Recommended start time and end time to use in the UI time selector if no time
    * is set.
@@ -117,6 +123,15 @@ public class AlertInsightsApi {
   public AlertInsightsApi setDefaultCron(
       final String defaultCron) {
     this.defaultCron = defaultCron;
+    return this;
+  }
+
+  public Long getSuspiciousDatasetStartTime() {
+    return suspiciousDatasetStartTime;
+  }
+
+  public AlertInsightsApi setSuspiciousDatasetStartTime(final Long suspiciousDatasetStartTime) {
+    this.suspiciousDatasetStartTime = suspiciousDatasetStartTime;
     return this;
   }
 }


### PR DESCRIPTION
A dataset can return suspicious start times, like very small negative numbers for something that is expected to be an epoch. 
Add logic to manage this case.

For the moment we only set a minimum of 0 and report the suspicious start time.