### PR TITLE
fix(ui): TE-2647 anomaly list filter with multiple alert fix

### DIFF
--- a/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/anomalies-all-page/anomalies-all-page.component.tsx
@@ -77,9 +77,9 @@ export const AnomaliesAllPage: FunctionComponent = () => {
     const anomalyFilters = useMemo(() => {
         const params: GetAnomaliesProps = {};
         if (searchParams.has(AnomalyFilterQueryStringKey.ALERT)) {
-            params.alertId = parseInt(
-                searchParams.get(AnomalyFilterQueryStringKey.ALERT) || ""
-            );
+            const alertIds =
+                searchParams.getAll(AnomalyFilterQueryStringKey.ALERT) || [];
+            params.alertIds = alertIds.map((id) => parseInt(id));
         }
 
         if (searchParams.has(AnomalyFilterQueryStringKey.DATASET)) {

--- a/thirdeye-ui/src/app/rest/anomalies/anomalies.rest.ts
+++ b/thirdeye-ui/src/app/rest/anomalies/anomalies.rest.ts
@@ -35,6 +35,7 @@ export const getAnomaly = async (id: number): Promise<Anomaly> => {
 
 export const getAnomalies = async ({
     alertId,
+    alertIds,
     startTime,
     endTime,
     dataset,
@@ -46,6 +47,9 @@ export const getAnomalies = async ({
 
     if (alertId) {
         queryParams.set("alert.id", alertId.toString());
+    }
+    if (alertIds) {
+        queryParams.set("alert.id", `[in]${alertIds.join(",")}`);
     }
 
     if (startTime) {

--- a/thirdeye-ui/src/app/rest/anomalies/anomaly.interfaces.ts
+++ b/thirdeye-ui/src/app/rest/anomalies/anomaly.interfaces.ts
@@ -32,6 +32,7 @@ export interface GetAnomalies extends ActionHook {
 
 export interface GetAnomaliesProps {
     alertId?: number | string;
+    alertIds?: number[] | string[];
     startTime?: number;
     endTime?: number;
     dataset?: string;


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2647

#### Description

When filtering anomalies to include more than one alert, the anomalies for the second alert don’t show up in the anomaly list.
API call is only taking first alert in the account. 

