### PR TITLE
[k8s] Add namespaceQuotasConfiguration to helm template

### DIFF
--- a/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/coordinator/configmap.yaml
@@ -104,6 +104,10 @@ data:
         minimumOnboardingStartTime: {{ .Values.defaultWorkspaceConfiguration.timeConfiguration.minimumOnboardingStartTime }}
       templateConfiguration:
         sqlLimitStatement: {{ .Values.defaultWorkspaceConfiguration.templateConfiguration.sqlLimitStatement }}
+      namespaceQuotasConfiguration:
+        taskQuotasConfiguration:
+          maximumDetectionTasksPerMonth: {{ .Values.defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumDetectionTasksPerMonth }}
+          maximumNotificationTasksPerMonth: {{ .Values.defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumNotificationTasksPerMonth }}
 
     rca:
       topContributors:

--- a/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/scheduler/scheduler-config.yaml
@@ -124,6 +124,10 @@ data:
         minimumOnboardingStartTime: {{ .Values.defaultWorkspaceConfiguration.timeConfiguration.minimumOnboardingStartTime }}
       templateConfiguration:
         sqlLimitStatement: {{ .Values.defaultWorkspaceConfiguration.templateConfiguration.sqlLimitStatement }}
+      namespaceQuotasConfiguration:
+        taskQuotasConfiguration:
+          maximumDetectionTasksPerMonth: {{ .Values.defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumDetectionTasksPerMonth }}
+          maximumNotificationTasksPerMonth: {{ .Values.defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumNotificationTasksPerMonth }}
     
     rca:
       topContributors:

--- a/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
+++ b/kubernetes/helm/startree-thirdeye/templates/worker/worker-config.yaml
@@ -128,6 +128,11 @@ data:
         minimumOnboardingStartTime: {{ .Values.defaultWorkspaceConfiguration.timeConfiguration.minimumOnboardingStartTime }}
       templateConfiguration:
         sqlLimitStatement: {{ .Values.defaultWorkspaceConfiguration.templateConfiguration.sqlLimitStatement }}
+      namespaceQuotasConfiguration:
+        taskQuotasConfiguration:
+          maximumDetectionTasksPerMonth: {{ .Values.defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumDetectionTasksPerMonth }}
+          maximumNotificationTasksPerMonth: {{ .Values.defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumNotificationTasksPerMonth }}    
+
     
     rca:
       topContributors:

--- a/kubernetes/helm/startree-thirdeye/values.yaml
+++ b/kubernetes/helm/startree-thirdeye/values.yaml
@@ -147,6 +147,10 @@ defaultWorkspaceConfiguration:
     minimumOnboardingStartTime: 946684800000
   templateConfiguration:
     sqlLimitStatement: 100000000
+  namespaceQuotasConfiguration:
+    taskQuotasConfiguration:
+      maximumDetectionTasksPerMonth: 0
+      maximumNotificationTasksPerMonth: 0
 
 rca:
   topContributors:


### PR DESCRIPTION
#### Issue(s)

[thirdeye tasks limit per month](https://startree.atlassian.net/browse/TE-2603)

#### Description

Adding namespaceQuotasConfiguration to helm templates
[ThirdEye Free Tier Usage Quota
](https://docs.google.com/document/d/10UK1rLjSnwoe-gIKy9K7erOM_1DpMaNOHsGn9jgQ4AM/edit?tab=t.0#heading=h.2k2bjxgh7f56)

It is used to enable the feature to set monthly quota for detection and notification tasks per namespace 

#### How to test
Validate helm install locally
`cd kubernetes/helm/startree-thirdeye`

`helm install --generate-name . --debug --dry-run`
[helm-install-default.txt](https://github.com/user-attachments/files/18477207/helm-install-default.txt)

`helm install --generate-name . --debug --dry-run --set defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumDetectionTasksPerMonth=3100 --set  defaultWorkspaceConfiguration.namespaceQuotasConfiguration.taskQuotasConfiguration.maximumNotificationTasksPerMonth=20000`
[helm-install-with-overrides.txt](https://github.com/user-attachments/files/18477213/helm-install-with-overrides.txt)

