### PR TITLE
fix(ui): TE-2655 upgrade axios, swagger-ui-react and harden Docker to fix critical Snyk CVEs

### DIFF
--- a/thirdeye-ui/Dockerfile
+++ b/thirdeye-ui/Dockerfile
@@ -15,6 +15,8 @@
 
 FROM nginx:1.27-alpine
 
+RUN apk update && apk upgrade --no-cache libxml2 libxslt
+
 RUN addgroup -S thirdeye && \
     adduser -S thirdeye -G thirdeye && \
     chown thirdeye:thirdeye /home/thirdeye

--- a/thirdeye-ui/package-lock.json
+++ b/thirdeye-ui/package-lock.json
@@ -20,7 +20,7 @@
                 "@tanstack/react-query": "^4.29.19",
                 "@tippyjs/react": "^4.2.6",
                 "@visx/visx": "3.1.2",
-                "axios": "^1.7.4",
+                "axios": "^1.14.0",
                 "binary-search-bounds": "^2.0.5",
                 "classnames": "^2.2.6",
                 "codemirror": "^5.59.1",
@@ -49,7 +49,7 @@
                 "react-markdown": "^8.0.4",
                 "react-router-dom": "^6.18.0",
                 "react-show-more-text": "^1.6.2",
-                "swagger-ui-react": "^5.10.5",
+                "swagger-ui-react": "^5.19.0",
                 "uuid": "^8.3.2",
                 "yup": "1.3.2",
                 "zustand": "^3.2.0"
@@ -1982,31 +1982,25 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-            "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
-            "dependencies": {
-                "regenerator-runtime": "^0.13.4"
-            }
-        },
-        "node_modules/@babel/runtime-corejs3": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
-            "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
-            "dev": true,
-            "dependencies": {
-                "core-js-pure": "^3.25.1",
-                "regenerator-runtime": "^0.13.10"
-            },
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
-            "version": "0.13.10",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-            "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
-            "dev": true
+        "node_modules/@babel/runtime-corejs3": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+            "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+            "license": "MIT",
+            "dependencies": {
+                "core-js-pure": "^3.48.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
         },
         "node_modules/@babel/template": {
             "version": "7.18.10",
@@ -2141,11 +2135,6 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
-        },
-        "node_modules/@braintree/sanitize-url": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-            "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
         },
         "node_modules/@cnakazawa/watch": {
             "version": "1.0.4",
@@ -3361,17 +3350,6 @@
                 "react": "^17.0.0"
             }
         },
-        "node_modules/@mui/x-data-grid/node_modules/@babel/runtime": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-            "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@mui/x-data-grid/node_modules/@material-ui/utils": {
             "version": "5.0.0-beta.5",
             "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-5.0.0-beta.5.tgz",
@@ -3399,11 +3377,6 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        },
-        "node_modules/@mui/x-data-grid/node_modules/regenerator-runtime": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
         },
         "node_modules/@musement/iso-duration": {
             "version": "1.0.0",
@@ -4373,6 +4346,13 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@scarf/scarf": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+            "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/@semantic-release/changelog": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.1.tgz",
@@ -5239,1337 +5219,679 @@
             }
         },
         "node_modules/@swagger-api/apidom-ast": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-SAOQrFSFwgDiI4QSIPDwAIJEb4Za+8bu45sNojgV3RMtCz+n4Agw66iqGsDib5YSI/Cg1h4AKFovT3iWdfGWfw==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.10.2.tgz",
+            "integrity": "sha512-vTl8gWyeZaj887/NSWYs3as4K8wXHar5wY/606XRBjR2UgmJBokBgKjq7S23LW9tsYjsT4MjQKC8idjgw17xvg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-error": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "unraw": "^3.0.0"
             }
         },
-        "node_modules/@swagger-api/apidom-ast/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ast/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ast/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        },
         "node_modules/@swagger-api/apidom-core": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-vGl8BWRf6ODl39fxElcIOjRE2QG5AJhn8tTNMqjjHB/2WppNBuxOVStYZeVJoWfK03OPK8v4Fp/TAcaP9+R7DQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.10.2.tgz",
+            "integrity": "sha512-qryNBGHNWDvSRyK1w5rox0UOrHrVBjZOHgeXFpGHF+oBO7ntSc/H7BSiYMDR+KQESkzMcAxn4tZMLYItaBt06w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "minim": "~0.23.8",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
-                "short-unique-id": "^5.0.2",
+                "short-unique-id": "^5.3.2",
                 "ts-mixer": "^6.0.3"
             }
         },
-        "node_modules/@swagger-api/apidom-core/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-core/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-core/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        },
         "node_modules/@swagger-api/apidom-error": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-FU/2sFSgsICB9HYFELJ79caRpXXzlAV41QTHsAM46WfRehbzZUQpOBQm4jRi3qJGSa/Jk+mQ7Vt8HLRFMpJFfg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.10.2.tgz",
+            "integrity": "sha512-SWyPyL5xwTUsDzPi0A5zwTFwqPezvlwj4opEqruqjESNTYupUA7+vt4Mdj7IlDaRYRG1qyCWQgKhIBXznVUD4w==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.20.7"
             }
         },
-        "node_modules/@swagger-api/apidom-error/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-error/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-error/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        },
         "node_modules/@swagger-api/apidom-json-pointer": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-/W8Ktbgbs29zdhed6KHTFk0qmuIRbvEFi8wu2MHGQ5UT4i99Bdu2OyUiayhnpejWztfQxDgL08pjrQPEwgY8Yg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.10.2.tgz",
+            "integrity": "sha512-zySHPqIXF4HZ3VWbHwTxO+H1e9dJw7mGHzoX+tZjx5wVyLQO3kZDCAAXzz3c3/TIY21Y2Zkpkez3q9hjFyuLvQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@types/ramda": "~0.30.0",
-                "ramda": "~0.30.0",
-                "ramda-adjunct": "^5.0.0"
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swaggerexpert/json-pointer": "^2.10.1"
             }
-        },
-        "node_modules/@swagger-api/apidom-json-pointer/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-json-pointer/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-json-pointer/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-aduC2vbwGgn6ia9IkKpqBYBaKyIDGM/80M3oU3DFgaYIIwynzuwVpN1TkBOLIFy3mAzkWoYKUS0jdZJhMy/6Ug==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.10.2.tgz",
+            "integrity": "sha512-MsZ4GWmWN7wkWv7G9Pwk8sHU1j0bwk7xoGeaZmNCylbTfYvGkg6jJGMHdAdQNCQXbbpfLeKt1O+3YCN//JUQ7w==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
             }
         },
-        "node_modules/@swagger-api/apidom-ns-api-design-systems/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-ns-arazzo-1": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.10.2.tgz",
+            "integrity": "sha512-fQSwDlIR85tbnLXAjtV/ypSGUBfrzFcZ4NbH6BL1DSTR4uEunVxAULdD4wlhCt9gGNDl/zxZD3vQtlYDkXDFmw==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
             }
-        },
-        "node_modules/@swagger-api/apidom-ns-api-design-systems/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-api-design-systems/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-hZjxXJgMt517ADnAauWJh01k7WNRwkbWT5p6b7AXF2H3tl549A2hhLnIg3BBSE3GwB3Nv25GyrI3aA/1dFVC8A==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.10.2.tgz",
+            "integrity": "sha512-obWHe3pyAj65Nf9ISwnbtJ4C5mZ15C6mtQXxzHVW5maVZqlqt3s/YbPY87EqK9ArdNOwOZHkQt2Uth02GMmjxA==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
             }
         },
-        "node_modules/@swagger-api/apidom-ns-asyncapi-2/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.10.2.tgz",
+            "integrity": "sha512-yqNmXeObF2OLAusgGEapXz2CrGjXwkcfG3DYcQDtOvgRytvGZxC2EkCUR+wEXCVNYhoJ7QpVzzTJOHs3jOvptg==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
             }
         },
-        "node_modules/@swagger-api/apidom-ns-asyncapi-2/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
+        "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.10.2.tgz",
+            "integrity": "sha512-I1FaBoDFMjybF4QVsesIYl8OilkwycZ0mQ0jf1P++zfTRG27uIePB8M+Iuj6iqMsE3qpkjjJJ6ZLnrLPdKvmRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
             }
         },
-        "node_modules/@swagger-api/apidom-ns-asyncapi-2/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
+        "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.10.2.tgz",
+            "integrity": "sha512-lg9XfRlJRNoBa2EDGpEFc7HvFV39G6RG0/SbjQY0BE/WZer10wmfTCU7l3RUNJXRFGKH6/O/nsYgP7AFjTanXQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-OfX4UBb08C0xD5+F80dQAM2yt5lXxcURWkVEeCwxz7i23BB3nNEbnZXNV91Qo9eaJflPh8dO9iiHQxvfw5IgSg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.10.2.tgz",
+            "integrity": "sha512-C50KnSKynrmHky/oOB6+hHyZVpwng78Fz5aZjay3h8X5C/PJHmm3sDJFvF3/9wkYHO3N9sPp7cpu4Xm9VJ4/wQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.4"
             }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-4/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-4/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-4/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-qzUVRSSrnlYGMhK6w57o/RboNvy1FO0iFgEnTk56dD4wN49JRNuFqKI18IgXc1W2r9tTTG70nG1khe4cPE8TNg==",
-            "optional": true,
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.10.2.tgz",
+            "integrity": "sha512-/wiP8+2lF8UJRrkoQ9HvKnMbnqijk2uY/hAg+/Bo73T9NGKkEa29jYVUKYNYj7gJBw4hhkUHfHFWuZUpxPC4ZA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.4"
             }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-6/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-6/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-6/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-Zml8Z8VCckdFjvTogaec1dabd85hg1+xZDseWcCuD0tYkaTY/sZ8zzI0dz6/4HsKCb58qjiWSa0w60N8Syr6WQ==",
-            "optional": true,
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.10.2.tgz",
+            "integrity": "sha512-firN/uvnVxQgACqcyzV3NU9qjbMvNMJkpmm3wOat3URmaFMaFBT3qjbU1pFHBGbnXI3+I9pQJZHmJSwqNzfUbQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.4"
             }
         },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-7/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-7/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-json-schema-draft-7/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
-        },
         "node_modules/@swagger-api/apidom-ns-openapi-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-WUZxt7Gs7P4EQsGtoD6cKAjf0uDJhkUxsIW9Bb4EAgO6tdp7LlXhbJ0fJ2QycCLY717SfJbvGLfhuSfTYo4Iow==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.10.2.tgz",
+            "integrity": "sha512-FK5kYvo/1uwAByumRVRsynBlnKxUUImfsjPEFgRCW6yhbCGRqN47NaZ7GYFHpbhjC3OmMN5/etYj6B0jnZx7Gg==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
             }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-2/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-2/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-2/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-7ra5uoZGrfCn1LabfJLueChPcYXyg24//LCYBtjTstyueqd5Vp7JCPeP5NnJSAaqVAP47r8ygceBPoxNp9k1EQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.10.2.tgz",
+            "integrity": "sha512-ziyv85QbJYHRdc9oTEFBy3pxwxg7BW/a9GrwH01/SmuXVQPjLjwzRb+SjCxLogJppm0yjxOkDFI2VWPp2RADFg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
             }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-3-0/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-3-0/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-3-0/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-nQOwNQgf0C8EVjf2loAAl4ifRuVOdcqycvXUdcTpsUfHN3fbndR8IKpb26mQNmnACmqgmX+LkbMdW9b+K6089g==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.10.2.tgz",
+            "integrity": "sha512-ngcmO4dH77JT5hZB04OJdyTzgKnt2lNhAZQ+4wXjum/xhszjUmDhOeYfXdHw3Lm7MxsEsTesWzLYQ5LKADc41A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
             }
         },
-        "node_modules/@swagger-api/apidom-ns-openapi-3-1/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.10.2.tgz",
+            "integrity": "sha512-3SWJ5ipWwn+w11HTUESWex/522jy2aGLzBqqMgH36sy+Wdwx+9Mw2bgSDqkxmNC5+jpzOGUOIWoQAMuCpS/Gzg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-3-1/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-openapi-3-1/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        },
-        "node_modules/@swagger-api/apidom-ns-workflows-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-yKo0p8OkQmDib93Kt1yqWmI7JsD6D9qUHxr/SCuAmNNWny1hxm7cZGoKJwJlGd0uAg84j4vmzWOlG3AsJbnT8g==",
-            "optional": true,
-            "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
             }
-        },
-        "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-xfVMR4HrTzXU0HB4TtxwkNbUIa/cQrPa0BWutJZ0fMYMAtUox2s8GsFYnJfZP52XfpSHFM1VPclivorZqET14g==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.10.2.tgz",
+            "integrity": "sha512-kzhJUGzsJ38Uohj5xRQDkQC08rqNhatbqgD30LZ0/UWryJ9nAsjqK2ovuP9t+5WKcDE4iwcYeGSt1NA2XgEZwg==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-lJZkrhZ8qRTtc5fSLKefCv8j7Xzo8UBfMjpqTJhmETAtU8YfVV2i2znjgxJpm0QwV6FVQqGfK1+ASZQWPLiVcA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.10.2.tgz",
+            "integrity": "sha512-i3CmSxJ/iG67ybRDAJ9xpuMrOMFvC/obX2lI36E0VZzBTb+llw4Zd5qFmBqNnImLpwdmk11Z1V7i+5HM+J7ijQ==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.10.2.tgz",
+            "integrity": "sha512-HwiUkwvo5i2hV2SS6KWrdj62BdceZGfhuXhr1il8akWekpU4jXPtr5pv4gOnKKJN7VgjAmwt/DlcCSRo1+9jVA==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
+        "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.10.2.tgz",
+            "integrity": "sha512-w8VTVuE7GPbRqWxvMgRoTb726JRsMhFPMfTBf8+MJ4pQThjk78dSXPV2Zlse71b2DWBuQy2sr6zGyLUNs/3ePQ==",
+            "license": "Apache-2.0",
             "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-65nmKdPzw4C1bmtYn+3zoxXCI6Gnobr0StI9XE0YWiK+lpso7RH3Cgyl1yPZ0DBRVGzP+Fn9FVzmDNulEfR95w==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.10.2.tgz",
+            "integrity": "sha512-FDNjqmn2vV1jFoVVwQDO0XPPm8R5xzmcyY/6yBLFmKZADin3smSKVZ+njYHmfRjpspXwN0AwI0drdvuH0FZLJg==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.10.2.tgz",
+            "integrity": "sha512-x/0vM2nDDzYzFnXr69+so/KSH+2py2TiZd1K49pWcX8cHsPV1Y4Ppih7GVOMymd8m/IOCjLYlV7qt4eWDwdldg==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-RLI4FpVB3vB6mIuT77yrsv5V2LMZ80dW9XpV+Fmbd4Jkdj+ysAFwT38cI4AsUMOxixpTDIXY1oWD7AjvylHhQQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.10.2.tgz",
+            "integrity": "sha512-2bVACmU9ZmAVVnqQWSc3Bs+xG0HHLU1tfZbYL8xNgSi8kw4HcnejF5mWtN+MLFzTaBmWCi2In7P7BYNR8+2Dyg==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.10.2.tgz",
+            "integrity": "sha512-oHpbf+iqBcDS3qtsipMpgCwAeckKMxg0qFKYTCRZyJdctRgupJTxVeir6t/SGo0Ny0a1iknt2LN0u5frEen0kg==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-json": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-aOewp8/3zobf/O+5Jx8y7+bX3BPRfRlHIv15qp4YVTsLs6gLISWSzTO9JpWe9cR+AfhpsAalFq4t1LwIkmLk4A==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.10.2.tgz",
+            "integrity": "sha512-VnwEkarKfsJYRF0zCI9AGiSIyBUXqS2d32KQuhVCt/HeuF1XO9sjeLjGiosA/24YVOnO0ul5TpiNFQn0pw89mA==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
-                "tree-sitter": "=0.20.4",
-                "tree-sitter-json": "=0.20.2",
-                "web-tree-sitter": "=0.20.3"
+                "tree-sitter": "=0.21.1",
+                "tree-sitter-json": "=0.24.8",
+                "web-tree-sitter": "=0.24.5"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-zgtsAfkplCFusX2P/saqdn10J8P3kQizCXxHLvxd2j0EhMJk2wfu4HYN5Pej/7/qf/OR1QZxqtacwebd4RfpXA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.10.2.tgz",
+            "integrity": "sha512-+d/o/8TrNBjvFzgPb0RQhrCc8gOWnrHZF+xvCO5gwp+4MUr1XP1AJIox1e6t1SO+j7IQjiF2ocx2r7eFE5QC7w==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-iPuHf0cAZSUhSv8mB0FnVgatTc26cVYohgqz2cvjoGofdqoh5KKIfxOkWlIhm+qGuBp71CfZUrPYPRsd0dHgeg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.10.2.tgz",
+            "integrity": "sha512-3ieUeX8/WywkUzdOO1U1QKQDNmpZFfOeTAeb4ISDd/PKOVwuEx/b0w5I8EuOu97tKAe3UUesEdii+pJlkcFlFw==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-jwkfO7tzZyyrAgok+O9fKFOv1q/5njMb9DBc3D/ZF3ZLTcnEw8uj4V2HkjKxUweH5k8ip/gc8ueKmO/i7p2fng==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.10.2.tgz",
+            "integrity": "sha512-z0c7IgMPLSDhE+ldTb54Xlhq+yPF0w/8LHXyeHX4V6BS1VG3Utb+mM/qTVfy1Eo+p1KGNlwNDEPsBp6jIaVb5Q==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.10.2.tgz",
+            "integrity": "sha512-bx/kEIXWtpHu+4LEiyNdt0v8ER5EVwPjhQdlpOaC5qghnRH9aUYOTawZtVHsNHAQWTIMNn9DdPKYQgttQKD0Pw==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-jEIDpjbjwFKXQXS/RHJeA4tthsguLoz+nJPYS3AOLfuSiby5QXsKTxgqHXxG/YJqF1xJbZL+5KcF8UyiDePumw==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.10.2.tgz",
+            "integrity": "sha512-e86JUXHGGEVsO4/xpy/GRSvYXGN30hLt1lMUhjzCFuE95N6/K3hmQHE3rA/H7ot1ajCWUhzukW5rGQac79NIjA==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-ieJL8dfIF8fmP3uJRNh/duJa3cCIIv6MzUe6o4uPT/oTDroy4qIATvnq9Dq/gtAv6rcPRpA9VhyghJ1DmjKsZQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.10.2.tgz",
+            "integrity": "sha512-ucfc13Ai31tJ0ruAm1YiHhqENgcBuiOXL00OhoICWA56ggAcnA5WfWmvtsXVMlZsTHVbhZP3XpsH5rui2N8u5w==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-EatIH7PZQSNDsRn9ompc62MYzboY7wAkjfYz+2FzBaSA8Vl5/+740qGQj22tu/xhwW4K72aV2NNL1m47QVF7hA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.10.2.tgz",
+            "integrity": "sha512-7o8j93qgf9yYAaaJ/GpH+5sB3fC9EmvmjTCqlw5YWXp+cRgCn9q7f80Sv4+NjbracUafB6qL4i9F/m+Xs0XZaQ==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.10.2.tgz",
+            "integrity": "sha512-blDIeVmo8bpXYV/C+b6PYi54yS+5jPEZTFsK5jQ2NzpCPrkBPacp/KTuHBUBzJsYj4bj/ivRL3+JXGw4YovUHw==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-LylC2cQdAmvR7bXqwMwBt6FHTMVGinwIdI8pjl4EbPT9hCVm1rdED53caTYM4gCm+CJGRw20r4gb9vn3+N6RrA==",
-            "optional": true,
-            "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-TlA4+1ca33D7fWxO5jKBytSCv86IGI4Lze4JfrawWUXZ5efhi4LiNmW5TrGlZUyvL7yJtZcA4tn3betlj6jVwA==",
-            "optional": true,
-            "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
-                "@types/ramda": "~0.30.0",
-                "ramda": "~0.30.0",
-                "ramda-adjunct": "^5.0.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "optional": true,
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-jSIHEB7lbh+MP3BhYIXFkeivDR01kugXN70e5FskW7oet2TIARsVEPheWKQFSP1U8bUZA4bsp9h9gOQ9xEeErw==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.10.2.tgz",
+            "integrity": "sha512-I5eCls8XS3SVEwH/cuL6T3iar1TPaFYh3gXwS/2rzP1aZQNKSHDP3y3ney7nAomKG4dFvE8Q248FL36arG7T/w==",
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
-                "tree-sitter": "=0.20.4",
-                "tree-sitter-yaml": "=0.5.0",
-                "web-tree-sitter": "=0.20.3"
+                "tree-sitter": "=0.22.4",
+                "web-tree-sitter": "=0.24.5"
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
+            "version": "0.22.4",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+            "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+            "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "node-addon-api": "^8.3.0",
+                "node-gyp-build": "^4.8.4"
             }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "optional": true
         },
         "node_modules/@swagger-api/apidom-reference": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-KQ6wB5KplqdSsjxdA8BaQulj5zlF5VBCd5KP3RN/9vvixgsD/gyrVY59nisdzmPTqiL6yjhk612eQ96MgG8KiA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.10.2.tgz",
+            "integrity": "sha512-H5UqOmae9CXdiLJbbh1j+/hwvcECmr6ci2XtUKTQpFviemvsIDZmPV1DKUAxCfzGr2iOkDO6SZc+/OEWlETqiQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
                 "@types/ramda": "~0.30.0",
-                "axios": "^1.4.0",
-                "minimatch": "^7.4.3",
-                "process": "^0.11.10",
+                "axios": "^1.15.0",
+                "minimatch": "^10.2.1",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             },
             "optionalDependencies": {
-                "@swagger-api/apidom-error": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-workflows-json-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1"
-            }
-        },
-        "node_modules/@swagger-api/apidom-reference/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-reference/node_modules/axios": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2"
             }
         },
         "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@swagger-api/apidom-reference/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/@swagger-api/apidom-reference/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@swagger-api/apidom-reference/node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
+                "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": ">= 6"
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": ">=10"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/@swagger-api/apidom-reference/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        "node_modules/@swaggerexpert/cookie": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-2.0.2.tgz",
+            "integrity": "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "apg-lite": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
         },
-        "node_modules/@swagger-api/apidom-reference/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        "node_modules/@swaggerexpert/json-pointer": {
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
+            "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "apg-lite": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
         },
         "node_modules/@tanstack/query-core": {
             "version": "4.29.19",
@@ -6860,6 +6182,26 @@
             "dev": true,
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+            "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-addon-api": "^8.3.1",
+                "node-gyp-build": "^4.8.4"
+            },
+            "peerDependencies": {
+                "tree-sitter": "^0.22.4"
+            },
+            "peerDependenciesMeta": {
+                "tree-sitter": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@trysound/sax": {
@@ -7281,6 +6623,12 @@
             "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
             "dev": true
         },
+        "node_modules/@types/prismjs": {
+            "version": "1.26.6",
+            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+            "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+            "license": "MIT"
+        },
         "node_modules/@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -7296,6 +6644,7 @@
             "version": "0.30.2",
             "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
             "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
+            "license": "MIT",
             "dependencies": {
                 "types-ramda": "^0.30.1"
             }
@@ -7506,6 +6855,13 @@
             "dependencies": {
                 "@types/jest": "*"
             }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/unist": {
             "version": "2.0.6",
@@ -8607,11 +7963,6 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
-        "node_modules/@yarnpkg/lockfile": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
-        },
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -8899,9 +8250,10 @@
             }
         },
         "node_modules/apg-lite": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.4.tgz",
-            "integrity": "sha512-B32zCN3IdHIc99Vy7V9BaYTUzLeRA8YXYY1aQD1/5I2aqIrO0coi4t6hJPqMisidlBxhyME8UexkHt31SlR6Og=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
+            "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/aproba": {
             "version": "2.0.0",
@@ -9173,6 +8525,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -9198,10 +8551,13 @@
             }
         },
         "node_modules/available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-            "dev": true,
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -9225,41 +8581,26 @@
             "dev": true
         },
         "node_modules/axios": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "node_modules/axios/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -9267,9 +8608,13 @@
             }
         },
         "node_modules/axios/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/babel-jest": {
             "version": "26.6.3",
@@ -9723,17 +9068,6 @@
             "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
             "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
         },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "optional": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
         "node_modules/blob-util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -9856,6 +9190,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9864,12 +9199,14 @@
         "node_modules/brace-expansion/node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
         },
         "node_modules/braces": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -9936,7 +9273,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -10223,13 +9560,47 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-            "dev": true,
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "license": "MIT",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -10376,6 +9747,7 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
             "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -10385,6 +9757,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
             "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -10394,6 +9767,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
             "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -10514,9 +9888,10 @@
             }
         },
         "node_modules/classnames": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-            "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+            "license": "MIT"
         },
         "node_modules/clean-css": {
             "version": "4.2.4",
@@ -11004,7 +10379,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "node_modules/connect-history-api-fallback": {
             "version": "1.6.0",
@@ -11550,11 +10926,11 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.0.tgz",
-            "integrity": "sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==",
-            "dev": true,
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
             "hasInstallScript": true,
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -11596,6 +10972,7 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -12272,21 +11649,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "optional": true,
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/deep-equal": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
@@ -12313,32 +11675,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/deep-equal/node_modules/get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/deep-equal/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/deep-equal/node_modules/isarray": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -12360,10 +11696,10 @@
             "dev": true
         },
         "node_modules/deepmerge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-            "dev": true,
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12440,6 +11776,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -12626,15 +11963,6 @@
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/detect-libc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/detect-newline": {
@@ -12830,9 +12158,13 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-            "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "node_modules/domutils": {
             "version": "2.8.0",
@@ -12897,6 +12229,20 @@
             "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/duplexer": {
@@ -13023,7 +12369,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -13215,32 +12561,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es-abstract/node_modules/get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-abstract/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/es-abstract/node_modules/object-inspect": {
             "version": "1.12.2",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -13251,57 +12571,19 @@
             }
         },
         "node_modules/es-define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-            "dependencies": {
-                "get-intrinsic": "^1.2.4"
-            },
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-define-property/node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-define-property/node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-define-property/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -13336,6 +12618,33 @@
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
             "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
             "dev": true
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/es-shim-unscopables": {
             "version": "1.0.0",
@@ -14153,15 +13462,6 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
-        "node_modules/expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "optional": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/expect": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
@@ -14478,7 +13778,8 @@
         "node_modules/fast-json-patch": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+            "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -14511,6 +13812,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
             "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+            "license": "MIT",
             "dependencies": {
                 "format": "^0.2.0"
             },
@@ -14600,6 +13902,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -14676,14 +13979,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dependencies": {
-                "micromatch": "^4.0.2"
-            }
-        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -14728,16 +14023,16 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
-            "dev": true,
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -14753,12 +14048,18 @@
             "integrity": "sha512-PxpFaesCSsDwaciw7MF6B2thUkH7skqZlz4BzUnvapR6+Es2877q7ru/tqfsITuaraPz+TGfsOfdtU4D0qjqEw=="
         },
         "node_modules/for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dev": true,
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "license": "MIT",
             "dependencies": {
-                "is-callable": "^1.1.3"
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/for-in": {
@@ -15029,16 +14330,11 @@
                 }
             ]
         },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "optional": true
-        },
         "node_modules/fs-extra": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
             "dependencies": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
@@ -15082,7 +14378,8 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -15099,9 +14396,13 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.5",
@@ -15207,14 +14508,24 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-            "dev": true,
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -15233,6 +14544,19 @@
             "dev": true,
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stdin": {
@@ -15362,12 +14686,6 @@
                 "xtend": "~4.0.1"
             }
         },
-        "node_modules/github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "optional": true
-        },
         "node_modules/gitignore-to-glob": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/gitignore-to-glob/-/gitignore-to-glob-0.3.0.tgz",
@@ -15382,6 +14700,7 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -15513,33 +14832,10 @@
             "dev": true
         },
         "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/gopd/node_modules/get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/gopd/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -15550,7 +14846,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "node_modules/growly": {
             "version": "1.3.0",
@@ -15620,6 +14917,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -15646,33 +14944,22 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-            "dev": true,
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-proto": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-            "engines": {
-                "node": ">= 0.4"
+                "es-define-property": "^1.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-            "dev": true,
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -15681,25 +14968,13 @@
             }
         },
         "node_modules/has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-            "dev": true,
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
             },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -15777,9 +15052,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -15787,21 +15063,26 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/hasown/node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/hast-util-parse-selector": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-            "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector/node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
             }
         },
         "node_modules/hast-util-whitespace": {
@@ -15814,46 +15095,36 @@
             }
         },
         "node_modules/hastscript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
-            "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "comma-separated-tokens": "^1.0.0",
-                "hast-util-parse-selector": "^2.0.0",
-                "property-information": "^5.0.0",
-                "space-separated-tokens": "^1.0.0"
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/hastscript/node_modules/comma-separated-tokens": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-            "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
+        "node_modules/hastscript/node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
             }
         },
         "node_modules/hastscript/node_modules/property-information": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
-            "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-            "dependencies": {
-                "xtend": "^4.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/hastscript/node_modules/space-separated-tokens": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-            "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+            "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -15877,9 +15148,16 @@
             "version": "10.7.3",
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
             "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/highlightjs-vue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+            "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+            "license": "CC0-1.0"
         },
         "node_modules/history": {
             "version": "5.3.0",
@@ -16266,22 +15544,6 @@
                 "@babel/runtime": "^7.14.6"
             }
         },
-        "node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-            "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
-            "dependencies": {
-                "regenerator-runtime": "^0.13.10"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/i18next-browser-languagedetector/node_modules/regenerator-runtime": {
-            "version": "0.13.10",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-            "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
-        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -16487,6 +15749,7 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -16501,7 +15764,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/init-package-json": {
             "version": "3.0.2",
@@ -16649,6 +15912,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
             "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -16658,6 +15922,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
             "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+            "dev": true,
             "dependencies": {
                 "is-alphabetical": "^1.0.0",
                 "is-decimal": "^1.0.0"
@@ -16739,7 +16004,6 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -16827,6 +16091,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
             "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -16859,6 +16124,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
             "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -16936,6 +16202,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
             "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -17002,6 +16269,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -17178,18 +16446,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-symbol/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-text-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
@@ -17203,16 +16459,12 @@
             }
         },
         "node_modules/is-typed-array": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-            "dev": true,
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "license": "MIT",
             "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
+                "which-typed-array": "^1.1.16"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -17286,6 +16538,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
             "dependencies": {
                 "is-docker": "^2.0.0"
             },
@@ -17302,7 +16555,8 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "node_modules/isobject": {
             "version": "3.0.1",
@@ -19232,88 +18486,11 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
-        "node_modules/json-stable-stringify": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
-            "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "isarray": "^2.0.5",
-                "jsonify": "^0.0.1",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
-        },
-        "node_modules/json-stable-stringify/node_modules/call-bind": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/json-stable-stringify/node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/json-stable-stringify/node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/json-stable-stringify/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/json-stable-stringify/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/json-stringify-nice": {
             "version": "1.1.4",
@@ -19420,19 +18597,12 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
             "dependencies": {
                 "universalify": "^2.0.0"
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonify": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/jsonparse": {
@@ -19599,14 +18769,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/klaw-sync": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-            "dependencies": {
-                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/kleur": {
@@ -20582,9 +19744,10 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "license": "MIT"
         },
         "node_modules/lodash.capitalize": {
             "version": "4.2.1",
@@ -20783,6 +19946,7 @@
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
             "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+            "license": "MIT",
             "dependencies": {
                 "fault": "^1.0.0",
                 "highlight.js": "~10.7.0"
@@ -21047,6 +20211,15 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.4.0.tgz",
             "integrity": "sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw=="
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/mathml-tag-names": {
             "version": "2.1.3",
@@ -21963,6 +21136,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
             "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "dev": true,
             "dependencies": {
                 "braces": "^3.0.1",
                 "picomatch": "^2.0.5"
@@ -22011,18 +21185,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "optional": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -22036,6 +21198,7 @@
             "version": "0.23.8",
             "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
             "integrity": "sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.15.0"
             },
@@ -22053,6 +21216,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -22063,7 +21227,8 @@
         "node_modules/minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
         },
         "node_modules/minimist-options": {
             "version": "4.1.0",
@@ -22302,12 +21467,6 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "optional": true
-        },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
@@ -22390,12 +21549,6 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
-        "node_modules/nan": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-            "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
-            "optional": true
-        },
         "node_modules/nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -22430,12 +21583,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/napi-build-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "optional": true
-        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -22461,6 +21608,7 @@
             "version": "0.6.18",
             "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
             "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 10"
             }
@@ -22487,39 +21635,27 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node_modules/node-abi": {
-            "version": "3.67.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
-            "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
-            "optional": true,
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-abi/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "optional": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/node-abort-controller": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+            "license": "MIT"
+        },
+        "node_modules/node-addon-api": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": "^18 || ^20 || >= 21"
+            }
         },
         "node_modules/node-domexception": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
             "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
             "funding": [
                 {
                     "type": "github",
@@ -22530,6 +21666,7 @@
                     "url": "https://paypal.me/jimmywarting"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=10.5.0"
             }
@@ -22567,6 +21704,7 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
             "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
+            "license": "MIT",
             "dependencies": {
                 "node-domexception": "^1.0.0",
                 "web-streams-polyfill": "^3.0.3"
@@ -22632,6 +21770,18 @@
             },
             "engines": {
                 "node": "^12.22 || ^14.13 || >=16"
+            }
+        },
+        "node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
             }
         },
         "node_modules/node-gyp/node_modules/nopt": {
@@ -23854,6 +23004,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -23897,18 +23048,6 @@
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object.assign/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -24007,6 +23146,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -24044,22 +23184,24 @@
             }
         },
         "node_modules/openapi-path-templating": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-1.6.0.tgz",
-            "integrity": "sha512-1atBNwOUrZXthTvlvvX8k8ovFEF3iA8mDidYMkdOtvVdndBhTrspbwGXNOzEUaJhm9iUl4Tf5uQaeTLAJvwPig==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-2.2.1.tgz",
+            "integrity": "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "apg-lite": "^1.0.3"
+                "apg-lite": "^1.0.4"
             },
             "engines": {
                 "node": ">=12.20.0"
             }
         },
         "node_modules/openapi-server-url-templating": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.1.0.tgz",
-            "integrity": "sha512-dtyTFKx2xVcO0W8JKaluXIHC9l/MLjHeflBaWjiWNMCHp/TBs9dEjQDbj/VFlHR4omFOKjjmqm1pW1aCAhmPBg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.3.0.tgz",
+            "integrity": "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "apg-lite": "^1.0.3"
+                "apg-lite": "^1.0.4"
             },
             "engines": {
                 "node": ">=12.20.0"
@@ -24089,14 +23231,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/ospath": {
@@ -24344,6 +23478,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
             "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+            "dev": true,
             "dependencies": {
                 "character-entities": "^1.0.0",
                 "character-entities-legacy": "^1.0.0",
@@ -24409,169 +23544,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/patch-package": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
-            "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
-            "dependencies": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "ci-info": "^3.7.0",
-                "cross-spawn": "^7.0.3",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "json-stable-stringify": "^1.0.2",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^7.5.3",
-                "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^2.2.2"
-            },
-            "bin": {
-                "patch-package": "index.js"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">5"
-            }
-        },
-        "node_modules/patch-package/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/patch-package/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/patch-package/node_modules/ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/patch-package/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/patch-package/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "node_modules/patch-package/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/patch-package/node_modules/open": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-            "dependencies": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/patch-package/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/patch-package/node_modules/slash": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/patch-package/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/patch-package/node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
-        "node_modules/patch-package/node_modules/yaml": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -24585,6 +23557,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -24599,6 +23572,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -24680,6 +23654,7 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
             "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -24955,6 +23930,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.3.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
@@ -25101,32 +24085,6 @@
             "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
             "dev": true
         },
-        "node_modules/prebuild-install": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-            "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
-            "optional": true,
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^1.0.1",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            },
-            "bin": {
-                "prebuild-install": "bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -25238,9 +24196,10 @@
             }
         },
         "node_modules/prismjs": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-            "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -25258,6 +24217,7 @@
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -25412,7 +24372,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -25500,6 +24460,7 @@
             "version": "0.30.1",
             "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
             "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/ramda"
@@ -25509,6 +24470,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
             "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.3"
             },
@@ -25585,7 +24547,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -25600,7 +24562,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -25801,17 +24763,6 @@
                 "react-native": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/react-i18next/node_modules/@babel/runtime": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-            "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
-            "dependencies": {
-                "regenerator-runtime": "^0.13.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/react-immutable-proptypes": {
@@ -26221,15 +25172,20 @@
             }
         },
         "node_modules/react-syntax-highlighter": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
-            "integrity": "sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==",
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+            "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.3.1",
+                "@babel/runtime": "^7.28.4",
                 "highlight.js": "^10.4.1",
+                "highlightjs-vue": "^1.0.0",
                 "lowlight": "^1.17.0",
-                "prismjs": "^1.27.0",
-                "refractor": "^3.6.0"
+                "prismjs": "^1.30.0",
+                "refractor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 16.20.2"
             },
             "peerDependencies": {
                 "react": ">= 0.14.0"
@@ -26589,7 +25545,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -26682,12 +25638,10 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/redux": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-            "dependencies": {
-                "@babel/runtime": "^7.9.2"
-            }
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
         },
         "node_modules/redux-immutable": {
             "version": "4.0.0",
@@ -26698,25 +25652,111 @@
             }
         },
         "node_modules/refractor": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
-            "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+            "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+            "license": "MIT",
             "dependencies": {
-                "hastscript": "^6.0.0",
-                "parse-entities": "^2.0.0",
-                "prismjs": "~1.27.0"
+                "@types/hast": "^3.0.0",
+                "@types/prismjs": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "parse-entities": "^4.0.0"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/refractor/node_modules/prismjs": {
-            "version": "1.27.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-            "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-            "engines": {
-                "node": ">=6"
+        "node_modules/refractor/node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/refractor/node_modules/character-entities-legacy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/refractor/node_modules/character-reference-invalid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/refractor/node_modules/is-alphabetical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/refractor/node_modules/is-alphanumerical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-alphabetical": "^2.0.0",
+                "is-decimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/refractor/node_modules/is-decimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/refractor/node_modules/is-hexadecimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/refractor/node_modules/parse-entities": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "character-entities-legacy": "^3.0.0",
+                "character-reference-invalid": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "is-alphanumerical": "^2.0.0",
+                "is-decimal": "^2.0.0",
+                "is-hexadecimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/regenerate": {
@@ -27256,6 +26296,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -27338,32 +26379,6 @@
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.3",
                 "is-regex": "^1.1.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/safe-regex-test/node_modules/get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/safe-regex-test/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -28454,6 +27469,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -28464,54 +27480,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/set-function-length/node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/set-function-length/node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/set-function-length/node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/set-function-length/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/set-value": {
@@ -28548,16 +27516,44 @@
             "dev": true
         },
         "node_modules/sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+            "license": "(MIT AND BSD-3-Clause)",
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
             },
             "bin": {
                 "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/sha.js/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
@@ -28580,6 +27576,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -28591,6 +27588,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -28603,9 +27601,10 @@
             "optional": true
         },
         "node_modules/short-unique-id": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.2.0.tgz",
-            "integrity": "sha512-cMGfwNyfDZ/nzJ2k2M+ClthBIh//GlZl1JEf47Uoa9XR11bz8Pa2T2wQO4bVrRdH48LrIDWJahQziKo3MjhsWg==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
+            "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==",
+            "license": "Apache-2.0",
             "bin": {
                 "short-unique-id": "bin/short-unique-id",
                 "suid": "bin/short-unique-id"
@@ -28655,51 +27654,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "optional": true
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "optional": true,
-            "dependencies": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
             }
         },
         "node_modules/sirv": {
@@ -29368,7 +28322,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -29377,7 +28331,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -29443,18 +28397,6 @@
                 "internal-slot": "^1.0.3",
                 "regexp.prototype.flags": "^1.4.1",
                 "side-channel": "^1.0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.matchall/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -30049,75 +28991,43 @@
             }
         },
         "node_modules/swagger-client": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.29.2.tgz",
-            "integrity": "sha512-7dOIAodJeUsYbvWTpDODY2+bfJcZ34WG84TByMet76OJ/ZjOLHZtJSgMFxEvnh9+yR0qn8wvHUdfg27ylg2eiQ==",
+            "version": "3.37.2",
+            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.2.tgz",
+            "integrity": "sha512-KcB8psL1On4GWwv9Ribp1oteh50ygNnAyvQbd5MwiXMGkcB4f53rkZEdvZKPDdJO764mQjgErxQEGDVw6QBUMQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.22.15",
-                "@swagger-api/apidom-core": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-error": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-reference": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "cookie": "~0.6.0",
+                "@scarf/scarf": "=1.4.0",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-reference": "^1.10.2",
+                "@swaggerexpert/cookie": "^2.0.2",
                 "deepmerge": "~4.3.0",
                 "fast-json-patch": "^3.0.0-1",
                 "js-yaml": "^4.1.0",
                 "neotraverse": "=0.6.18",
                 "node-abort-controller": "^3.1.1",
                 "node-fetch-commonjs": "^3.3.2",
-                "openapi-path-templating": "^1.5.1",
-                "openapi-server-url-templating": "^1.0.0",
-                "ramda-adjunct": "^5.0.0"
-            }
-        },
-        "node_modules/swagger-client/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "openapi-path-templating": "^2.2.1",
+                "openapi-server-url-templating": "^1.3.0",
+                "ramda": "^0.30.1",
+                "ramda-adjunct": "^5.1.0"
             }
         },
         "node_modules/swagger-client/node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "node_modules/swagger-client/node_modules/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/swagger-client/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/swagger-client/node_modules/deepmerge": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
         },
         "node_modules/swagger-client/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -30125,29 +29035,25 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/swagger-client/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        },
         "node_modules/swagger-ui-react": {
-            "version": "5.10.5",
-            "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.10.5.tgz",
-            "integrity": "sha512-uBQLku4j3L1NC4/xE3HTgz1EcFisBphh8AnGqbj9LMxeGGcpKOlx/ZDigRAeVXWr9jOnZZbeGBzMe4NVHxPZrQ==",
+            "version": "5.32.4",
+            "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.4.tgz",
+            "integrity": "sha512-OsTqKCiDT/o8/oqZbt+p1djPkrOk3unKK/7+wGvP1+WY6pOzFoDLM4D39cNFtpIArtlg9uoK6MKIz3W00WX8qw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime-corejs3": "^7.23.5",
-                "@braintree/sanitize-url": "=6.0.4",
+                "@babel/runtime-corejs3": "^7.27.1",
+                "@scarf/scarf": "=1.4.0",
                 "base64-js": "^1.5.1",
-                "classnames": "^2.3.1",
+                "buffer": "^6.0.3",
+                "classnames": "^2.5.1",
                 "css.escape": "1.5.1",
                 "deep-extend": "0.6.0",
-                "dompurify": "=3.0.6",
+                "dompurify": "^3.3.2",
                 "ieee754": "^1.2.1",
                 "immutable": "^3.x.x",
                 "js-file-download": "^0.4.12",
-                "js-yaml": "=4.1.0",
-                "lodash": "^4.17.21",
-                "patch-package": "^8.0.0",
+                "js-yaml": "=4.1.1",
+                "lodash": "^4.18.1",
                 "prop-types": "^15.8.1",
                 "randexp": "^0.5.3",
                 "randombytes": "^2.1.0",
@@ -30156,56 +29062,60 @@
                 "react-immutable-proptypes": "2.2.0",
                 "react-immutable-pure-component": "^2.2.0",
                 "react-inspector": "^6.0.1",
-                "react-redux": "^8.1.3",
-                "react-syntax-highlighter": "^15.5.0",
-                "redux": "^4.1.2",
+                "react-redux": "^9.2.0",
+                "react-syntax-highlighter": "^16.0.0",
+                "redux": "^5.0.1",
                 "redux-immutable": "^4.0.0",
                 "remarkable": "^2.0.1",
-                "reselect": "^4.1.8",
+                "reselect": "^5.1.1",
                 "serialize-error": "^8.1.0",
-                "sha.js": "^2.4.11",
-                "swagger-client": "^3.24.6",
+                "sha.js": "^2.4.12",
+                "swagger-client": "^3.37.2",
                 "url-parse": "^1.5.10",
                 "xml": "=1.0.1",
                 "xml-but-prettier": "^1.0.1",
                 "zenscroll": "^4.0.2"
             },
             "peerDependencies": {
-                "react": ">=17.0.0",
-                "react-dom": ">=17.0.0"
-            }
-        },
-        "node_modules/swagger-ui-react/node_modules/@babel/runtime-corejs3": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-            "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-            "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "react": ">=16.8.0 <20",
+                "react-dom": ">=16.8.0 <20"
             }
         },
         "node_modules/swagger-ui-react/node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
         },
-        "node_modules/swagger-ui-react/node_modules/core-js-pure": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-            "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
+        "node_modules/swagger-ui-react/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
             }
         },
         "node_modules/swagger-ui-react/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -30228,10 +29138,11 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
-        "node_modules/swagger-ui-react/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        "node_modules/swagger-ui-react/node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "license": "MIT"
         },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
@@ -30327,40 +29238,6 @@
             },
             "engines": {
                 "node": ">= 10"
-            }
-        },
-        "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "optional": true,
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/tar-fs/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "optional": true
-        },
-        "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "optional": true,
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/tar/node_modules/minipass": {
@@ -30721,6 +29598,46 @@
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
+        "node_modules/to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "license": "MIT"
+        },
+        "node_modules/to-buffer/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -30773,6 +29690,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -30854,34 +29772,35 @@
             }
         },
         "node_modules/tree-sitter": {
-            "version": "0.20.4",
-            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.4.tgz",
-            "integrity": "sha512-rjfR5dc4knG3jnJNN/giJ9WOoN1zL/kZyrS0ILh+eqq8RNcIbiXA63JsMEgluug0aNvfQvK4BfCErN1vIzvKog==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+            "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "nan": "^2.17.0",
-                "prebuild-install": "^7.1.1"
+                "node-addon-api": "^8.0.0",
+                "node-gyp-build": "^4.8.0"
             }
         },
         "node_modules/tree-sitter-json": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.20.2.tgz",
-            "integrity": "sha512-eUxrowp4F1QEGk/i7Sa+Xl8Crlfp7J0AXxX1QdJEQKQYMWhgMbCIgyQvpO3Q0P9oyTrNQxRLlRipDS44a8EtRw==",
+            "version": "0.24.8",
+            "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
+            "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "nan": "^2.18.0"
-            }
-        },
-        "node_modules/tree-sitter-yaml": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/tree-sitter-yaml/-/tree-sitter-yaml-0.5.0.tgz",
-            "integrity": "sha512-POJ4ZNXXSWIG/W4Rjuyg36MkUD4d769YRUGKRqN+sVaj/VCo6Dh6Pkssn1Rtewd5kybx+jT1BWMyWN0CijXnMA==",
-            "hasInstallScript": true,
-            "optional": true,
-            "dependencies": {
-                "nan": "^2.14.0"
+                "node-addon-api": "^8.2.2",
+                "node-gyp-build": "^4.8.2"
+            },
+            "peerDependencies": {
+                "tree-sitter": "^0.21.1"
+            },
+            "peerDependenciesMeta": {
+                "tree-sitter": {
+                    "optional": true
+                }
             }
         },
         "node_modules/treeverse": {
@@ -31092,12 +30011,14 @@
         "node_modules/ts-mixer": {
             "version": "6.0.4",
             "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+            "license": "MIT"
         },
         "node_modules/ts-toolbelt": {
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-            "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
+            "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+            "license": "Apache-2.0"
         },
         "node_modules/tslib": {
             "version": "2.3.1",
@@ -31129,7 +30050,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -31186,6 +30107,20 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/typedarray-to-buffer": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -31199,6 +30134,7 @@
             "version": "0.30.1",
             "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
             "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
+            "license": "MIT",
             "dependencies": {
                 "ts-toolbelt": "^9.6.0"
             }
@@ -31239,18 +30175,6 @@
                 "has-bigints": "^1.0.2",
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/unbox-primitive/node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -31511,6 +30435,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true,
             "engines": {
                 "node": ">= 10.0.0"
             }
@@ -31551,7 +30476,8 @@
         "node_modules/unraw": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
-            "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
+            "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==",
+            "license": "MIT"
         },
         "node_modules/unset-value": {
             "version": "1.0.0",
@@ -31728,7 +30654,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/utila": {
             "version": "0.4.0",
@@ -31985,14 +30911,16 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
             "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/web-tree-sitter": {
-            "version": "0.20.3",
-            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.3.tgz",
-            "integrity": "sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==",
+            "version": "0.24.5",
+            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
+            "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
+            "license": "MIT",
             "optional": true
         },
         "node_modules/webidl-conversions": {
@@ -32758,6 +31686,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -32806,17 +31735,18 @@
             "dev": true
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-            "dev": true,
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "license": "MIT",
             "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.10"
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -32905,7 +31835,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -32969,6 +31900,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4"
             }
@@ -34441,29 +33373,16 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-            "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
-            "requires": {
-                "regenerator-runtime": "^0.13.4"
-            }
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
         },
         "@babel/runtime-corejs3": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
-            "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
-            "dev": true,
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+            "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
             "requires": {
-                "core-js-pure": "^3.25.1",
-                "regenerator-runtime": "^0.13.10"
-            },
-            "dependencies": {
-                "regenerator-runtime": {
-                    "version": "0.13.10",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-                    "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
-                    "dev": true
-                }
+                "core-js-pure": "^3.48.0"
             }
         },
         "@babel/template": {
@@ -34575,11 +33494,6 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
-        },
-        "@braintree/sanitize-url": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-            "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
         },
         "@cnakazawa/watch": {
             "version": "1.0.4",
@@ -34718,8 +33632,7 @@
         "@hookform/resolvers": {
             "version": "2.9.11",
             "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.11.tgz",
-            "integrity": "sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==",
-            "requires": {}
+            "integrity": "sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.5.0",
@@ -34742,8 +33655,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/@iconify/react/-/react-3.2.2.tgz",
             "integrity": "sha512-z3+Jno3VcJzgNHsN5mEvYMsgCkOZkydqdIwOxjXh45+i2Vs9RGH68Y52vt39izwFSfuYUXhaW+1u7m7+IhCn/g==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@isaacs/string-locale-compare": {
             "version": "1.1.0",
@@ -35438,8 +34350,7 @@
         "@material-ui/types": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-            "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-            "requires": {}
+            "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
         },
         "@material-ui/utils": {
             "version": "4.11.2",
@@ -35462,14 +34373,6 @@
                 "reselect": "^4.0.0"
             },
             "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.23.5",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-                    "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
-                    "requires": {
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
                 "@material-ui/utils": {
                     "version": "5.0.0-beta.5",
                     "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-5.0.0-beta.5.tgz",
@@ -35491,11 +34394,6 @@
                     "version": "17.0.2",
                     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
                     "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.0",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-                    "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
                 }
             }
         },
@@ -36047,8 +34945,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
             "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@octokit/plugin-rest-endpoint-methods": {
             "version": "6.7.0",
@@ -36212,6 +35109,11 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.0.tgz",
             "integrity": "sha512-5dMOnVnefRsl4uRnAdoWjtVTdh8e6aZqgM4puy9nmEADH72ck+uXwzpJLEKE9Q6F8ZljNewLgmTfkxUrBdv4WA=="
+        },
+        "@scarf/scarf": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+            "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="
         },
         "@semantic-release/changelog": {
             "version": "6.0.1",
@@ -36666,57 +35568,49 @@
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz",
             "integrity": "sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-plugin-remove-jsx-attribute": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.5.0.tgz",
             "integrity": "sha512-8zYdkym7qNyfXpWvu4yq46k41pyNM9SOstoWhKlm+IfdCE1DdnRKeMUPsWIEO/DEkaWxJ8T9esNdG3QwQ93jBA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-plugin-remove-jsx-empty-expression": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.5.0.tgz",
             "integrity": "sha512-NFdxMq3xA42Kb1UbzCVxplUc0iqSyM9X8kopImvFnB+uSDdzIHOdbs1op8ofAvVRtbg4oZiyRl3fTYeKcOe9Iw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-plugin-replace-jsx-attribute-value": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.5.1.tgz",
             "integrity": "sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-plugin-svg-dynamic-title": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.5.1.tgz",
             "integrity": "sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-plugin-svg-em-dimensions": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.5.1.tgz",
             "integrity": "sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-plugin-transform-react-native-svg": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.5.1.tgz",
             "integrity": "sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-plugin-transform-svg-component": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.5.1.tgz",
             "integrity": "sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@svgr/babel-preset": {
             "version": "6.5.1",
@@ -36827,1143 +35721,619 @@
             }
         },
         "@swagger-api/apidom-ast": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-SAOQrFSFwgDiI4QSIPDwAIJEb4Za+8bu45sNojgV3RMtCz+n4Agw66iqGsDib5YSI/Cg1h4AKFovT3iWdfGWfw==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.10.2.tgz",
+            "integrity": "sha512-vTl8gWyeZaj887/NSWYs3as4K8wXHar5wY/606XRBjR2UgmJBokBgKjq7S23LW9tsYjsT4MjQKC8idjgw17xvg==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-error": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "unraw": "^3.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-                }
             }
         },
         "@swagger-api/apidom-core": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-vGl8BWRf6ODl39fxElcIOjRE2QG5AJhn8tTNMqjjHB/2WppNBuxOVStYZeVJoWfK03OPK8v4Fp/TAcaP9+R7DQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.10.2.tgz",
+            "integrity": "sha512-qryNBGHNWDvSRyK1w5rox0UOrHrVBjZOHgeXFpGHF+oBO7ntSc/H7BSiYMDR+KQESkzMcAxn4tZMLYItaBt06w==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "minim": "~0.23.8",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
-                "short-unique-id": "^5.0.2",
+                "short-unique-id": "^5.3.2",
                 "ts-mixer": "^6.0.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-                }
             }
         },
         "@swagger-api/apidom-error": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-FU/2sFSgsICB9HYFELJ79caRpXXzlAV41QTHsAM46WfRehbzZUQpOBQm4jRi3qJGSa/Jk+mQ7Vt8HLRFMpJFfg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.10.2.tgz",
+            "integrity": "sha512-SWyPyL5xwTUsDzPi0A5zwTFwqPezvlwj4opEqruqjESNTYupUA7+vt4Mdj7IlDaRYRG1qyCWQgKhIBXznVUD4w==",
             "requires": {
                 "@babel/runtime-corejs3": "^7.20.7"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-                }
             }
         },
         "@swagger-api/apidom-json-pointer": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-/W8Ktbgbs29zdhed6KHTFk0qmuIRbvEFi8wu2MHGQ5UT4i99Bdu2OyUiayhnpejWztfQxDgL08pjrQPEwgY8Yg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.10.2.tgz",
+            "integrity": "sha512-zySHPqIXF4HZ3VWbHwTxO+H1e9dJw7mGHzoX+tZjx5wVyLQO3kZDCAAXzz3c3/TIY21Y2Zkpkez3q9hjFyuLvQ==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@types/ramda": "~0.30.0",
-                "ramda": "~0.30.0",
-                "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-                }
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swaggerexpert/json-pointer": "^2.10.1"
             }
         },
         "@swagger-api/apidom-ns-api-design-systems": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-aduC2vbwGgn6ia9IkKpqBYBaKyIDGM/80M3oU3DFgaYIIwynzuwVpN1TkBOLIFy3mAzkWoYKUS0jdZJhMy/6Ug==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.10.2.tgz",
+            "integrity": "sha512-MsZ4GWmWN7wkWv7G9Pwk8sHU1j0bwk7xoGeaZmNCylbTfYvGkg6jJGMHdAdQNCQXbbpfLeKt1O+3YCN//JUQ7w==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
+            }
+        },
+        "@swagger-api/apidom-ns-arazzo-1": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.10.2.tgz",
+            "integrity": "sha512-fQSwDlIR85tbnLXAjtV/ypSGUBfrzFcZ4NbH6BL1DSTR4uEunVxAULdD4wlhCt9gGNDl/zxZD3vQtlYDkXDFmw==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
             }
         },
         "@swagger-api/apidom-ns-asyncapi-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-hZjxXJgMt517ADnAauWJh01k7WNRwkbWT5p6b7AXF2H3tl549A2hhLnIg3BBSE3GwB3Nv25GyrI3aA/1dFVC8A==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.10.2.tgz",
+            "integrity": "sha512-obWHe3pyAj65Nf9ISwnbtJ4C5mZ15C6mtQXxzHVW5maVZqlqt3s/YbPY87EqK9ArdNOwOZHkQt2Uth02GMmjxA==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
+            }
+        },
+        "@swagger-api/apidom-ns-asyncapi-3": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.10.2.tgz",
+            "integrity": "sha512-yqNmXeObF2OLAusgGEapXz2CrGjXwkcfG3DYcQDtOvgRytvGZxC2EkCUR+wEXCVNYhoJ7QpVzzTJOHs3jOvptg==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-json-schema-2019-09": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.10.2.tgz",
+            "integrity": "sha512-I1FaBoDFMjybF4QVsesIYl8OilkwycZ0mQ0jf1P++zfTRG27uIePB8M+Iuj6iqMsE3qpkjjJJ6ZLnrLPdKvmRw==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "@swagger-api/apidom-ns-json-schema-2020-12": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.10.2.tgz",
+            "integrity": "sha512-lg9XfRlJRNoBa2EDGpEFc7HvFV39G6RG0/SbjQY0BE/WZer10wmfTCU7l3RUNJXRFGKH6/O/nsYgP7AFjTanXQ==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
             }
         },
         "@swagger-api/apidom-ns-json-schema-draft-4": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-OfX4UBb08C0xD5+F80dQAM2yt5lXxcURWkVEeCwxz7i23BB3nNEbnZXNV91Qo9eaJflPh8dO9iiHQxvfw5IgSg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.10.2.tgz",
+            "integrity": "sha512-C50KnSKynrmHky/oOB6+hHyZVpwng78Fz5aZjay3h8X5C/PJHmm3sDJFvF3/9wkYHO3N9sPp7cpu4Xm9VJ4/wQ==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.4"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-                }
             }
         },
         "@swagger-api/apidom-ns-json-schema-draft-6": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-qzUVRSSrnlYGMhK6w57o/RboNvy1FO0iFgEnTk56dD4wN49JRNuFqKI18IgXc1W2r9tTTG70nG1khe4cPE8TNg==",
-            "optional": true,
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.10.2.tgz",
+            "integrity": "sha512-/wiP8+2lF8UJRrkoQ9HvKnMbnqijk2uY/hAg+/Bo73T9NGKkEa29jYVUKYNYj7gJBw4hhkUHfHFWuZUpxPC4ZA==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.4"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-ns-json-schema-draft-7": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-Zml8Z8VCckdFjvTogaec1dabd85hg1+xZDseWcCuD0tYkaTY/sZ8zzI0dz6/4HsKCb58qjiWSa0w60N8Syr6WQ==",
-            "optional": true,
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.10.2.tgz",
+            "integrity": "sha512-firN/uvnVxQgACqcyzV3NU9qjbMvNMJkpmm3wOat3URmaFMaFBT3qjbU1pFHBGbnXI3+I9pQJZHmJSwqNzfUbQ==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.4"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-ns-openapi-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-WUZxt7Gs7P4EQsGtoD6cKAjf0uDJhkUxsIW9Bb4EAgO6tdp7LlXhbJ0fJ2QycCLY717SfJbvGLfhuSfTYo4Iow==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.10.2.tgz",
+            "integrity": "sha512-FK5kYvo/1uwAByumRVRsynBlnKxUUImfsjPEFgRCW6yhbCGRqN47NaZ7GYFHpbhjC3OmMN5/etYj6B0jnZx7Gg==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-ns-openapi-3-0": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-7ra5uoZGrfCn1LabfJLueChPcYXyg24//LCYBtjTstyueqd5Vp7JCPeP5NnJSAaqVAP47r8ygceBPoxNp9k1EQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.10.2.tgz",
+            "integrity": "sha512-ziyv85QbJYHRdc9oTEFBy3pxwxg7BW/a9GrwH01/SmuXVQPjLjwzRb+SjCxLogJppm0yjxOkDFI2VWPp2RADFg==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-                }
             }
         },
         "@swagger-api/apidom-ns-openapi-3-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-nQOwNQgf0C8EVjf2loAAl4ifRuVOdcqycvXUdcTpsUfHN3fbndR8IKpb26mQNmnACmqgmX+LkbMdW9b+K6089g==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.10.2.tgz",
+            "integrity": "sha512-ngcmO4dH77JT5hZB04OJdyTzgKnt2lNhAZQ+4wXjum/xhszjUmDhOeYfXdHw3Lm7MxsEsTesWzLYQ5LKADc41A==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-                }
             }
         },
-        "@swagger-api/apidom-ns-workflows-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-yKo0p8OkQmDib93Kt1yqWmI7JsD6D9qUHxr/SCuAmNNWny1hxm7cZGoKJwJlGd0uAg84j4vmzWOlG3AsJbnT8g==",
-            "optional": true,
+        "@swagger-api/apidom-ns-openapi-3-2": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.10.2.tgz",
+            "integrity": "sha512-3SWJ5ipWwn+w11HTUESWex/522jy2aGLzBqqMgH36sy+Wdwx+9Mw2bgSDqkxmNC5+jpzOGUOIWoQAMuCpS/Gzg==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
                 "ts-mixer": "^6.0.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-xfVMR4HrTzXU0HB4TtxwkNbUIa/cQrPa0BWutJZ0fMYMAtUox2s8GsFYnJfZP52XfpSHFM1VPclivorZqET14g==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.10.2.tgz",
+            "integrity": "sha512-kzhJUGzsJ38Uohj5xRQDkQC08rqNhatbqgD30LZ0/UWryJ9nAsjqK2ovuP9t+5WKcDE4iwcYeGSt1NA2XgEZwg==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-lJZkrhZ8qRTtc5fSLKefCv8j7Xzo8UBfMjpqTJhmETAtU8YfVV2i2znjgxJpm0QwV6FVQqGfK1+ASZQWPLiVcA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.10.2.tgz",
+            "integrity": "sha512-i3CmSxJ/iG67ybRDAJ9xpuMrOMFvC/obX2lI36E0VZzBTb+llw4Zd5qFmBqNnImLpwdmk11Z1V7i+5HM+J7ijQ==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.10.2.tgz",
+            "integrity": "sha512-HwiUkwvo5i2hV2SS6KWrdj62BdceZGfhuXhr1il8akWekpU4jXPtr5pv4gOnKKJN7VgjAmwt/DlcCSRo1+9jVA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.10.2.tgz",
+            "integrity": "sha512-w8VTVuE7GPbRqWxvMgRoTb726JRsMhFPMfTBf8+MJ4pQThjk78dSXPV2Zlse71b2DWBuQy2sr6zGyLUNs/3ePQ==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
         },
         "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-65nmKdPzw4C1bmtYn+3zoxXCI6Gnobr0StI9XE0YWiK+lpso7RH3Cgyl1yPZ0DBRVGzP+Fn9FVzmDNulEfR95w==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.10.2.tgz",
+            "integrity": "sha512-FDNjqmn2vV1jFoVVwQDO0XPPm8R5xzmcyY/6yBLFmKZADin3smSKVZ+njYHmfRjpspXwN0AwI0drdvuH0FZLJg==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.10.2.tgz",
+            "integrity": "sha512-x/0vM2nDDzYzFnXr69+so/KSH+2py2TiZd1K49pWcX8cHsPV1Y4Ppih7GVOMymd8m/IOCjLYlV7qt4eWDwdldg==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
         },
         "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-RLI4FpVB3vB6mIuT77yrsv5V2LMZ80dW9XpV+Fmbd4Jkdj+ysAFwT38cI4AsUMOxixpTDIXY1oWD7AjvylHhQQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.10.2.tgz",
+            "integrity": "sha512-2bVACmU9ZmAVVnqQWSc3Bs+xG0HHLU1tfZbYL8xNgSi8kw4HcnejF5mWtN+MLFzTaBmWCi2In7P7BYNR8+2Dyg==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.10.2.tgz",
+            "integrity": "sha512-oHpbf+iqBcDS3qtsipMpgCwAeckKMxg0qFKYTCRZyJdctRgupJTxVeir6t/SGo0Ny0a1iknt2LN0u5frEen0kg==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
         },
         "@swagger-api/apidom-parser-adapter-json": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-aOewp8/3zobf/O+5Jx8y7+bX3BPRfRlHIv15qp4YVTsLs6gLISWSzTO9JpWe9cR+AfhpsAalFq4t1LwIkmLk4A==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.10.2.tgz",
+            "integrity": "sha512-VnwEkarKfsJYRF0zCI9AGiSIyBUXqS2d32KQuhVCt/HeuF1XO9sjeLjGiosA/24YVOnO0ul5TpiNFQn0pw89mA==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
-                "tree-sitter": "=0.20.4",
-                "tree-sitter-json": "=0.20.2",
-                "web-tree-sitter": "=0.20.3"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
+                "tree-sitter": "=0.21.1",
+                "tree-sitter-json": "=0.24.8",
+                "web-tree-sitter": "=0.24.5"
             }
         },
         "@swagger-api/apidom-parser-adapter-openapi-json-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-zgtsAfkplCFusX2P/saqdn10J8P3kQizCXxHLvxd2j0EhMJk2wfu4HYN5Pej/7/qf/OR1QZxqtacwebd4RfpXA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.10.2.tgz",
+            "integrity": "sha512-+d/o/8TrNBjvFzgPb0RQhrCc8gOWnrHZF+xvCO5gwp+4MUr1XP1AJIox1e6t1SO+j7IQjiF2ocx2r7eFE5QC7w==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-iPuHf0cAZSUhSv8mB0FnVgatTc26cVYohgqz2cvjoGofdqoh5KKIfxOkWlIhm+qGuBp71CfZUrPYPRsd0dHgeg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.10.2.tgz",
+            "integrity": "sha512-3ieUeX8/WywkUzdOO1U1QKQDNmpZFfOeTAeb4ISDd/PKOVwuEx/b0w5I8EuOu97tKAe3UUesEdii+pJlkcFlFw==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-jwkfO7tzZyyrAgok+O9fKFOv1q/5njMb9DBc3D/ZF3ZLTcnEw8uj4V2HkjKxUweH5k8ip/gc8ueKmO/i7p2fng==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.10.2.tgz",
+            "integrity": "sha512-z0c7IgMPLSDhE+ldTb54Xlhq+yPF0w/8LHXyeHX4V6BS1VG3Utb+mM/qTVfy1Eo+p1KGNlwNDEPsBp6jIaVb5Q==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.10.2.tgz",
+            "integrity": "sha512-bx/kEIXWtpHu+4LEiyNdt0v8ER5EVwPjhQdlpOaC5qghnRH9aUYOTawZtVHsNHAQWTIMNn9DdPKYQgttQKD0Pw==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
             }
         },
         "@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-jEIDpjbjwFKXQXS/RHJeA4tthsguLoz+nJPYS3AOLfuSiby5QXsKTxgqHXxG/YJqF1xJbZL+5KcF8UyiDePumw==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.10.2.tgz",
+            "integrity": "sha512-e86JUXHGGEVsO4/xpy/GRSvYXGN30hLt1lMUhjzCFuE95N6/K3hmQHE3rA/H7ot1ajCWUhzukW5rGQac79NIjA==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-ieJL8dfIF8fmP3uJRNh/duJa3cCIIv6MzUe6o4uPT/oTDroy4qIATvnq9Dq/gtAv6rcPRpA9VhyghJ1DmjKsZQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.10.2.tgz",
+            "integrity": "sha512-ucfc13Ai31tJ0ruAm1YiHhqENgcBuiOXL00OhoICWA56ggAcnA5WfWmvtsXVMlZsTHVbhZP3XpsH5rui2N8u5w==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-EatIH7PZQSNDsRn9ompc62MYzboY7wAkjfYz+2FzBaSA8Vl5/+740qGQj22tu/xhwW4K72aV2NNL1m47QVF7hA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.10.2.tgz",
+            "integrity": "sha512-7o8j93qgf9yYAaaJ/GpH+5sB3fC9EmvmjTCqlw5YWXp+cRgCn9q7f80Sv4+NjbracUafB6qL4i9F/m+Xs0XZaQ==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
-        "@swagger-api/apidom-parser-adapter-workflows-json-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-LylC2cQdAmvR7bXqwMwBt6FHTMVGinwIdI8pjl4EbPT9hCVm1rdED53caTYM4gCm+CJGRw20r4gb9vn3+N6RrA==",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.10.2.tgz",
+            "integrity": "sha512-blDIeVmo8bpXYV/C+b6PYi54yS+5jPEZTFsK5jQ2NzpCPrkBPacp/KTuHBUBzJsYj4bj/ivRL3+JXGw4YovUHw==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
-            }
-        },
-        "@swagger-api/apidom-parser-adapter-workflows-yaml-1": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-TlA4+1ca33D7fWxO5jKBytSCv86IGI4Lze4JfrawWUXZ5efhi4LiNmW5TrGlZUyvL7yJtZcA4tn3betlj6jVwA==",
-            "optional": true,
-            "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.9",
-                "@types/ramda": "~0.30.0",
-                "ramda": "~0.30.0",
-                "ramda-adjunct": "^5.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "optional": true,
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
-                }
             }
         },
         "@swagger-api/apidom-parser-adapter-yaml-1-2": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-jSIHEB7lbh+MP3BhYIXFkeivDR01kugXN70e5FskW7oet2TIARsVEPheWKQFSP1U8bUZA4bsp9h9gOQ9xEeErw==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.10.2.tgz",
+            "integrity": "sha512-I5eCls8XS3SVEwH/cuL6T3iar1TPaFYh3gXwS/2rzP1aZQNKSHDP3y3ney7nAomKG4dFvE8Q248FL36arG7T/w==",
             "optional": true,
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-ast": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.9",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.10.2",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
-                "tree-sitter": "=0.20.4",
-                "tree-sitter-yaml": "=0.5.0",
-                "web-tree-sitter": "=0.20.3"
+                "tree-sitter": "=0.22.4",
+                "web-tree-sitter": "=0.24.5"
             },
             "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+                "tree-sitter": {
+                    "version": "0.22.4",
+                    "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+                    "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
                     "optional": true,
                     "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
+                        "node-addon-api": "^8.3.0",
+                        "node-gyp-build": "^4.8.4"
                     }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-                    "optional": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-                    "optional": true
                 }
             }
         },
         "@swagger-api/apidom-reference": {
-            "version": "1.0.0-alpha.9",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-alpha.9.tgz",
-            "integrity": "sha512-KQ6wB5KplqdSsjxdA8BaQulj5zlF5VBCd5KP3RN/9vvixgsD/gyrVY59nisdzmPTqiL6yjhk612eQ96MgG8KiA==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.10.2.tgz",
+            "integrity": "sha512-H5UqOmae9CXdiLJbbh1j+/hwvcECmr6ci2XtUKTQpFviemvsIDZmPV1DKUAxCfzGr2iOkDO6SZc+/OEWlETqiQ==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.20.7",
-                "@swagger-api/apidom-core": "^1.0.0-alpha.9",
-                "@swagger-api/apidom-error": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-workflows-json-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-alpha.1",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.10.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
                 "@types/ramda": "~0.30.0",
-                "axios": "^1.4.0",
-                "minimatch": "^7.4.3",
-                "process": "^0.11.10",
+                "axios": "^1.15.0",
+                "minimatch": "^10.2.1",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             },
             "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
-                "axios": {
-                    "version": "1.7.7",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-                    "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-                    "requires": {
-                        "follow-redirects": "^1.15.6",
-                        "form-data": "^4.0.0",
-                        "proxy-from-env": "^1.1.0"
-                    }
-                },
                 "balanced-match": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-                    "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+                    "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
                 },
                 "brace-expansion": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "version": "5.0.5",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+                    "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
                     "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "follow-redirects": {
-                    "version": "1.15.9",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                    "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
-                },
-                "form-data": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
+                        "balanced-match": "^4.0.2"
                     }
                 },
                 "minimatch": {
-                    "version": "7.4.6",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-                    "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+                    "version": "10.2.5",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+                    "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
                     "requires": {
-                        "brace-expansion": "^2.0.1"
+                        "brace-expansion": "^5.0.5"
                     }
-                },
-                "proxy-from-env": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-                    "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
                 }
+            }
+        },
+        "@swaggerexpert/cookie": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-2.0.2.tgz",
+            "integrity": "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==",
+            "requires": {
+                "apg-lite": "^1.0.3"
+            }
+        },
+        "@swaggerexpert/json-pointer": {
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
+            "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
+            "requires": {
+                "apg-lite": "^1.0.4"
             }
         },
         "@tanstack/query-core": {
@@ -38162,6 +36532,16 @@
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "dev": true
+        },
+        "@tree-sitter-grammars/tree-sitter-yaml": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+            "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+            "optional": true,
+            "requires": {
+                "node-addon-api": "^8.3.1",
+                "node-gyp-build": "^4.8.4"
+            }
         },
         "@trysound/sax": {
             "version": "0.2.0",
@@ -38579,6 +36959,11 @@
             "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
             "dev": true
         },
+        "@types/prismjs": {
+            "version": "1.26.6",
+            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+            "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="
+        },
         "@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -38812,6 +37197,12 @@
             "requires": {
                 "@types/jest": "*"
             }
+        },
+        "@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "optional": true
         },
         "@types/unist": {
             "version": "2.0.6",
@@ -39667,8 +38058,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
             "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@webpack-cli/info": {
             "version": "1.5.0",
@@ -39683,8 +38073,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
             "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@xml-tools/parser": {
             "version": "1.0.11",
@@ -39706,11 +38095,6 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
-        },
-        "@yarnpkg/lockfile": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
         },
         "abab": {
             "version": "2.0.6",
@@ -39771,15 +38155,13 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
             "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -39860,8 +38242,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ansi-colors": {
             "version": "4.1.1",
@@ -39924,9 +38305,9 @@
             }
         },
         "apg-lite": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.4.tgz",
-            "integrity": "sha512-B32zCN3IdHIc99Vy7V9BaYTUzLeRA8YXYY1aQD1/5I2aqIrO0coi4t6hJPqMisidlBxhyME8UexkHt31SlR6Og=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
+            "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw=="
         },
         "aproba": {
             "version": "2.0.0",
@@ -40129,7 +38510,8 @@
         "at-least-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true
         },
         "atob": {
             "version": "2.1.2",
@@ -40146,10 +38528,12 @@
             }
         },
         "available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-            "dev": true
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "requires": {
+                "possible-typed-array-names": "^1.0.0"
+            }
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -40164,34 +38548,31 @@
             "dev": true
         },
         "axios": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             },
             "dependencies": {
-                "follow-redirects": {
-                    "version": "1.15.9",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                    "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
-                },
                 "form-data": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+                    "version": "4.0.5",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+                    "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
                     "requires": {
                         "asynckit": "^0.4.0",
                         "combined-stream": "^1.0.8",
+                        "es-set-tostringtag": "^2.1.0",
+                        "hasown": "^2.0.2",
                         "mime-types": "^2.1.12"
                     }
                 },
                 "proxy-from-env": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-                    "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+                    "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
                 }
             }
         },
@@ -40537,17 +38918,6 @@
             "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
             "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
         },
-        "bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "optional": true,
-            "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
         "blob-util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -40658,6 +39028,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -40666,7 +39037,8 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
                 }
             }
         },
@@ -40674,6 +39046,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -40718,7 +39091,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -40931,13 +39304,32 @@
             "dev": true
         },
         "call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-            "dev": true,
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            }
+        },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
+        "call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             }
         },
         "callsites": {
@@ -41038,17 +39430,20 @@
         "character-entities": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+            "dev": true
         },
         "character-entities-legacy": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+            "dev": true
         },
         "character-reference-invalid": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+            "dev": true
         },
         "check-more-types": {
             "version": "2.24.0",
@@ -41138,9 +39533,9 @@
             }
         },
         "classnames": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-            "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
         },
         "clean-css": {
             "version": "4.2.4",
@@ -41528,7 +39923,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "connect-history-api-fallback": {
             "version": "1.6.0",
@@ -41927,10 +40323,9 @@
             }
         },
         "core-js-pure": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.0.tgz",
-            "integrity": "sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==",
-            "dev": true
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw=="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -41965,6 +40360,7 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -42486,15 +40882,6 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "optional": true,
-            "requires": {
-                "mimic-response": "^3.1.0"
-            }
-        },
         "deep-equal": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
@@ -42518,23 +40905,6 @@
                 "which-typed-array": "^1.1.8"
             },
             "dependencies": {
-                "get-intrinsic": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-                    "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-                    "dev": true,
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.3"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
-                },
                 "isarray": {
                     "version": "2.0.5",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -42555,10 +40925,9 @@
             "dev": true
         },
         "deepmerge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-            "dev": true
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
         },
         "default-gateway": {
             "version": "6.0.3",
@@ -42756,12 +41125,6 @@
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "dev": true
         },
-        "detect-libc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-            "optional": true
-        },
         "detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -42921,9 +41284,12 @@
             }
         },
         "dompurify": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-            "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+            "requires": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "domutils": {
             "version": "2.8.0",
@@ -42973,6 +41339,16 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
             "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
+        },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
         },
         "duplexer": {
             "version": "0.1.2",
@@ -43087,7 +41463,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -43235,23 +41611,6 @@
                 "unbox-primitive": "^1.0.2"
             },
             "dependencies": {
-                "get-intrinsic": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-                    "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-                    "dev": true,
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.3"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
-                },
                 "object-inspect": {
                     "version": "1.12.2",
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -43261,36 +41620,9 @@
             }
         },
         "es-define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-            "requires": {
-                "get-intrinsic": "^1.2.4"
-            },
-            "dependencies": {
-                "function-bind": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-                    "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-                },
-                "get-intrinsic": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-                    "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-                    "requires": {
-                        "es-errors": "^1.3.0",
-                        "function-bind": "^1.1.2",
-                        "has-proto": "^1.0.1",
-                        "has-symbols": "^1.0.3",
-                        "hasown": "^2.0.0"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-                }
-            }
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
         },
         "es-errors": {
             "version": "1.3.0",
@@ -43326,6 +41658,25 @@
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
             "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
             "dev": true
+        },
+        "es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "requires": {
+                "es-errors": "^1.3.0"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            }
         },
         "es-shim-unscopables": {
             "version": "1.0.0",
@@ -43573,8 +41924,7 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
             "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-cypress": {
             "version": "2.11.3",
@@ -43598,8 +41948,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-3.0.0.tgz",
             "integrity": "sha512-XM1CHe1jX6j+t/NeppcVnm/1zgDAFqwiSLJEyLB7HDpcqBEGbbTFLSayCW2Q9y7VwcXrJbDAKRoO6vZ7jCmRFw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-jsonc": {
             "version": "2.5.0",
@@ -43685,8 +42034,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -43920,12 +42268,6 @@
                     "dev": true
                 }
             }
-        },
-        "expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "optional": true
         },
         "expect": {
             "version": "26.6.2",
@@ -44272,6 +42614,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -44332,14 +42675,6 @@
                 "semver-regex": "^3.1.2"
             }
         },
-        "find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "requires": {
-                "micromatch": "^4.0.2"
-            }
-        },
         "flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -44373,10 +42708,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
-            "dev": true
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
         },
         "font-color-contrast": {
             "version": "11.1.0",
@@ -44384,12 +42718,11 @@
             "integrity": "sha512-PxpFaesCSsDwaciw7MF6B2thUkH7skqZlz4BzUnvapR6+Es2877q7ru/tqfsITuaraPz+TGfsOfdtU4D0qjqEw=="
         },
         "for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dev": true,
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
             "requires": {
-                "is-callable": "^1.1.3"
+                "is-callable": "^1.2.7"
             }
         },
         "for-in": {
@@ -44588,16 +42921,11 @@
             "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
             "dev": true
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "optional": true
-        },
         "fs-extra": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
             "requires": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
@@ -44634,7 +42962,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
             "version": "2.3.2",
@@ -44644,9 +42973,9 @@
             "optional": true
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
         },
         "function.prototype.name": {
             "version": "1.1.5",
@@ -44729,14 +43058,20 @@
             "dev": true
         },
         "get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-            "dev": true,
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             }
         },
         "get-own-enumerable-property-symbols": {
@@ -44750,6 +43085,15 @@
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
         },
         "get-stdin": {
             "version": "8.0.0",
@@ -44859,12 +43203,6 @@
                 }
             }
         },
-        "github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "optional": true
-        },
         "gitignore-to-glob": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/gitignore-to-glob/-/gitignore-to-glob-0.3.0.tgz",
@@ -44875,6 +43213,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -44974,34 +43313,15 @@
             "dev": true
         },
         "gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "requires": {
-                "get-intrinsic": "^1.1.3"
-            },
-            "dependencies": {
-                "get-intrinsic": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-                    "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.3"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-                }
-            }
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
         },
         "graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "growly": {
             "version": "1.3.0",
@@ -45054,6 +43374,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -45071,40 +43392,24 @@
             "dev": true
         },
         "has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-            "dev": true,
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "requires": {
-                "get-intrinsic": "^1.1.1"
+                "es-define-property": "^1.0.0"
             }
         },
-        "has-proto": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
-        },
         "has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-            "dev": true
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
         },
         "has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-            "dev": true,
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "requires": {
-                "has-symbols": "^1.0.2"
-            },
-            "dependencies": {
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
-                }
+                "has-symbols": "^1.0.3"
             }
         },
         "has-unicode": {
@@ -45166,24 +43471,30 @@
             }
         },
         "hasown": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "requires": {
                 "function-bind": "^1.1.2"
-            },
-            "dependencies": {
-                "function-bind": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-                    "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-                }
             }
         },
         "hast-util-parse-selector": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-            "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "requires": {
+                "@types/hast": "^3.0.0"
+            },
+            "dependencies": {
+                "@types/hast": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+                    "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+                    "requires": {
+                        "@types/unist": "*"
+                    }
+                }
+            }
         },
         "hast-util-whitespace": {
             "version": "2.0.0",
@@ -45191,34 +43502,29 @@
             "integrity": "sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg=="
         },
         "hastscript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
-            "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
             "requires": {
-                "@types/hast": "^2.0.0",
-                "comma-separated-tokens": "^1.0.0",
-                "hast-util-parse-selector": "^2.0.0",
-                "property-information": "^5.0.0",
-                "space-separated-tokens": "^1.0.0"
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
             },
             "dependencies": {
-                "comma-separated-tokens": {
-                    "version": "1.0.8",
-                    "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-                    "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
-                },
-                "property-information": {
-                    "version": "5.6.0",
-                    "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
-                    "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+                "@types/hast": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+                    "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
                     "requires": {
-                        "xtend": "^4.0.0"
+                        "@types/unist": "*"
                     }
                 },
-                "space-separated-tokens": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-                    "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+                "property-information": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+                    "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
                 }
             }
         },
@@ -45237,6 +43543,11 @@
             "version": "10.7.3",
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
             "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+        },
+        "highlightjs-vue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+            "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="
         },
         "history": {
             "version": "5.3.0",
@@ -45545,21 +43856,6 @@
             "integrity": "sha512-YDzIGHhMRvr7M+c8B3EQUKyiMBhfqox4o1qkFvt4QXuu5V2cxf74+NCr+VEkUuU0y+RwcupA238eeolW1Yn80g==",
             "requires": {
                 "@babel/runtime": "^7.14.6"
-            },
-            "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.20.1",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-                    "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
-                    "requires": {
-                        "regenerator-runtime": "^0.13.10"
-                    }
-                },
-                "regenerator-runtime": {
-                    "version": "0.13.10",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-                    "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
-                }
             }
         },
         "iconv-lite": {
@@ -45575,8 +43871,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "identity-obj-proxy": {
             "version": "3.0.0",
@@ -45697,6 +43992,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -45711,7 +44007,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "devOptional": true
+            "dev": true
         },
         "init-package-json": {
             "version": "3.0.2",
@@ -45825,12 +44121,14 @@
         "is-alphabetical": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+            "dev": true
         },
         "is-alphanumerical": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
             "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+            "dev": true,
             "requires": {
                 "is-alphabetical": "^1.0.0",
                 "is-decimal": "^1.0.0"
@@ -45889,8 +44187,7 @@
         "is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "dev": true
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
         },
         "is-ci": {
             "version": "2.0.0",
@@ -45951,7 +44248,8 @@
         "is-decimal": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -45975,7 +44273,8 @@
         "is-docker": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -46022,7 +44321,8 @@
         "is-hexadecimal": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+            "dev": true
         },
         "is-in-browser": {
             "version": "1.1.3",
@@ -46068,7 +44368,8 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
         },
         "is-number-object": {
             "version": "1.0.7",
@@ -46183,14 +44484,6 @@
             "dev": true,
             "requires": {
                 "has-symbols": "^1.0.2"
-            },
-            "dependencies": {
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
-                }
             }
         },
         "is-text-path": {
@@ -46203,16 +44496,11 @@
             }
         },
         "is-typed-array": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-            "dev": true,
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "requires": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
+                "which-typed-array": "^1.1.16"
             }
         },
         "is-typedarray": {
@@ -46262,6 +44550,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
             "requires": {
                 "is-docker": "^2.0.0"
             }
@@ -46275,7 +44564,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isobject": {
             "version": "3.0.1",
@@ -47007,8 +45297,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jest-regex-util": {
             "version": "26.0.0",
@@ -47738,58 +46027,6 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
-        "json-stable-stringify": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
-            "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
-            "requires": {
-                "call-bind": "^1.0.5",
-                "isarray": "^2.0.5",
-                "jsonify": "^0.0.1",
-                "object-keys": "^1.1.1"
-            },
-            "dependencies": {
-                "call-bind": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-                    "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-                    "requires": {
-                        "es-define-property": "^1.0.0",
-                        "es-errors": "^1.3.0",
-                        "function-bind": "^1.1.2",
-                        "get-intrinsic": "^1.2.4",
-                        "set-function-length": "^1.2.1"
-                    }
-                },
-                "function-bind": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-                    "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-                },
-                "get-intrinsic": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-                    "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-                    "requires": {
-                        "es-errors": "^1.3.0",
-                        "function-bind": "^1.1.2",
-                        "has-proto": "^1.0.1",
-                        "has-symbols": "^1.0.3",
-                        "hasown": "^2.0.0"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-                },
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-                }
-            }
-        },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -47867,15 +46104,11 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
             }
-        },
-        "jsonify": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
         },
         "jsonparse": {
             "version": "1.3.1",
@@ -48022,14 +46255,6 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
-        },
-        "klaw-sync": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-            "requires": {
-                "graceful-fs": "^4.1.11"
-            }
         },
         "kleur": {
             "version": "3.0.3",
@@ -48781,9 +47006,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
         },
         "lodash.capitalize": {
             "version": "4.2.1",
@@ -49134,6 +47359,11 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.4.0.tgz",
             "integrity": "sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw=="
+        },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
         },
         "mathml-tag-names": {
             "version": "2.1.3",
@@ -49704,6 +47934,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
             "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "dev": true,
             "requires": {
                 "braces": "^3.0.1",
                 "picomatch": "^2.0.5"
@@ -49734,12 +47965,6 @@
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true
         },
-        "mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "optional": true
-        },
         "min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -49764,6 +47989,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -49771,7 +47997,8 @@
         "minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
         },
         "minimist-options": {
             "version": "4.1.0",
@@ -49970,12 +48197,6 @@
                 "minimist": "^1.2.6"
             }
         },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "optional": true
-        },
         "mkdirp-infer-owner": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
@@ -50039,12 +48260,6 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
-        "nan": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-            "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
-            "optional": true
-        },
         "nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -50069,12 +48284,6 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
             }
-        },
-        "napi-build-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "optional": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -50121,27 +48330,16 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node-abi": {
-            "version": "3.67.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
-            "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
-            "optional": true,
-            "requires": {
-                "semver": "^7.3.5"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.6.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-                    "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-                    "optional": true
-                }
-            }
-        },
         "node-abort-controller": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
             "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+        },
+        "node-addon-api": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+            "optional": true
         },
         "node-domexception": {
             "version": "1.0.0",
@@ -50251,6 +48449,12 @@
                     }
                 }
             }
+        },
+        "node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "optional": true
         },
         "node-int64": {
             "version": "0.4.0",
@@ -51091,7 +49295,8 @@
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
         },
         "object-visit": {
             "version": "1.0.1",
@@ -51123,12 +49328,6 @@
                         "has-property-descriptors": "^1.0.0",
                         "object-keys": "^1.1.1"
                     }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
                 }
             }
         },
@@ -51199,6 +49398,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -51224,19 +49424,19 @@
             }
         },
         "openapi-path-templating": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-1.6.0.tgz",
-            "integrity": "sha512-1atBNwOUrZXthTvlvvX8k8ovFEF3iA8mDidYMkdOtvVdndBhTrspbwGXNOzEUaJhm9iUl4Tf5uQaeTLAJvwPig==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-2.2.1.tgz",
+            "integrity": "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg==",
             "requires": {
-                "apg-lite": "^1.0.3"
+                "apg-lite": "^1.0.4"
             }
         },
         "openapi-server-url-templating": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.1.0.tgz",
-            "integrity": "sha512-dtyTFKx2xVcO0W8JKaluXIHC9l/MLjHeflBaWjiWNMCHp/TBs9dEjQDbj/VFlHR4omFOKjjmqm1pW1aCAhmPBg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.3.0.tgz",
+            "integrity": "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ==",
             "requires": {
-                "apg-lite": "^1.0.3"
+                "apg-lite": "^1.0.4"
             }
         },
         "opener": {
@@ -51258,11 +49458,6 @@
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.3"
             }
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
         },
         "ospath": {
             "version": "1.2.2",
@@ -51443,6 +49638,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
             "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+            "dev": true,
             "requires": {
                 "character-entities": "^1.0.0",
                 "character-entities-legacy": "^1.0.0",
@@ -51492,110 +49688,6 @@
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
             "dev": true
         },
-        "patch-package": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
-            "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
-            "requires": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "ci-info": "^3.7.0",
-                "cross-spawn": "^7.0.3",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "json-stable-stringify": "^1.0.2",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^7.5.3",
-                "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^2.2.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "ci-info": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-                    "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "open": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-                    "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-                    "requires": {
-                        "is-docker": "^2.0.0",
-                        "is-wsl": "^2.1.1"
-                    }
-                },
-                "semver": {
-                    "version": "7.6.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-                    "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
-                },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "tmp": {
-                    "version": "0.0.33",
-                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                    "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                    "requires": {
-                        "os-tmpdir": "~1.0.2"
-                    }
-                },
-                "yaml": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-                    "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q=="
-                }
-            }
-        },
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -51605,7 +49697,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -51616,7 +49709,8 @@
         "path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
         },
         "path-parse": {
             "version": "1.0.7",
@@ -51681,7 +49775,8 @@
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "dev": true
         },
         "pify": {
             "version": "4.0.1",
@@ -51886,6 +49981,11 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
         },
+        "possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+        },
         "postcss": {
             "version": "8.3.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
@@ -51915,8 +50015,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
             "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -51957,15 +50056,13 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
             "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-scss": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
             "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-selector-parser": {
             "version": "6.0.10",
@@ -51983,26 +50080,6 @@
             "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
             "dev": true
         },
-        "prebuild-install": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-            "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
-            "optional": true,
-            "requires": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^1.0.1",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            }
-        },
         "prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -52019,8 +50096,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.3.tgz",
             "integrity": "sha512-PBOwQ8vEIB2b7B3gCuBG7D+dqsr1fsTR4TSAjNacRVdHJrD0yzgz9grOLPSyfwJm+NUTZLyWeHoZ+1mHaUrk+g==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "pretty-bytes": {
             "version": "5.6.0",
@@ -52083,9 +50159,9 @@
             "dev": true
         },
         "prismjs": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-            "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
         },
         "proc-log": {
             "version": "2.0.1",
@@ -52096,7 +50172,8 @@
         "process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "dev": true
         },
         "process-nextick-args": {
             "version": "2.0.1",
@@ -52226,7 +50303,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -52284,8 +50361,7 @@
         "ramda-adjunct": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
-            "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
-            "requires": {}
+            "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg=="
         },
         "randexp": {
             "version": "0.5.3",
@@ -52341,7 +50417,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -52353,7 +50429,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "devOptional": true
+                    "dev": true
                 }
             }
         },
@@ -52390,8 +50466,7 @@
         "react-codemirror2": {
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-            "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw==",
-            "requires": {}
+            "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
         },
         "react-copy-to-clipboard": {
             "version": "5.1.0",
@@ -52495,8 +50570,7 @@
         "react-hook-form": {
             "version": "7.48.2",
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.48.2.tgz",
-            "integrity": "sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==",
-            "requires": {}
+            "integrity": "sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A=="
         },
         "react-i18next": {
             "version": "11.18.1",
@@ -52505,16 +50579,6 @@
             "requires": {
                 "@babel/runtime": "^7.14.5",
                 "html-parse-stringify": "^3.0.1"
-            },
-            "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.18.9",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-                    "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
-                    "requires": {
-                        "regenerator-runtime": "^0.13.4"
-                    }
-                }
             }
         },
         "react-immutable-proptypes": {
@@ -52528,20 +50592,17 @@
         "react-immutable-pure-component": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/react-immutable-pure-component/-/react-immutable-pure-component-2.2.2.tgz",
-            "integrity": "sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A==",
-            "requires": {}
+            "integrity": "sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A=="
         },
         "react-inspector": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz",
-            "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==",
-            "requires": {}
+            "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ=="
         },
         "react-intersection-observer": {
             "version": "9.4.0",
             "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.0.tgz",
-            "integrity": "sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A==",
-            "requires": {}
+            "integrity": "sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A=="
         },
         "react-is": {
             "version": "17.0.1",
@@ -52751,8 +50812,7 @@
             "version": "2.0.9",
             "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.9.tgz",
             "integrity": "sha512-chAnOO4vpxm/3WkgOVmti+eN8yUtkJzeGkOigV6UA9eDFz12W34e/SsYe2H5+RwYJ3+sfSZkVbiXcG1chEBxlg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "react-router": {
             "version": "6.20.0",
@@ -52781,15 +50841,16 @@
             }
         },
         "react-syntax-highlighter": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
-            "integrity": "sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==",
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+            "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
+                "@babel/runtime": "^7.28.4",
                 "highlight.js": "^10.4.1",
+                "highlightjs-vue": "^1.0.0",
                 "lowlight": "^1.17.0",
-                "prismjs": "^1.27.0",
-                "refractor": "^3.6.0"
+                "prismjs": "^1.30.0",
+                "refractor": "^5.0.0"
             }
         },
         "react-test-renderer": {
@@ -52834,8 +50895,7 @@
         "react-virtualized-auto-sizer": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-            "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-            "requires": {}
+            "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ=="
         },
         "react-window": {
             "version": "1.8.6",
@@ -53058,7 +51118,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -53140,33 +51200,81 @@
             }
         },
         "redux": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-            "requires": {
-                "@babel/runtime": "^7.9.2"
-            }
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
         },
         "redux-immutable": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-4.0.0.tgz",
-            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==",
-            "requires": {}
+            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg=="
         },
         "refractor": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
-            "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+            "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
             "requires": {
-                "hastscript": "^6.0.0",
-                "parse-entities": "^2.0.0",
-                "prismjs": "~1.27.0"
+                "@types/hast": "^3.0.0",
+                "@types/prismjs": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "parse-entities": "^4.0.0"
             },
             "dependencies": {
-                "prismjs": {
-                    "version": "1.27.0",
-                    "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-                    "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
+                "@types/hast": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+                    "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+                    "requires": {
+                        "@types/unist": "*"
+                    }
+                },
+                "character-entities-legacy": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+                    "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+                },
+                "character-reference-invalid": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+                    "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+                },
+                "is-alphabetical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+                    "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
+                },
+                "is-alphanumerical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+                    "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+                    "requires": {
+                        "is-alphabetical": "^2.0.0",
+                        "is-decimal": "^2.0.0"
+                    }
+                },
+                "is-decimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+                    "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
+                },
+                "is-hexadecimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+                    "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
+                },
+                "parse-entities": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+                    "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "character-entities-legacy": "^3.0.0",
+                        "character-reference-invalid": "^2.0.0",
+                        "decode-named-character-reference": "^1.0.0",
+                        "is-alphanumerical": "^2.0.0",
+                        "is-decimal": "^2.0.0",
+                        "is-hexadecimal": "^2.0.0"
+                    }
                 }
             }
         },
@@ -53565,6 +51673,7 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -53624,25 +51733,6 @@
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.3",
                 "is-regex": "^1.1.4"
-            },
-            "dependencies": {
-                "get-intrinsic": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-                    "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-                    "dev": true,
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.3"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
-                }
             }
         },
         "safer-buffer": {
@@ -54516,38 +52606,6 @@
                 "get-intrinsic": "^1.2.4",
                 "gopd": "^1.0.1",
                 "has-property-descriptors": "^1.0.2"
-            },
-            "dependencies": {
-                "function-bind": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-                    "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-                },
-                "get-intrinsic": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-                    "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-                    "requires": {
-                        "es-errors": "^1.3.0",
-                        "function-bind": "^1.1.2",
-                        "has-proto": "^1.0.1",
-                        "has-symbols": "^1.0.3",
-                        "hasown": "^2.0.0"
-                    }
-                },
-                "has-property-descriptors": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-                    "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-                    "requires": {
-                        "es-define-property": "^1.0.0"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-                }
             }
         },
         "set-value": {
@@ -54580,12 +52638,20 @@
             "dev": true
         },
         "sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                }
             }
         },
         "shallow-clone": {
@@ -54606,6 +52672,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "requires": {
                 "shebang-regex": "^3.0.0"
             }
@@ -54613,7 +52680,8 @@
         "shebang-regex": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
         },
         "shellwords": {
             "version": "0.1.1",
@@ -54623,9 +52691,9 @@
             "optional": true
         },
         "short-unique-id": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.2.0.tgz",
-            "integrity": "sha512-cMGfwNyfDZ/nzJ2k2M+ClthBIh//GlZl1JEf47Uoa9XR11bz8Pa2T2wQO4bVrRdH48LrIDWJahQziKo3MjhsWg=="
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
+            "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg=="
         },
         "side-channel": {
             "version": "1.0.4",
@@ -54664,23 +52732,6 @@
                         "escape-string-regexp": "^1.0.5"
                     }
                 }
-            }
-        },
-        "simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "optional": true
-        },
-        "simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "optional": true,
-            "requires": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
             }
         },
         "sirv": {
@@ -55242,7 +53293,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.2.0"
             },
@@ -55251,7 +53302,7 @@
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
                     "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                    "devOptional": true
+                    "dev": true
                 }
             }
         },
@@ -55296,14 +53347,6 @@
                 "internal-slot": "^1.0.3",
                 "regexp.prototype.flags": "^1.4.1",
                 "side-channel": "^1.0.4"
-            },
-            "dependencies": {
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
-                }
             }
         },
         "string.prototype.trimend": {
@@ -55409,8 +53452,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
             "integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "style-search": {
             "version": "0.1.0",
@@ -55634,15 +53676,13 @@
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
             "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "stylelint-config-recommended": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
             "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "stylelint-config-recommended-scss": {
             "version": "5.0.2",
@@ -55738,90 +53778,64 @@
             }
         },
         "swagger-client": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.29.2.tgz",
-            "integrity": "sha512-7dOIAodJeUsYbvWTpDODY2+bfJcZ34WG84TByMet76OJ/ZjOLHZtJSgMFxEvnh9+yR0qn8wvHUdfg27ylg2eiQ==",
+            "version": "3.37.2",
+            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.2.tgz",
+            "integrity": "sha512-KcB8psL1On4GWwv9Ribp1oteh50ygNnAyvQbd5MwiXMGkcB4f53rkZEdvZKPDdJO764mQjgErxQEGDVw6QBUMQ==",
             "requires": {
                 "@babel/runtime-corejs3": "^7.22.15",
-                "@swagger-api/apidom-core": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-error": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "@swagger-api/apidom-reference": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-                "cookie": "~0.6.0",
+                "@scarf/scarf": "=1.4.0",
+                "@swagger-api/apidom-core": "^1.10.2",
+                "@swagger-api/apidom-error": "^1.10.2",
+                "@swagger-api/apidom-json-pointer": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+                "@swagger-api/apidom-reference": "^1.10.2",
+                "@swaggerexpert/cookie": "^2.0.2",
                 "deepmerge": "~4.3.0",
                 "fast-json-patch": "^3.0.0-1",
                 "js-yaml": "^4.1.0",
                 "neotraverse": "=0.6.18",
                 "node-abort-controller": "^3.1.1",
                 "node-fetch-commonjs": "^3.3.2",
-                "openapi-path-templating": "^1.5.1",
-                "openapi-server-url-templating": "^1.0.0",
-                "ramda-adjunct": "^5.0.0"
+                "openapi-path-templating": "^2.2.1",
+                "openapi-server-url-templating": "^1.3.0",
+                "ramda": "^0.30.1",
+                "ramda-adjunct": "^5.1.0"
             },
             "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
                 "argparse": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
                     "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
                 },
-                "cookie": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-                    "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
-                },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-                },
-                "deepmerge": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-                    "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
-                },
                 "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+                    "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
                     "requires": {
                         "argparse": "^2.0.1"
                     }
-                },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
                 }
             }
         },
         "swagger-ui-react": {
-            "version": "5.10.5",
-            "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.10.5.tgz",
-            "integrity": "sha512-uBQLku4j3L1NC4/xE3HTgz1EcFisBphh8AnGqbj9LMxeGGcpKOlx/ZDigRAeVXWr9jOnZZbeGBzMe4NVHxPZrQ==",
+            "version": "5.32.4",
+            "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.4.tgz",
+            "integrity": "sha512-OsTqKCiDT/o8/oqZbt+p1djPkrOk3unKK/7+wGvP1+WY6pOzFoDLM4D39cNFtpIArtlg9uoK6MKIz3W00WX8qw==",
             "requires": {
-                "@babel/runtime-corejs3": "^7.23.5",
-                "@braintree/sanitize-url": "=6.0.4",
+                "@babel/runtime-corejs3": "^7.27.1",
+                "@scarf/scarf": "=1.4.0",
                 "base64-js": "^1.5.1",
-                "classnames": "^2.3.1",
+                "buffer": "^6.0.3",
+                "classnames": "^2.5.1",
                 "css.escape": "1.5.1",
                 "deep-extend": "0.6.0",
-                "dompurify": "=3.0.6",
+                "dompurify": "^3.3.2",
                 "ieee754": "^1.2.1",
                 "immutable": "^3.x.x",
                 "js-file-download": "^0.4.12",
-                "js-yaml": "=4.1.0",
-                "lodash": "^4.17.21",
-                "patch-package": "^8.0.0",
+                "js-yaml": "=4.1.1",
+                "lodash": "^4.18.1",
                 "prop-types": "^15.8.1",
                 "randexp": "^0.5.3",
                 "randombytes": "^2.1.0",
@@ -55830,44 +53844,39 @@
                 "react-immutable-proptypes": "2.2.0",
                 "react-immutable-pure-component": "^2.2.0",
                 "react-inspector": "^6.0.1",
-                "react-redux": "^8.1.3",
-                "react-syntax-highlighter": "^15.5.0",
-                "redux": "^4.1.2",
+                "react-redux": "8.1.3",
+                "react-syntax-highlighter": "^16.0.0",
+                "redux": "^5.0.1",
                 "redux-immutable": "^4.0.0",
                 "remarkable": "^2.0.1",
-                "reselect": "^4.1.8",
+                "reselect": "^5.1.1",
                 "serialize-error": "^8.1.0",
-                "sha.js": "^2.4.11",
-                "swagger-client": "^3.24.6",
+                "sha.js": "^2.4.12",
+                "swagger-client": "^3.37.2",
                 "url-parse": "^1.5.10",
                 "xml": "=1.0.1",
                 "xml-but-prettier": "^1.0.1",
                 "zenscroll": "^4.0.2"
             },
             "dependencies": {
-                "@babel/runtime-corejs3": {
-                    "version": "7.25.6",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
-                    "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
-                    "requires": {
-                        "core-js-pure": "^3.30.2",
-                        "regenerator-runtime": "^0.14.0"
-                    }
-                },
                 "argparse": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
                     "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
                 },
-                "core-js-pure": {
-                    "version": "3.38.1",
-                    "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-                    "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
+                "buffer": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.2.1"
+                    }
                 },
                 "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+                    "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
                     "requires": {
                         "argparse": "^2.0.1"
                     }
@@ -55887,10 +53896,10 @@
                     "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
                     "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
                 },
-                "regenerator-runtime": {
-                    "version": "0.14.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-                    "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+                "reselect": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+                    "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
                 }
             }
         },
@@ -55988,39 +53997,6 @@
                     "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
                     "dev": true
                 }
-            }
-        },
-        "tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "optional": true,
-            "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            },
-            "dependencies": {
-                "chownr": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-                    "optional": true
-                }
-            }
-        },
-        "tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "optional": true,
-            "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
             }
         },
         "temp-dir": {
@@ -56264,6 +54240,28 @@
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
+        "to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "requires": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                }
+            }
+        },
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -56306,6 +54304,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -56368,31 +54367,23 @@
             "dev": true
         },
         "tree-sitter": {
-            "version": "0.20.4",
-            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.4.tgz",
-            "integrity": "sha512-rjfR5dc4knG3jnJNN/giJ9WOoN1zL/kZyrS0ILh+eqq8RNcIbiXA63JsMEgluug0aNvfQvK4BfCErN1vIzvKog==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+            "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
             "optional": true,
             "requires": {
-                "nan": "^2.17.0",
-                "prebuild-install": "^7.1.1"
+                "node-addon-api": "^8.0.0",
+                "node-gyp-build": "^4.8.0"
             }
         },
         "tree-sitter-json": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.20.2.tgz",
-            "integrity": "sha512-eUxrowp4F1QEGk/i7Sa+Xl8Crlfp7J0AXxX1QdJEQKQYMWhgMbCIgyQvpO3Q0P9oyTrNQxRLlRipDS44a8EtRw==",
+            "version": "0.24.8",
+            "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
+            "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
             "optional": true,
             "requires": {
-                "nan": "^2.18.0"
-            }
-        },
-        "tree-sitter-yaml": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/tree-sitter-yaml/-/tree-sitter-yaml-0.5.0.tgz",
-            "integrity": "sha512-POJ4ZNXXSWIG/W4Rjuyg36MkUD4d769YRUGKRqN+sVaj/VCo6Dh6Pkssn1Rtewd5kybx+jT1BWMyWN0CijXnMA==",
-            "optional": true,
-            "requires": {
-                "nan": "^2.14.0"
+                "node-addon-api": "^8.2.2",
+                "node-gyp-build": "^4.8.2"
             }
         },
         "treeverse": {
@@ -56567,7 +54558,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -56607,6 +54598,16 @@
             "requires": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
+            }
+        },
+        "typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "requires": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
             }
         },
         "typedarray-to-buffer": {
@@ -56649,14 +54650,6 @@
                 "has-bigints": "^1.0.2",
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
-            },
-            "dependencies": {
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-                    "dev": true
-                }
             }
         },
         "undici-types": {
@@ -56835,7 +54828,8 @@
         "universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true
         },
         "unpipe": {
             "version": "1.0.0",
@@ -56974,8 +54968,7 @@
         "use-sync-external-store": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-            "requires": {}
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
         },
         "util": {
             "version": "0.12.5",
@@ -56994,7 +54987,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "devOptional": true
+            "dev": true
         },
         "utila": {
             "version": "0.4.0",
@@ -57194,9 +55187,9 @@
             "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
         },
         "web-tree-sitter": {
-            "version": "0.20.3",
-            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.3.tgz",
-            "integrity": "sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==",
+            "version": "0.24.5",
+            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
+            "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
             "optional": true
         },
         "webidl-conversions": {
@@ -57561,8 +55554,7 @@
                     "version": "8.10.0",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
                     "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
-                    "dev": true,
-                    "requires": {}
+                    "dev": true
                 }
             }
         },
@@ -57722,6 +55714,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -57758,17 +55751,17 @@
             "dev": true
         },
         "which-typed-array": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-            "dev": true,
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
             "requires": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.10"
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
             }
         },
         "wide-align": {
@@ -57838,7 +55831,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "3.0.3",
@@ -57856,8 +55850,7 @@
             "version": "7.4.6",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
             "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xml": {
             "version": "1.0.1",
@@ -57887,7 +55880,8 @@
         "xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
         },
         "y18n": {
             "version": "4.0.1",
@@ -58025,8 +56019,7 @@
         "zustand": {
             "version": "3.5.10",
             "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.10.tgz",
-            "integrity": "sha512-upluvSRWrlCiExu2UbkuMIPJ9AigyjRFoO7O9eUossIj7rPPq7pcJ0NKk6t2P7KF80tg/UdPX6/pNKOSbs9DEg==",
-            "requires": {}
+            "integrity": "sha512-upluvSRWrlCiExu2UbkuMIPJ9AigyjRFoO7O9eUossIj7rPPq7pcJ0NKk6t2P7KF80tg/UdPX6/pNKOSbs9DEg=="
         },
         "zwitch": {
             "version": "1.0.5",

--- a/thirdeye-ui/package.json
+++ b/thirdeye-ui/package.json
@@ -64,7 +64,7 @@
         "@tanstack/react-query": "^4.29.19",
         "@tippyjs/react": "^4.2.6",
         "@visx/visx": "3.1.2",
-        "axios": "^1.7.4",
+        "axios": "^1.14.0",
         "binary-search-bounds": "^2.0.5",
         "classnames": "^2.2.6",
         "codemirror": "^5.59.1",
@@ -93,7 +93,7 @@
         "react-markdown": "^8.0.4",
         "react-router-dom": "^6.18.0",
         "react-show-more-text": "^1.6.2",
-        "swagger-ui-react": "^5.10.5",
+        "swagger-ui-react": "^5.19.0",
         "uuid": "^8.3.2",
         "yup": "1.3.2",
         "zustand": "^3.2.0"
@@ -177,5 +177,8 @@
         "webpack-dev-server": "4.7.3",
         "webpack-retry-chunk-load-plugin": "2.2.0",
         "webpackbar": "5.0.0-3"
+    },
+    "overrides": {
+        "react-redux": "8.1.3"
     }
 }

--- a/thirdeye-ui/src/test/e2e/helper-scripts/docker-compose.yaml
+++ b/thirdeye-ui/src/test/e2e/helper-scripts/docker-compose.yaml
@@ -16,7 +16,7 @@ version: "3"
 
 services:
     pinot:
-        image: apachepinot/pinot:1.2.0
+        image: apachepinot/pinot:1.4.0
         command: QuickStart -type batch
         ports:
             - "2123:2123"


### PR DESCRIPTION
### Issue(s)

Address critical and high-severity Snyk vulnerabilities in the ThirdEye frontend and UI Docker image.

Fix 5+ Snyk security vulnerabilities by upgrading npm dependencies and hardening the UI container image:

| CVE | Package | CVSS | Vulnerability |
|-----|---------|------|---------------|
| [CWE-918](https://cwe.mitre.org/data/definitions/918.html) | `axios` | 6.2 | Server-side Request Forgery (SSRF) |
| [CWE-770](https://cwe.mitre.org/data/definitions/770.html) | `axios` | 6.9 | Allocation of Resources Without Limits or Throttling |
| — | `dompurify` (via `swagger-ui-react`) | 5.3 | Template Injection (CWE-1336) |
| — | `dompurify` (via `swagger-ui-react`) | 6.2 | Cross-site Scripting (CWE-79) |
| — | `dompurify` (via `swagger-ui-react`) | 8.3 | Prototype Pollution (CWE-1321) |
| [CVE-2025-49796](https://nvd.nist.gov/vuln/detail/CVE-2025-49796) | `libxml2` | 9.1 | Out-of-bounds Read |
| [CVE-2025-49794](https://nvd.nist.gov/vuln/detail/CVE-2025-49794) | `libxml2` | 9.1 | Expired Pointer Dereference |

The axios SSRF and resource allocation issues are fixed by upgrading to ^1.14.0. The dompurify vulnerabilities (template injection, XSS, prototype pollution) are resolved by upgrading swagger-ui-react to ^5.19.0 which pulls dompurify 3.1.x+. The libxml2 CVEs are resolved by adding `apk upgrade` to the UI Dockerfile.

---

### Description

Frontend dependency upgrades and Docker hardening across **4 files** in `thirdeye-ui/`. This is the minimum-scope set of changes needed to resolve all reported critical/high frontend Snyk findings.

---

### What Changed

| # | Area | Change |
|---|------|--------|
| 1 | **axios** | `^1.7.4` → `^1.14.0`. Fixes SSRF (CWE-918) and resource allocation (CWE-770) issues. |
| 2 | **swagger-ui-react** | `^5.10.5` → `^5.19.0`. Fixes dompurify 3.0.6 template injection, XSS, and prototype pollution. Added `overrides: { "react-redux": "8.1.3" }` to maintain React 16 compatibility (swagger-ui-react >=5.12 pulls react-redux@9 which requires React 18's `useSyncExternalStore`). |
| 3 | **Docker: UI image** | Added `RUN apk update && apk upgrade --no-cache libxml2 libxslt` to `thirdeye-ui/Dockerfile` (nginx:1.27-alpine base). Fixes CVE-2025-49796, CVE-2025-49794. |
| 4 | **e2e docker-compose** | Updated Pinot image from `1.2.0` to `1.4.0` to match backend client version upgrade. |

### Version Changes

| Dependency | Before | After | Notes |
|------------|--------|-------|-------|
| `axios` (npm) | ^1.7.4 | ^1.14.0 | Fixes CWE-918, CWE-770 |
| `swagger-ui-react` (npm) | ^5.10.5 | ^5.19.0 | Fixes dompurify vulns |
| `react-redux` (override) | — | 8.1.3 | React 16 compat pin |
| Pinot Docker (e2e) | 1.2.0 | 1.4.0 | Match backend client version |

---

### Risk: react-redux Override

The `overrides` block in `package.json` pins `react-redux` to `8.1.3` because `swagger-ui-react >= 5.12` transitively pulls `react-redux@9` which uses React 18's `useSyncExternalStore` hook — unavailable in ThirdEye's React 16 runtime. This override is safe as long as ThirdEye remains on React 16. When React is eventually upgraded to 18+, the override should be removed.

---

### Test Plan

- [x] `npm install --legacy-peer-deps` — succeeds
- [x] `npm run build` — webpack production build succeeds
- [x] `npm test` — all 127 suites, 948 unit tests pass
- [ ] Manual verification of Swagger UI page
- [ ] Re-run Snyk scan on rebuilt UI Docker image to confirm libxml2 CVE resolution
