### PR TITLE
[k8s] Add quotas to helm template

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -135,6 +135,9 @@ data:
       tags:
         component: "{{ .Values.coordinator.name }}"  
 
+    quotas:
+{{ toYaml .Values.quotas | indent 6 }}
+
     notifications:
       useSendgridEmail: true
       smtp:

--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -133,10 +133,11 @@ data:
       # Some characters are forbidden - see https://docs.sentry.io/platforms/java/configuration/environments
       environment: {{regexReplaceAll `(https?:|\n| |/)` .Values.ui.publicUrl ""}}
       tags:
-        component: "{{ .Values.coordinator.name }}"  
-
+        component: "{{ .Values.coordinator.name }}"
+{{ if .Values.quotas }}
     quotas:
-{{ toYaml .Values.quotas | indent 6 }}
+{{- toYaml .Values.quotas  | nindent 6 }}
+{{- end }}
 
     notifications:
       useSendgridEmail: true


### PR DESCRIPTION
#### Issue(s)

[upgrade qps quota in Pinot table when table is onboarded in TE](https://startree.atlassian.net/browse/TE-2505)

#### Description
Adding quotas to helm template configuration
It is used to enable the feature to override the default pinot max QPS quota for the tables that are being onboarded to TE (#1741)

#### How to test
Validate helm install locally
`cd kubernetes/helm/startree-thirdeye`

`helm install --generate-name . --debug --dry-run`
[helm-debug-output-log-plain.txt](https://github.com/user-attachments/files/18361263/helm-debug-output-log-plain.txt)

`helm install --generate-name . --debug --dry-run --set quotas.pinotMaxQPSQuotaOverride=100`
[Uploading helm-debug-output-log-override.txt…]()



