### PR TITLE
[server] remove deprecated insights endpoint by alert id

### DIFF
--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/resources/AlertResource.java
@@ -97,17 +97,6 @@ public class AlertResource extends CrudResource<AlertApi, AlertDTO> {
     this.alertService = alertService;
   }
 
-  @Path("{id}/insights")
-  @GET
-  @Timed(percentiles = {0.5, 0.75, 0.90, 0.95, 0.98, 0.99, 0.999})
-  @Produces(MediaType.APPLICATION_JSON)
-  @Deprecated(forRemoval = true)
-  public Response getInsights(
-      @Parameter(hidden = true) @Auth final ThirdEyeServerPrincipal principal,
-      @PathParam("id") final Long id) {
-    return Response.ok(alertService.getInsightsById(principal, id)).build();
-  }
-
   @Path("insights")
   @POST
   @Timed(percentiles = {0.5, 0.75, 0.90, 0.95, 0.98, 0.99, 0.999})

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/AlertService.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/AlertService.java
@@ -203,13 +203,6 @@ public class AlertService extends CrudService<AlertApi, AlertDTO> {
     return ApiBeanMapper.toApi(dto);
   }
 
-  public AlertInsightsApi getInsightsById(final ThirdEyeServerPrincipal principal, final Long id) {
-    final AlertDTO dto = getDto(id);
-    authorizationManager.ensureNamespace(principal, dto);
-    authorizationManager.ensureCanRead(principal, dto);
-    return alertInsightsProvider.getInsights(principal, dto);
-  }
-
   public AlertInsightsApi getInsights(final ThirdEyeServerPrincipal principal,
       final AlertInsightsRequestApi request) {
     return alertInsightsProvider.getInsights(principal, request);

--- a/thirdeye-server/src/main/java/ai/startree/thirdeye/service/alert/AlertInsightsProvider.java
+++ b/thirdeye-server/src/main/java/ai/startree/thirdeye/service/alert/AlertInsightsProvider.java
@@ -101,6 +101,8 @@ public class AlertInsightsProvider {
   public AlertInsightsApi getInsights(final ThirdEyePrincipal principal,
       final AlertInsightsRequestApi request) {
     final AlertApi alertApi = request.getAlert();
+    // TODO CYRIL around March 1 2025 - ensure the id of the alert is not set - only support alerts configuration - this endpoint is not responsible for fetching an existing alert - it should run a a full valid alert configuration
+
     // creating a dummy entity to check access then inject namespace - rewrite this - todo authz possible to redesign this?
     final AlertDTO alertDto = toAlertDto(alertApi);
     authorizationManager.enrichNamespace(principal, alertDto);


### PR DESCRIPTION
Frontend currently calls `alerts/insights` endpoint via 2 ways:
1. On create alert page, when user has selected upto granularity, this API is called with alert configuration (without id) to get insights
2. On alert details page, this API is called with just the alert Id.

This PR -> 
1. Cleans up deprecated `alerts/{id}/insights` endpoint
2. Handles both cases in `alerts/insights` endpoint
   a -> if the id is set, id takes precedence, we fetch the entity from the db
   b -> if the id is not set, we use the fields passed in the payload