### PR TITLE
[scheduler] Add core logic to accomodate monthly tasks limit

### DIFF
--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
@@ -17,6 +17,8 @@ import static ai.startree.thirdeye.spi.util.ExecutorUtils.shutdownExecutionServi
 
 import ai.startree.thirdeye.scheduler.job.DetectionPipelineJob;
 import ai.startree.thirdeye.spi.datalayer.bao.AlertManager;
+import ai.startree.thirdeye.spi.datalayer.bao.NamespaceConfigurationManager;
+import ai.startree.thirdeye.spi.datalayer.bao.TaskManager;
 import ai.startree.thirdeye.spi.datalayer.dto.AlertDTO;
 import ai.startree.thirdeye.spi.task.TaskType;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -39,17 +41,24 @@ public class DetectionCronScheduler {
   private final AlertManager alertManager;
   private TaskCronSchedulerRunnable<AlertDTO> runnable;
 
+  private final TaskManager taskManager;
+  private final NamespaceConfigurationManager namespaceConfigurationManager;
+
   @Inject
   public DetectionCronScheduler(
       final AlertManager alertManager,
       final ThirdEyeSchedulerConfiguration configuration,
-      final GuiceJobFactory guiceJobFactory) {
+      final GuiceJobFactory guiceJobFactory,
+      final TaskManager taskManager,
+      final NamespaceConfigurationManager namespaceConfigurationManager) {
     this.configuration = configuration;
     this.guiceJobFactory = guiceJobFactory;
     executorService = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat("detection-cron-%d").build());
     
     this.alertManager = alertManager;
+    this.taskManager = taskManager;
+    this.namespaceConfigurationManager = namespaceConfigurationManager;
   }
 
   public void start() throws SchedulerException {
@@ -62,7 +71,9 @@ public class DetectionCronScheduler {
         DetectionPipelineJob.class,
         guiceJobFactory,
         DETECTION_SCHEDULER_CRON_MAX_TRIGGERS_PER_MINUTE,
-        this.getClass()
+        this.getClass(),
+        taskManager,
+        namespaceConfigurationManager
     );
     executorService.scheduleWithFixedDelay(runnable,
         0, 

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
@@ -73,7 +73,8 @@ public class DetectionCronScheduler {
         DETECTION_SCHEDULER_CRON_MAX_TRIGGERS_PER_MINUTE,
         this.getClass(),
         taskManager,
-        namespaceConfigurationManager
+        namespaceConfigurationManager,
+        configuration.getNamespaceQuotaMapRefreshDelay()
     );
     executorService.scheduleWithFixedDelay(runnable,
         0, 

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/DetectionCronScheduler.java
@@ -74,7 +74,7 @@ public class DetectionCronScheduler {
         this.getClass(),
         taskManager,
         namespaceConfigurationManager,
-        configuration.getNamespaceQuotaMapRefreshDelay()
+        configuration.getNamespaceQuotaCacheDurationSeconds()
     );
     executorService.scheduleWithFixedDelay(runnable,
         0, 

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SubscriptionCronScheduler.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SubscriptionCronScheduler.java
@@ -78,7 +78,7 @@ public class SubscriptionCronScheduler {
         this.getClass(),
         taskManager,
         namespaceConfigurationManager,
-        configuration.getNamespaceQuotaMapRefreshDelay()
+        configuration.getNamespaceQuotaCacheDurationSeconds()
     );
     executorService.scheduleWithFixedDelay(runnable,
         0,

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SubscriptionCronScheduler.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/SubscriptionCronScheduler.java
@@ -77,7 +77,8 @@ public class SubscriptionCronScheduler {
         SUBSCRIPTION_SCHEDULER_CRON_MAX_TRIGGERS_PER_MINUTE,
         this.getClass(),
         taskManager,
-        namespaceConfigurationManager
+        namespaceConfigurationManager,
+        configuration.getNamespaceQuotaMapRefreshDelay()
     );
     executorService.scheduleWithFixedDelay(runnable,
         0,

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/ThirdEyeSchedulerConfiguration.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/ThirdEyeSchedulerConfiguration.java
@@ -28,6 +28,7 @@ public class ThirdEyeSchedulerConfiguration {
   private boolean detectionAlert = false;
   private boolean dataAvailabilityEventListener = false;
   private int alertUpdateDelay = 60;
+  private int namespaceQuotaMapRefreshDelay = 600;
 
   // TODO spyne: consolidate all the update delays into a single configuration after consolidating the core scheduler code
   private int subscriptionGroupUpdateDelay = 60;
@@ -113,6 +114,16 @@ public class ThirdEyeSchedulerConfiguration {
 
   public ThirdEyeSchedulerConfiguration setAlertUpdateDelay(final int alertUpdateDelay) {
     this.alertUpdateDelay = alertUpdateDelay;
+    return this;
+  }
+
+  public int getNamespaceQuotaMapRefreshDelay() {
+    return namespaceQuotaMapRefreshDelay;
+  }
+
+  public ThirdEyeSchedulerConfiguration setNamespaceQuotaMapRefreshDelay(
+      final int namespaceQuotaMapRefreshDelay) {
+    this.namespaceQuotaMapRefreshDelay = namespaceQuotaMapRefreshDelay;
     return this;
   }
 

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/ThirdEyeSchedulerConfiguration.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/ThirdEyeSchedulerConfiguration.java
@@ -28,7 +28,7 @@ public class ThirdEyeSchedulerConfiguration {
   private boolean detectionAlert = false;
   private boolean dataAvailabilityEventListener = false;
   private int alertUpdateDelay = 60;
-  private int namespaceQuotaCacheDurationSeconds = 600;
+  private int namespaceQuotaCacheDurationSeconds = 300;
 
   // TODO spyne: consolidate all the update delays into a single configuration after consolidating the core scheduler code
   private int subscriptionGroupUpdateDelay = 60;

--- a/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/ThirdEyeSchedulerConfiguration.java
+++ b/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/ThirdEyeSchedulerConfiguration.java
@@ -28,7 +28,7 @@ public class ThirdEyeSchedulerConfiguration {
   private boolean detectionAlert = false;
   private boolean dataAvailabilityEventListener = false;
   private int alertUpdateDelay = 60;
-  private int namespaceQuotaMapRefreshDelay = 600;
+  private int namespaceQuotaCacheDurationSeconds = 600;
 
   // TODO spyne: consolidate all the update delays into a single configuration after consolidating the core scheduler code
   private int subscriptionGroupUpdateDelay = 60;
@@ -117,13 +117,13 @@ public class ThirdEyeSchedulerConfiguration {
     return this;
   }
 
-  public int getNamespaceQuotaMapRefreshDelay() {
-    return namespaceQuotaMapRefreshDelay;
+  public int getNamespaceQuotaCacheDurationSeconds() {
+    return namespaceQuotaCacheDurationSeconds;
   }
 
-  public ThirdEyeSchedulerConfiguration setNamespaceQuotaMapRefreshDelay(
-      final int namespaceQuotaMapRefreshDelay) {
-    this.namespaceQuotaMapRefreshDelay = namespaceQuotaMapRefreshDelay;
+  public ThirdEyeSchedulerConfiguration setNamespaceQuotaCacheDurationSeconds(
+      final int namespaceQuotaCacheDurationSeconds) {
+    this.namespaceQuotaCacheDurationSeconds = namespaceQuotaCacheDurationSeconds;
     return this;
   }
 


### PR DESCRIPTION
#### Issue(s)

[thirdeye tasks limit per month](https://startree.atlassian.net/browse/TE-2603)

#### Description

[ThirdEye Free Tier Usage Quota
](https://docs.google.com/document/d/10UK1rLjSnwoe-gIKy9K7erOM_1DpMaNOHsGn9jgQ4AM/edit?tab=t.0#heading=h.2k2bjxgh7f56)

#1751 introduced TaskQuotasConfiguration as part of workspace configuration
This PR adds the core logic to incorporate task quotas in the job scheduler for both DETECTION and NOTIFICATION tasks

It computes, for each workspace, if it has exceeded the DETECTION/NOTIFICATION monthly task quota
If yes, then it stops the currently running jobs and does not let any new job get scheduled

#### Testing

e2e tests are out of scope, will be done in another PR.

Manually tested locally with following data

Related server.yaml config:
```
defaultWorkspaceConfiguration:
  ...
  ...
  namespaceQuotasConfiguration:
    taskQuotasConfiguration:
      maximumDetectionTasksPerMonth: 3100
      maximumNotificationTasksPerMonth: 2446
  ...
```

Tasks Count for Current Month:
| Namespace  | Detection Tasks | Notification Tasks |
| ------------- | ------------- | ------------- |
| null  | 207 | 2444 |
| namespace1  | 7598  | 2446 |
| namespace3  | 2452  | 2446 |
| ws_2exrxop2u3ad  | 0  | 0 |
| ws_2ehw4puhqucn  | 0  | 0 |

As per the above data, namespace 1 has exceeded DETECTION tasks quota
and namespace1 and namespace3 have exceeded NOTIFICATION tasks quota
Scheduler should not schedule & should cleanup any tasks for such cases

Scheduler activity in Server log:
[server-logs-with-quota.txt](https://github.com/user-attachments/files/18453664/server-logs-with-quota.txt)
```
INFO  [2025-01-17 11:03:35,239] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 3664 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:44,358] ai.startree.thirdeye.scheduler.SubscriptionCronScheduler: workspace namespace1 corresponding to SubscriptionGroupDTO with id 7344 has exceeded monthly quota. Skipping scheduling NOTIFICATION job.
INFO  [2025-01-17 11:03:44,359] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 5282 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,425] ai.startree.thirdeye.scheduler.SubscriptionCronScheduler: workspace namespace3 corresponding to SubscriptionGroupDTO with id 10308 has exceeded monthly quota. Skipping scheduling NOTIFICATION job.
INFO  [2025-01-17 11:03:49,425] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 7269 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,425] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 7345 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,425] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 7346 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,434] ai.startree.thirdeye.scheduler.SubscriptionCronScheduler: Scheduled NOTIFICATION job NOTIFICATION_14319
INFO  [2025-01-17 11:03:49,434] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_10309
INFO  [2025-01-17 11:03:49,434] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 10378 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,435] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 11304 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,436] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_11655
INFO  [2025-01-17 11:03:49,436] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 11910 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,437] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_12161
INFO  [2025-01-17 11:03:49,437] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 12297 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,437] ai.startree.thirdeye.scheduler.DetectionCronScheduler: workspace namespace1 corresponding to AlertDTO with id 12552 has exceeded monthly quota. Skipping scheduling DETECTION job.
INFO  [2025-01-17 11:03:49,438] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_12621
```

Reset the task quotas to null by removing namespaceQuotasConfiguration from server.yaml and using `/api/workspace-configuration/reset`
All jobs should be scheduled for all namespaces
without any detection/notification task quota check

Scheduler activity in Server log:
[server-logs-without-quota.txt](https://github.com/user-attachments/files/18453669/server-logs-without-quota.txt)
```
INFO  [2025-01-17 11:29:29,060] ai.startree.thirdeye.scheduler.SubscriptionCronScheduler: Scheduled NOTIFICATION job NOTIFICATION_7344
INFO  [2025-01-17 11:29:29,060] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_3664
INFO  [2025-01-17 11:29:32,668] ai.startree.thirdeye.worker.task.TaskDriverRunnable: Task 82762 NOTIFICATION_7344: executing {"detectionAlertConfigId":7344}
INFO  [2025-01-17 11:29:32,669] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_5282
INFO  [2025-01-17 11:29:32,669] ai.startree.thirdeye.scheduler.SubscriptionCronScheduler: Scheduled NOTIFICATION job NOTIFICATION_10308
INFO  [2025-01-17 11:29:32,670] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_7269
INFO  [2025-01-17 11:29:32,671] ai.startree.thirdeye.scheduler.SubscriptionCronScheduler: Scheduled NOTIFICATION job NOTIFICATION_14319
INFO  [2025-01-17 11:29:32,671] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_7345
INFO  [2025-01-17 11:29:32,672] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_7346
INFO  [2025-01-17 11:29:32,672] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_10309
INFO  [2025-01-17 11:29:32,673] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_10378
INFO  [2025-01-17 11:29:32,674] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_11304
INFO  [2025-01-17 11:29:32,674] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_11655
INFO  [2025-01-17 11:29:32,675] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_11910
INFO  [2025-01-17 11:29:32,675] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_12161
INFO  [2025-01-17 11:29:32,676] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_12297
INFO  [2025-01-17 11:29:32,677] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_12552
INFO  [2025-01-17 11:29:32,678] ai.startree.thirdeye.scheduler.DetectionCronScheduler: Scheduled DETECTION job DETECTION_12621
```