### PR TITLE
[detectors] add inclusive flag to threshold boundaries

### DIFF
--- a/thirdeye-plugins/thirdeye-detectors/src/main/java/ai/startree/thirdeye/plugins/detectors/ThresholdRuleDetector.java
+++ b/thirdeye-plugins/thirdeye-detectors/src/main/java/ai/startree/thirdeye/plugins/detectors/ThresholdRuleDetector.java
@@ -65,14 +65,22 @@ public class ThresholdRuleDetector implements AnomalyDetector<ThresholdRuleDetec
     if (Double.isNaN(spec.getMax())) {
       return BooleanSeries.fillValues(values.size(), false);
     }
-    return values.gt(spec.getMax());
+    if (spec.isMaxInclusive()) {
+      return values.gt(spec.getMax());
+    } else {
+      return values.gte(spec.getMax());
+    }
   }
 
   private BooleanSeries valueTooLow(DoubleSeries values) {
     if (Double.isNaN(spec.getMin())) {
       return BooleanSeries.fillValues(values.size(), false);
     }
-    return values.lt(spec.getMin());
+    if (spec.isMinInclusive()) {
+      return values.lt(spec.getMin()); 
+    } else {
+      return values.lte(spec.getMin());
+    }
   }
 
   private AnomalyDetectorResult runDetectionOnSingleDataTable(final DataFrame inputDf,

--- a/thirdeye-plugins/thirdeye-detectors/src/main/java/ai/startree/thirdeye/plugins/detectors/ThresholdRuleDetectorSpec.java
+++ b/thirdeye-plugins/thirdeye-detectors/src/main/java/ai/startree/thirdeye/plugins/detectors/ThresholdRuleDetectorSpec.java
@@ -21,6 +21,10 @@ public class ThresholdRuleDetectorSpec extends AbstractSpec {
 
   private double min = Double.NaN;
   private double max = Double.NaN;
+  
+  private boolean maxInclusive = true;
+
+  private boolean minInclusive = true;
 
   public double getMin() {
     return min;
@@ -37,6 +41,24 @@ public class ThresholdRuleDetectorSpec extends AbstractSpec {
 
   public ThresholdRuleDetectorSpec setMax(final double max) {
     this.max = max;
+    return this;
+  }
+
+  public boolean isMaxInclusive() {
+    return maxInclusive;
+  }
+
+  public ThresholdRuleDetectorSpec setMaxInclusive(final boolean maxInclusive) {
+    this.maxInclusive = maxInclusive;
+    return this;
+  }
+
+  public boolean isMinInclusive() {
+    return minInclusive;
+  }
+
+  public ThresholdRuleDetectorSpec setMinInclusive(final boolean minInclusive) {
+    this.minInclusive = minInclusive;
     return this;
   }
 }

--- a/thirdeye-plugins/thirdeye-detectors/src/test/java/ai/startree/thirdeye/plugins/detectors/ThresholdRuleDetectorTest.java
+++ b/thirdeye-plugins/thirdeye-detectors/src/test/java/ai/startree/thirdeye/plugins/detectors/ThresholdRuleDetectorTest.java
@@ -170,7 +170,7 @@ public class ThresholdRuleDetectorTest {
         BooleanSeries.FALSE, // not an anomaly because equal to minValue and default is to be inclusive of the min
         BooleanSeries.FALSE,
         BooleanSeries.FALSE,
-        BooleanSeries.TRUE, // anomaly because equal to maxValue maxInclusive is set to false
+        BooleanSeries.TRUE, // anomaly because equal to maxValue and maxInclusive is set to false
         BooleanSeries.TRUE);
     assertThat(outputAnomalySeries).isEqualTo(expectedAnomalySeries);
   }


### PR DESCRIPTION
add `maxInclusive`, `minInclusive` to threshold to control whether the max/min value is detected as an anomaly or not.