### PR TITLE
fix(ui): TE-2648 send entire alert in insight api req

### DIFF
--- a/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
+++ b/thirdeye-ui/src/app/components/alert-view/sub-header/alert-sub-header.component.tsx
@@ -46,7 +46,7 @@ export const AlertViewSubHeader: FunctionComponent<AlertViewSubHeaderProps> = ({
     const getAlertInsightQuery = useFetchQuery({
         queryKey: ["alertInsight", alert.id],
         queryFn: () => {
-            return getAlertInsight({ alertId: alert.id });
+            return getAlertInsight({ alert });
         },
     });
 

--- a/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
+++ b/thirdeye-ui/src/app/pages/alerts-view-page/alerts-view-page.component.tsx
@@ -52,10 +52,7 @@ import {
     useNotificationProviderV1,
 } from "../../platform/components";
 import { ActionStatus } from "../../rest/actions.interfaces";
-import {
-    useGetAlertInsight,
-    useResetAlert,
-} from "../../rest/alerts/alerts.actions";
+import { useResetAlert } from "../../rest/alerts/alerts.actions";
 import {
     getAlert,
     getAlertStats,
@@ -97,7 +94,6 @@ export const AlertsViewPage: FunctionComponent = () => {
         useState<NotificationV1 | null>(null);
     const [resetStatusNotification, setResetStatusNotification] =
         useState<NotificationV1 | null>(null);
-    const { alertInsight, getAlertInsight } = useGetAlertInsight();
     const [taskStatusLoading, setTaskStatusLoading] = useState(false);
 
     const [searchParams, setSearchParams] = useSearchParams();
@@ -153,7 +149,6 @@ export const AlertsViewPage: FunctionComponent = () => {
                     getAlertQuery.refetch();
                     getEnumerationItemsQuery.refetch();
                     getAnomaliesQuery.refetch();
-                    getAlertInsight({ alertId: Number(alertId) });
                     fetchStats();
                     setNextAttemptTime(0);
                 }
@@ -172,7 +167,6 @@ export const AlertsViewPage: FunctionComponent = () => {
             getAlertQuery.refetch();
             getEnumerationItemsQuery.refetch();
             getAnomaliesQuery.refetch();
-            getAlertInsight({ alertId: Number(alertId) });
             fetchStats();
             setNextAttemptTime(0);
         }
@@ -238,26 +232,6 @@ export const AlertsViewPage: FunctionComponent = () => {
         ],
         [searchParams]
     );
-
-    useEffect(() => {
-        getAlertInsight({ alertId: Number(alertId) });
-    }, []);
-
-    useEffect(() => {
-        if (
-            !alertInsight?.analysisRunInfo?.success &&
-            alertInsight?.analysisRunInfo?.message
-        ) {
-            notifyIfErrors(
-                ActionStatus.Error,
-                [{ message: alertInsight.analysisRunInfo.message }],
-                notify,
-                t("message.error-while-fetching", {
-                    entity: t("label.alert-insight"),
-                })
-            );
-        }
-    }, [alertInsight?.analysisRunInfo]);
 
     const fetchStats = (): void => {
         getAlertStats({

--- a/thirdeye-ui/src/app/utils/routes/alert-fetch-redirect-params/alert-fetch-redirect-params.component.tsx
+++ b/thirdeye-ui/src/app/utils/routes/alert-fetch-redirect-params/alert-fetch-redirect-params.component.tsx
@@ -25,7 +25,10 @@ import {
     TimeRangeQueryStringKey,
 } from "../../../components/time-range/time-range-provider/time-range-provider.interfaces";
 import { AppLoadingIndicatorV1 } from "../../../platform/components";
-import { useGetAlertInsight } from "../../../rest/alerts/alerts.actions";
+import {
+    useGetAlert,
+    useGetAlertInsight,
+} from "../../../rest/alerts/alerts.actions";
 import { useLastUsedSearchParams } from "../../../stores/last-used-params/last-used-search-params.store";
 import { AlertFetchRedirectParamsProps } from "./alert-fetch-redirect-params.interfaces";
 
@@ -34,6 +37,7 @@ export const AlertFetchRedirectParams: FunctionComponent<AlertFetchRedirectParam
         const [isLoading, setIsLoading] = useState(true);
         const { id: alertId } = useParams();
         const { alertInsight, getAlertInsight } = useGetAlertInsight();
+        const { alert, getAlert } = useGetAlert();
         const location = useLocation();
         const navigate = useNavigate();
         const [searchParams] = useSearchParams();
@@ -41,14 +45,16 @@ export const AlertFetchRedirectParams: FunctionComponent<AlertFetchRedirectParam
         let searchString: string | undefined;
 
         useEffect(() => {
-            if (alertId) {
-                getAlertInsight({ alertId: Number(alertId) }).finally(() =>
+            getAlert(Number(alertId));
+        }, [alertId]);
+
+        useEffect(() => {
+            if (alert) {
+                getAlertInsight({ alert: alert }).finally(() =>
                     setIsLoading(false)
                 );
-            } else {
-                setIsLoading(false);
             }
-        }, []);
+        }, [alert]);
 
         useEffect(() => {
             if (isLoading) {


### PR DESCRIPTION
#### Issue(s)

https://startree.atlassian.net/browse/TE-2648

#### Description

Sending the entire alert in the insights API call and also removing the redundant extra calls to the same endpoint on the alert details page.
