### PR TITLE
[ui] Fix Slack MemberID format validation logic

### DIFF
--- a/thirdeye-ui/src/app/utils/notifications/notifications.util.ts
+++ b/thirdeye-ui/src/app/utils/notifications/notifications.util.ts
@@ -62,5 +62,5 @@ export const convertSlackConfigurationToSlackFormEntries = (
 };
 
 export const validateSlackMemberIDFormat = (memberId: string): boolean => {
-    return /^U[0-9A-Z]{10}$/.test(memberId);
+    return /^[US][0-9A-Z]{8,}$/.test(memberId);
 };


### PR DESCRIPTION
#### Issue(s)

Incorrect Slack MemberID format validation logic on UI

#### Description

Backend supports both users and user groups in Slack Member IDs to be tagged in a slack notification subscription group
But UI only allows user mentions currently and marks user groups as invalid

Moreover, the regex is not fully correct

This PR fixes the slack memberID format validation logic on UI side to recognize both users (example -> _U012AB3CD_) and user groups (example -> _SAZ94GDB8_)

#### Testing

- [x] Manual test

Before:
<img width="1073" alt="Screenshot 2025-05-07 at 2 19 08 PM" src="https://github.com/user-attachments/assets/3d1edb07-9138-4dd0-9c7b-0c5a014d9821" />

After:
<img width="1072" alt="Screenshot 2025-05-07 at 2 24 57 PM" src="https://github.com/user-attachments/assets/8ab95c98-b99e-47b3-8a7b-1c92006c740f" />

