### PR TITLE
migrate check-license-header to self hosted

### DIFF
--- a/.github/workflows/check-license-header.yml
+++ b/.github/workflows/check-license-header.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   header-check:
-    runs-on: ubuntu-latest
+    runs-on: 2vcpu-8gb-on-demand-runner
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
#### Description

Migrate check-license-header pipeline to self hosted runner