### PR TITLE
[persistence] Add counter to track invalid namespace configuration state

### DIFF
--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
@@ -51,7 +51,7 @@ public class NamespaceConfigurationManagerImpl implements NamespaceConfiguration
     this.dao = dao;
     this.timeConfiguration = timeConfiguration;
     this.defaultNamespaceConfiguration = defaultNamespaceConfiguration;
-    this.namespaceConfigurationInvalidStateCounter = io.micrometer.core.instrument.Counter.builder(
+    this.namespaceConfigurationInvalidStateCounter = Counter.builder(
             "thirdeye_invalid_namespace_configuration_state_total")
         .register(Metrics.globalRegistry);
   }

--- a/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
+++ b/thirdeye-persistence/src/main/java/ai/startree/thirdeye/datalayer/bao/NamespaceConfigurationManagerImpl.java
@@ -29,6 +29,8 @@ import ai.startree.thirdeye.spi.datalayer.dto.TemplateConfigurationDTO;
 import ai.startree.thirdeye.spi.datalayer.dto.TimeConfigurationDTO;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -40,6 +42,8 @@ public class NamespaceConfigurationManagerImpl implements NamespaceConfiguration
   private final @Nullable TimeConfiguration timeConfiguration;
   private final NamespaceConfigurationDTO defaultNamespaceConfiguration;
 
+  private final Counter namespaceConfigurationInvalidStateCounter;
+
   @Inject
   public NamespaceConfigurationManagerImpl(final NamespaceConfigurationDao dao,
       final @Nullable TimeConfiguration timeConfiguration,
@@ -47,6 +51,9 @@ public class NamespaceConfigurationManagerImpl implements NamespaceConfiguration
     this.dao = dao;
     this.timeConfiguration = timeConfiguration;
     this.defaultNamespaceConfiguration = defaultNamespaceConfiguration;
+    this.namespaceConfigurationInvalidStateCounter = io.micrometer.core.instrument.Counter.builder(
+            "thirdeye_invalid_namespace_configuration_state_total")
+        .register(Metrics.globalRegistry);
   }
 
   public @NonNull NamespaceConfigurationDTO getNamespaceConfiguration(final String namespace) {
@@ -137,6 +144,9 @@ public class NamespaceConfigurationManagerImpl implements NamespaceConfiguration
         "namespace", namespace));
     final List<NamespaceConfigurationDTO> results = filter(daoFilter);
     if (results != null && !results.isEmpty()) {
+      if (results.size() != 1) {
+        namespaceConfigurationInvalidStateCounter.increment();
+      }
       checkState(results.size() == 1,
           "Invalid state. Multiple namespace configuration exist for namespace %s. Contact support",
           namespace);


### PR DESCRIPTION
#### Description

Currently, if somehow namespace configuration goes into an invalid state, multiple parts of the system might break
and we don't have a dedicated alert for tracking this

This PR adds a counter to track all such cases, so that we can create a prometheus alert to get notified of such cases
