### PR TITLE
[persistence] improve time mock for quartz scheduler

### DIFF
--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/HappyPathTest.java
@@ -419,7 +419,7 @@ public class HappyPathTest implements ITest {
     List<AnomalyApi> anomalies = List.of();
     while (anomalies.size() == 0) {
       // see taskDriver server config for optimization
-      Thread.sleep(1000);
+      Thread.sleep(500);
       final Response response = request("api/anomalies?isChild=false").get();
       assert200(response);
       anomalies = response.readEntity(ANOMALIES_LIST_TYPE);
@@ -448,7 +448,7 @@ public class HappyPathTest implements ITest {
     long newAlertLastUpdateTime = alertLastUpdateTime;
     while (newAlertLastUpdateTime == alertLastUpdateTime) {
       // see taskDriver server config for optimization
-      Thread.sleep(1000);
+      Thread.sleep(500);
       newAlertLastUpdateTime = getAlertLastUpdatedTime();
     }
     final Response response = request("api/anomalies?isChild=false").get();
@@ -595,7 +595,7 @@ public class HappyPathTest implements ITest {
     assertThat(replayResponse.getStatus()).isEqualTo(200);
 
     while (getAlertLastUpdatedTime() == lastUpdatedTime) {
-      Thread.sleep(1000);
+      Thread.sleep(500);
     }
 
     final Response afterReplayResponse = request(alertAnomaliesRoute).get();
@@ -867,7 +867,7 @@ public class HappyPathTest implements ITest {
   private void waitForAnyAnomalies(final long alertId) throws InterruptedException {
     List<AnomalyApi> gotAnomalies = mustGetAnomaliesForAlert(alertId);
     while (gotAnomalies.size() == 0) {
-      Thread.sleep(1000);
+      Thread.sleep(500);
       gotAnomalies = mustGetAnomaliesForAlert(alertId);
     }
   }

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/SchedulingTest.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -168,7 +167,7 @@ public class SchedulingTest {
     TaskApi onboardingTask = getTask(onboardingTaskId);
     while (TASK_PENDING_STATUSES.contains(onboardingTask.getStatus())) {
       // see taskDriver server config for optimization
-      Thread.sleep(1000);
+      Thread.sleep(500);
       onboardingTask = getTask(onboardingTaskId); 
     }
 
@@ -185,12 +184,12 @@ public class SchedulingTest {
     // not exact time should not impact lastTimestamp
     CLOCK.tick(5);
     // give thread to detectionCronScheduler and to quartz scheduler - (quartz idle time is weaved to 100 ms for test speed)
-    Thread.sleep(1000);
+    Thread.sleep(500);
 
     // wait for the new task to be created - proxy to know when the detection is triggered
     List<TaskApi> tasks = getTasks();
     while (tasks.size() == 1 || TASK_PENDING_STATUSES.contains(tasks.getLast().getStatus())) {
-      Thread.sleep(1000);
+      Thread.sleep(500);
       tasks = getTasks();
     }
      assertThat(tasks.getLast().getTaskSubType()).isEqualTo(TaskSubType.DETECTION_TRIGGERED_BY_CRON);
@@ -211,11 +210,11 @@ public class SchedulingTest {
     // not exact time should not impact lastTimestamp
     CLOCK.tick(5);
     // give thread to quartz scheduler - (quartz idle time is weaved to 1000 ms for test speed)
-    Thread.sleep(1000);
+    Thread.sleep(500);
 
     // wait for a new anomaly to be created - proxy to know when the detection has run
     while (anomalies.size() == numAnomaliesBeforeDetectionRun) {
-      Thread.sleep(1000);
+      Thread.sleep(500);
       anomalies = getAnomalies();
     }
 
@@ -226,7 +225,7 @@ public class SchedulingTest {
     // find anomalies starting on MARCH 21 - there should be 2
     final List<AnomalyApi> march21Anomalies = anomalies.stream()
         .filter(a -> a.getStartTime().getTime() == MARCH_21_2020_00H00)
-        .collect(Collectors.toList());
+        .toList();
     assertThat(march21Anomalies.size()).isEqualTo(2);
     // check that one anomaly finishes on MARCH 22: the child anomaly
     assertThat(march21Anomalies.stream()

--- a/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/TestNotificationServiceFactory.java
+++ b/thirdeye-integration-tests/src/test/java/ai/startree/thirdeye/TestNotificationServiceFactory.java
@@ -43,11 +43,11 @@ public class TestNotificationServiceFactory implements NotificationServiceFactor
     };
   }
 
-  public int getCount() {
+  public int notificationSentCount() {
     return count;
   }
 
-  public NotificationPayloadApi getNotificationPayload() {
+  public NotificationPayloadApi lastNotificationPayload() {
     return f.get();
   }
 

--- a/thirdeye-integration-tests/src/test/resources/anomalyresolution/payloads/alert-1.json
+++ b/thirdeye-integration-tests/src/test/resources/anomalyresolution/payloads/alert-1.json
@@ -1,7 +1,7 @@
 {
   "name": "threshold-pageviews-daily-merge-3-15",
   "description": "Daily Threshold Alert with mergeMaxGap = 3 days and mergeMaxDuration = 15 days",
-  "cron": "0 0 5 1/1 * ? *",
+  "cron": "0 0 5 * * ? *",
   "template": {
     "nodes": [
       {
@@ -74,9 +74,9 @@
     "monitoringGranularity": "P1D",
     "timeColumn": "AUTO",
     "timeColumnFormat": "",
-    "max": "600000",
+    "max": "680000",
     "min": "250000",
     "mergeMaxGap": "P3D",
-    "mergeMaxDuration": "P15D"
+    "mergeMaxDuration": "P6D"
   }
 }

--- a/thirdeye-integration-tests/src/test/resources/anomalyresolution/payloads/subscription-group.json
+++ b/thirdeye-integration-tests/src/test/resources/anomalyresolution/payloads/subscription-group.json
@@ -1,6 +1,6 @@
 {
   "name": "sg-anomalyresolution",
-  "cron": "0 0/5 0 ? * * *",
+  "cron": "0 0 7 * * ? *",
   "active": true,
   "notifyHistoricalAnomalies": false,
   "specs": [

--- a/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationTaskFilter.java
+++ b/thirdeye-notification/src/main/java/ai/startree/thirdeye/notification/NotificationTaskFilter.java
@@ -193,6 +193,9 @@ public class NotificationTaskFilter {
     final AlertDTO alert = alertManager.findById(alertId);
     final AlertTemplateDTO renderedTemplate = alertTemplateRenderer.renderAlert(alert);
     final Period mergeMaxGap = AlertUtils.getMergeMaxGap(renderedTemplate);
+    // note: a ThirdEye anomaly could also be completed if its mergeMaxDuration is reached, 
+    // but in this case a new ThirdEye anomaly would be created for the same data anomaly just after
+    // we don't call out these anomalies as completed
     final long endTimeIsLt = alert.getLastTimestamp() - mergeMaxGap.toStandardDuration().getMillis();
 
     return new AnomalyFilter()

--- a/thirdeye-persistence/src/test/java/ai/startree/thirdeye/aspect/CronTriggerImplAspect.java
+++ b/thirdeye-persistence/src/test/java/ai/startree/thirdeye/aspect/CronTriggerImplAspect.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 StarTree Inc
+ *
+ * Licensed under the StarTree Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.startree.ai/legal/startree-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT * WARRANTIES OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ai.startree.thirdeye.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Aspect
+public class CronTriggerImplAspect {
+  
+  private static final Logger LOG = LoggerFactory.getLogger(CronTriggerImplAspect.class);
+
+  @Around("execution(* org.quartz.impl.triggers.CronTriggerImpl.updateAfterMisfire(..))")
+  public void disableUpdateAfterMisfire(ProceedingJoinPoint joinPoint) throws Throwable {
+    LOG.debug("Time is mocked, skipping misfire update in quartz trigger.");
+    return;
+  }
+}

--- a/thirdeye-persistence/src/test/resources/META-INF/aop.xml
+++ b/thirdeye-persistence/src/test/resources/META-INF/aop.xml
@@ -18,6 +18,7 @@
     <aspect name="ai.startree.thirdeye.aspect.SystemTimeMockAspect"/>
     <aspect name="ai.startree.thirdeye.aspect.NanoTimeAspect"/>
     <aspect name="ai.startree.thirdeye.aspect.DateMockAspect"/>
+    <aspect name="ai.startree.thirdeye.aspect.CronTriggerImplAspect"/>
     <aspect name="ai.startree.thirdeye.aspect.QuartzRandomizedIdleWaitTimeMockAspect"/>
     <weaver options="-showWeaveInfo">
     </weaver>

--- a/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/DetectionPipelineTaskRunner.java
+++ b/thirdeye-worker/src/main/java/ai/startree/thirdeye/worker/task/runner/DetectionPipelineTaskRunner.java
@@ -134,6 +134,7 @@ public class DetectionPipelineTaskRunner implements TaskRunner {
         .forEach(anomalyManager::save);
     alertManager.update(alert);
 
+    // TODO CYRIL - improve this log compute stats: new anomalies: child, parent, existing anomalies, child, parent
     LOG.info("Completed detection task for id {} between {} and {}. Detected {} anomalies.",
         alert.getId(),
         detectionInterval.getStart(),


### PR DESCRIPTION
This PR makes the behavior of the QuartzScheduler simpler to understand when the time is mocked in e2e tests. 

## Problem

When the time is mocked, time can jump and the quartz scheduler can miss cron triggers. 
See 
- https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-04.html#:~:text=A%20misfire%20occurs%20if%20a,pool%20for%20executing%20the%20job.
- https://nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html and 
- read the code of `org.quartz.simpl.RamJobStore`, `org.quartz.core.QuartzSchedulerThread` and `org.quartz.impl.triggers.CronTriggerImpl`

Previously the logic applied for the cron trigger schedules created [here](https://github.com/startreedata/thirdeye/blob/713d3b4f9b61320103f6f8955f4d4047c2daf61c/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/TaskCronSchedulerRunnable.java#L269): 
was `MISFIRE_INSTRUCTION_SMART_POLICY`, which resulted in `MISFIRE_INSTRUCTION_FIRE_ONCE_NOW` in `CronTriggerImpl.updateAfterMisfire`
```
@Override
public void updateAfterMisfire(org.quartz.Calendar cal) {
    int instr = getMisfireInstruction();

    if(instr == Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY)
        return;

    if (instr == MISFIRE_INSTRUCTION_SMART_POLICY) {
        instr = MISFIRE_INSTRUCTION_FIRE_ONCE_NOW;
    }

    if (instr == MISFIRE_INSTRUCTION_DO_NOTHING) {
        Date newFireTime = getFireTimeAfter(new Date());
        while (newFireTime != null && cal != null
                && !cal.isTimeIncluded(newFireTime.getTime())) {
            newFireTime = getFireTimeAfter(newFireTime);
        }
        setNextFireTime(newFireTime);
    } else if (instr == MISFIRE_INSTRUCTION_FIRE_ONCE_NOW) {
        setNextFireTime(new Date());
    }
}
```

This means jobs were created with a scheduled fire time equal to the mocked time, which would not necessarily correspond to a correct cron trigger time.
This caused issue in the simulation because when a task is created, the endTime is obtained from the scheduled fire time and it is assumed this time is a valid cron time.
See https://github.com/startreedata/thirdeye/blob/0756d068c863c48131efc2823bd9f769d69bcac4/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/job/DetectionPipelineJob.java#L74. 

## Change
The behavior of the function above `updateAfterMisfire` is overridden with aspectJ to behave like MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY.
The other implementation option was to introduce a configuration knob in the server and add `.withMisfireHandlingInstructionIgnoreMisfires()` to the code here https://github.com/startreedata/thirdeye/blob/713d3b4f9b61320103f6f8955f4d4047c2daf61c/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/TaskCronSchedulerRunnable.java#L270
but introducing some hard to understand logic in the public config API did not seem like a good idea. 
This may be changed in the future if need be, changing from one solution to the other is simple.

The behavior of the QuartzScheduler is now simpler to understand when time is mocked: 
- if a cron is supposed to run everyday, and the time is jumped by 3 days, then 3 triggers will happen, and the triggers schedule time will correspond to the 3 expected cron times. 
- note that in ThirdEye context, this does not mean 3 DETECTION/NOTIFICATION tasks will be created --> in the quartz job, if a task is already created and in waiting /running state, backpressure is applied and task creation is skipped. See example here: https://github.com/startreedata/thirdeye/blob/0756d068c863c48131efc2823bd9f769d69bcac4/thirdeye-scheduler/src/main/java/ai/startree/thirdeye/scheduler/job/NotificationPipelineJob.java#L65
Because the triggers will run at roughly the same time, this is very likely to happen, so if the output of tasks or the number of tasks is important, best is to increase time 1 cron trigger at a time. 

The AnomalyResolutionTest are fixed: they were incorrect, flaky and exploiting the issue described above.


Time mock changes: 
- thirdeye-persistence/src/test/resources/META-INF/aop.xml
- thirdeye-persistence/src/test/java/ai/startree/thirdeye/aspect/CronTriggerImplAspect.java

other changes are test fixes and improvements
